### PR TITLE
Extensions of the interface_main classes

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -3,7 +3,7 @@
 test -z "$OFFLINE_MAIN" && echo "Need set 'OFFLINE_MAIN'.  Abort." && exit
 test -z "$MY_INSTALL"   && echo   "Need set 'MY_INSTALL'.  Abort." && exit
 
-src=$(dirname $(readlink -f $0)) # /e906/app/users/yuhw/seaquest-offline
+src=$(dirname $(readlink -f $0))
 build=`pwd`
 install=$MY_INSTALL
 
@@ -18,30 +18,29 @@ else
 		framework/ffaobjects
 		framework/fun4all
 		interface_main
-	online/event
-	online/decoder_maindaq
-#    packages/Half
-#    packages/vararray
-#    database/pdbcal/base
-#    database/PHParameter
-#    packages/PHGeometry
-#    packages/PHField
-#    generators/phhepmc
-#    generators/PHPythia8
-#    simulation/g4decayer
-#    simulation/g4gdml
-#    simulation/g4main
-#    simulation/g4detectors
-#    simulation/g4dst
-#    simulation/g4eval
-#		packages/global_consts
-#		packages/jobopts_svc
-#		packages/geom_svc
-#		packages/db2g4
-#		packages/PHGenFitPkg/GenFitExp
-#		packages/PHGenFitPkg/PHGenFit
-#		packages/ktracker
-#		module_example
+		online/decoder_maindaq
+		packages/Half
+		packages/vararray
+		database/pdbcal/base
+		database/PHParameter
+		packages/PHGeometry
+		packages/PHField
+		generators/phhepmc
+		generators/PHPythia8
+		simulation/g4decayer
+		simulation/g4gdml
+		simulation/g4main
+		simulation/g4detectors
+		simulation/g4dst
+		simulation/g4eval
+		packages/global_consts
+		packages/jobopts_svc
+		packages/geom_svc
+		packages/db2g4
+		packages/PHGenFitPkg/GenFitExp
+		packages/PHGenFitPkg/PHGenFit
+		packages/ktracker
+		module_example
 	)
 fi
 

--- a/interface_main/SQIntMap.cxx
+++ b/interface_main/SQIntMap.cxx
@@ -1,0 +1,8 @@
+/*
+ * SQIntMap.C
+ */
+#include "SQIntMap.h"
+
+using namespace std;
+
+ClassImp(SQIntMap)

--- a/interface_main/SQIntMap.h
+++ b/interface_main/SQIntMap.h
@@ -1,0 +1,51 @@
+/*
+ * SQIntMap.h
+ */
+#ifndef _H_SQIntMap_H_
+#define _H_SQIntMap_H_
+
+#include <phool/PHObject.h>
+#include <map>
+#include <iostream>
+
+class SQIntMap : public PHObject {
+public:
+  typedef std::map<unsigned int, PHObject*> ObjectMap;
+  typedef ObjectMap::const_iterator ConstIter;
+  typedef ObjectMap::iterator            Iter;
+
+  virtual ~SQIntMap() {}
+
+  virtual void identify(std::ostream& os = std::cout) const {
+    os << "SQIntMap base class" << std::endl;
+  }
+  virtual void Reset() {}
+  virtual int  isValid() const {return 0;}
+  virtual SQIntMap* Clone() const {return NULL;}
+
+  virtual bool   empty()                   const {return true;}
+  virtual size_t  size()                   const {return 0;}
+  virtual size_t count(unsigned int idkey) const {return 0;}
+  virtual void   clear()                         {}
+
+  virtual const PHObject* get(unsigned int idkey) const {return NULL;}
+  virtual       PHObject* get(unsigned int idkey) {return NULL;}
+  virtual       PHObject* insert(const unsigned int idkey, const PHObject *item) {return NULL;}
+  virtual       size_t   erase(unsigned int idkey) {return 0;}
+
+  virtual ConstIter begin()                   const {return ObjectMap().end();}
+  virtual ConstIter  find(unsigned int idkey) const {return ObjectMap().end();}
+  virtual ConstIter   end()                   const {return ObjectMap().end();}
+
+  virtual Iter begin()                   {return ObjectMap().end();}
+  virtual Iter  find(unsigned int idkey) {return ObjectMap().end();}
+  virtual Iter   end()                   {return ObjectMap().end();}
+
+protected:
+  SQIntMap() {}
+
+private:
+  ClassDef(SQIntMap, 1);
+};
+
+#endif /* _H_SQIntMap_H_ */

--- a/interface_main/SQIntMapLinkDef.h
+++ b/interface_main/SQIntMapLinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class SQIntMap+;
+
+#endif /* __CINT__ */

--- a/interface_main/SQIntMap_v1.cxx
+++ b/interface_main/SQIntMap_v1.cxx
@@ -1,0 +1,59 @@
+/*
+ * SQIntMap_v1.C
+ */
+#include "SQIntMap_v1.h"
+using namespace std;
+
+ClassImp(SQIntMap_v1)
+
+SQIntMap_v1::SQIntMap_v1() : _map()
+{}
+
+SQIntMap_v1::SQIntMap_v1(const SQIntMap_v1& map) : _map()
+{
+  for (ConstIter iter = map.begin(); iter != map.end(); ++iter) {
+    _map.insert(make_pair(iter->first, iter->second->clone()));
+  }
+}
+
+SQIntMap_v1& SQIntMap_v1::operator=(const SQIntMap_v1& map)
+{
+  Reset();
+  for (ConstIter iter = map.begin(); iter != map.end(); ++iter) {
+    _map.insert(make_pair(iter->first, iter->second->clone()));
+  }
+  return *this;
+}
+
+SQIntMap_v1::~SQIntMap_v1() {
+  Reset();
+}
+
+void SQIntMap_v1::Reset() {
+  for (Iter iter = _map.begin(); iter != _map.end(); ++iter) {
+    delete iter->second;
+  }
+  _map.clear();
+}
+
+void SQIntMap_v1::identify(ostream& os) const {
+  os << "SQIntMap_v1: size = " << _map.size() << endl;
+  return;
+}
+
+const PHObject* SQIntMap_v1::get(unsigned int id) const {
+  ConstIter iter = _map.find(id);
+  if (iter == _map.end()) return NULL;
+  return iter->second;
+}
+
+PHObject* SQIntMap_v1::get(unsigned int id) {
+  Iter iter = _map.find(id);
+  if (iter == _map.end()) return NULL;
+  return iter->second;
+}
+
+PHObject* SQIntMap_v1::insert(const unsigned int id, const PHObject *item) {
+  _map.insert(make_pair(id, item->clone() ));
+  return _map[id];
+}

--- a/interface_main/SQIntMap_v1.h
+++ b/interface_main/SQIntMap_v1.h
@@ -1,0 +1,47 @@
+/*
+ * SQIntMap_v1.h
+ */
+#ifndef _H_SQIntMap_v1_H_
+#define _H_SQIntMap_v1_H_
+#include "SQIntMap.h"
+
+class SQIntMap_v1 : public SQIntMap {
+public:
+  SQIntMap_v1();
+  SQIntMap_v1(const SQIntMap_v1& map);
+  SQIntMap_v1& operator=(const SQIntMap_v1& map);
+  virtual ~SQIntMap_v1();
+
+  void identify(std::ostream& os = std::cout) const;
+  void Reset();
+  int  isValid() const {return 1;}
+  SQIntMap* Clone() const {return new SQIntMap_v1(*this);}
+
+  bool   empty()                   const {return _map.empty();}
+  size_t  size()                   const {return _map.size();}
+  size_t count(unsigned int idkey) const {return _map.count(idkey);}
+  void   clear()                         {Reset();}
+
+  const PHObject* get(unsigned int idkey) const;
+        PHObject* get(unsigned int idkey);
+        PHObject* insert(unsigned int idkey, const PHObject *item);
+        size_t erase(unsigned int idkey) {
+	  delete _map[idkey];
+          return _map.erase(idkey);
+	}
+
+  ConstIter begin()                   const {return _map.begin();}
+  ConstIter  find(unsigned int idkey) const {return _map.find(idkey);}
+  ConstIter   end()                   const {return _map.end();}
+
+  Iter begin()                   {return _map.begin();}
+  Iter  find(unsigned int idkey) {return _map.find(idkey);}
+  Iter   end()                   {return _map.end();}
+
+private:
+  ObjectMap _map;
+
+  ClassDef(SQIntMap_v1, 1);
+};
+
+#endif

--- a/interface_main/SQIntMap_v1LinkDef.h
+++ b/interface_main/SQIntMap_v1LinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class SQIntMap_v1+;
+
+#endif /* __CINT__ */

--- a/interface_main/SQScaler.cxx
+++ b/interface_main/SQScaler.cxx
@@ -1,0 +1,8 @@
+/*
+ * SQScaler.C
+ */
+#include "SQScaler.h"
+
+using namespace std;
+
+ClassImp(SQScaler);

--- a/interface_main/SQScaler.h
+++ b/interface_main/SQScaler.h
@@ -1,0 +1,45 @@
+/*
+ * SQScaler.h
+ */
+#ifndef _H_SQScaler_H_
+#define _H_SQScaler_H_
+#include <phool/PHObject.h>
+#include <iostream>
+#include <limits>
+#include <string>
+
+class SQScaler : public PHObject {
+public:
+  typedef enum {
+    UNDEF = -1,
+    BOS   =  0,
+    EOS   =  1
+  } ScalerType_t;
+  
+  virtual ~SQScaler() {}
+
+  // PHObject virtual overloads
+
+  virtual void         identify(std::ostream& os = std::cout) const {
+    os << "---SQScaler base class------------" << std::endl;
+  }
+  virtual void      Reset() {};
+  virtual int       isValid() const {return 0;}
+  virtual SQScaler* Clone() const {return NULL;}
+  virtual PHObject* clone() const {return NULL;}
+
+  virtual ScalerType_t get_type() const {return UNDEF;}
+  virtual void set_type(const ScalerType_t a) {}
+  virtual std::string get_name() const {return "";}
+  virtual void set_name(const std::string a) {}
+  virtual int  get_count() const {return 0;}
+  virtual void set_count(const int a) {}
+
+protected:
+  SQScaler() {}
+  
+private:
+  ClassDef(SQScaler, 1);
+};
+
+#endif /* _H_SQScaler_H_ */

--- a/interface_main/SQScalerLinkDef.h
+++ b/interface_main/SQScalerLinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class SQScaler+;
+
+#endif /* __CINT__ */

--- a/interface_main/SQScaler_v1.cxx
+++ b/interface_main/SQScaler_v1.cxx
@@ -1,0 +1,29 @@
+/*
+ * SQScaler_v1.C
+ */
+#include "SQScaler_v1.h"
+
+#include <limits>
+#include <cmath>
+
+//#include <TMatrixF.h>
+
+using namespace std;
+
+ClassImp(SQScaler_v1);
+
+SQScaler_v1::SQScaler_v1() : _type(UNDEF), _name(""), _count(0)
+{}
+
+void SQScaler_v1::identify(ostream& os) const {
+  os << "---SQScaler_v1--------------------" << endl;
+  os << "  type: " << get_type() << endl;
+  os << "  name: " << get_name() << endl;
+  os << " count: " << get_count() << endl;
+  os << "---------------------------------" << endl;
+  return;
+}
+
+int SQScaler_v1::isValid() const {
+  return (_type != UNDEF && _name.length() > 0) ? 1 : 0;
+}

--- a/interface_main/SQScaler_v1.h
+++ b/interface_main/SQScaler_v1.h
@@ -1,0 +1,39 @@
+/*
+ * SQScaler_v1.h
+ */
+#ifndef _H_SQScaler_v1_H_
+#define _H_SQScaler_v1_H_
+#include <phool/PHObject.h>
+#include <iostream>
+#include "SQScaler.h"
+
+class SQScaler_v1 : public SQScaler {
+public:
+  SQScaler_v1();
+  virtual ~SQScaler_v1() {}
+
+  // PHObject virtual overloads
+  void      identify(std::ostream& os = std::cout) const;
+  void      Reset() {*this = SQScaler_v1();}
+  int       isValid() const;
+  SQScaler* Clone() const {return (new SQScaler_v1(*this));} ///< Use Clone() or clone()??
+  PHObject* clone() const {return (new SQScaler_v1(*this));} ///< Use Clone() or clone()??
+
+  virtual ScalerType_t get_type() const { return _type; }
+  virtual void set_type(const ScalerType_t a) { _type = a; }
+
+  virtual std::string get_name() const { return _name; }
+  virtual void set_name(const std::string a) { _name = a; }
+
+  virtual int  get_count() const { return _count; }
+  virtual void set_count(const int a) { _count = a; }
+
+private:
+  ScalerType_t _type;
+  std::string _name;
+  int _count;
+
+  ClassDef(SQScaler_v1, 1);
+};
+
+#endif /* _H_SQScaler_v1_H_ */

--- a/interface_main/SQScaler_v1LinkDef.h
+++ b/interface_main/SQScaler_v1LinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class SQScaler_v1+;
+
+#endif /* __CINT__ */

--- a/interface_main/SQSlowCont.cxx
+++ b/interface_main/SQSlowCont.cxx
@@ -1,0 +1,8 @@
+/*
+ * SQSlowCont.C
+ */
+#include "SQSlowCont.h"
+
+using namespace std;
+
+ClassImp(SQSlowCont);

--- a/interface_main/SQSlowCont.h
+++ b/interface_main/SQSlowCont.h
@@ -1,0 +1,44 @@
+/*
+ * SQSlowCont.h
+ */
+#ifndef _H_SQSlowCont_H_
+#define _H_SQSlowCont_H_
+#include <phool/PHObject.h>
+#include <iostream>
+#include <limits>
+#include <string>
+
+class SQSlowCont : public PHObject {
+public:
+  virtual ~SQSlowCont() {}
+
+  // PHObject virtual overloads
+
+  virtual void         identify(std::ostream& os = std::cout) const {
+    os << "---SQSlowCont base class------------" << std::endl;
+  }
+  virtual void      Reset() {};
+  virtual int       isValid() const {return 0;}
+  virtual SQSlowCont* Clone() const {return NULL;}
+  virtual PHObject*   clone() const {return NULL;}
+
+  virtual std::string get_time_stamp() const {return "";}
+  virtual void set_time_stamp(const std::string a) {}
+
+  virtual std::string get_name() const {return "";}
+  virtual void set_name(const std::string a) {}
+
+  virtual std::string get_value() const {return "";}
+  virtual void set_value(const std::string a) {}
+
+  virtual std::string get_type() const {return "";}
+  virtual void set_type(const std::string a) {}
+
+protected:
+  SQSlowCont() {}
+  
+private:
+  ClassDef(SQSlowCont, 1);
+};
+
+#endif /* _H_SQSlowCont_H_ */

--- a/interface_main/SQSlowContLinkDef.h
+++ b/interface_main/SQSlowContLinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class SQSlowCont+;
+
+#endif /* __CINT__ */

--- a/interface_main/SQSlowCont_v1.cxx
+++ b/interface_main/SQSlowCont_v1.cxx
@@ -1,0 +1,27 @@
+/*
+ * SQSlowCont_v1.C
+ */
+#include "SQSlowCont_v1.h"
+
+#include <limits>
+#include <cmath>
+
+//#include <TMatrixF.h>
+
+using namespace std;
+
+ClassImp(SQSlowCont_v1);
+
+SQSlowCont_v1::SQSlowCont_v1() : _time_stamp(""), _name(""), _value(""), _type("")
+{}
+
+void SQSlowCont_v1::identify(ostream& os) const {
+  os << "---SQSlowCont_v1--------------------" << endl;
+  os << "  name: " << get_name() << endl;
+  os << "---------------------------------" << endl;
+  return;
+}
+
+int SQSlowCont_v1::isValid() const {
+  return (_name.length() > 0) ? 1 : 0;
+}

--- a/interface_main/SQSlowCont_v1.h
+++ b/interface_main/SQSlowCont_v1.h
@@ -1,0 +1,43 @@
+/*
+ * SQSlowCont_v1.h
+ */
+#ifndef _H_SQSlowCont_v1_H_
+#define _H_SQSlowCont_v1_H_
+#include <phool/PHObject.h>
+#include <iostream>
+#include "SQSlowCont.h"
+
+class SQSlowCont_v1 : public SQSlowCont {
+public:
+  SQSlowCont_v1();
+  virtual ~SQSlowCont_v1() {}
+
+  // PHObject virtual overloads
+  void      identify(std::ostream& os = std::cout) const;
+  void      Reset() {*this = SQSlowCont_v1();}
+  int       isValid() const;
+  SQSlowCont* Clone() const {return (new SQSlowCont_v1(*this));}
+  PHObject*   clone() const {return (new SQSlowCont_v1(*this));}
+
+  virtual std::string get_time_stamp() const {return _time_stamp;}
+  virtual void set_time_stamp(const std::string a) { _time_stamp = a; }
+
+  virtual std::string get_name() const {return _name;}
+  virtual void set_name(const std::string a) { _name = a; }
+
+  virtual std::string get_value() const {return _value;}
+  virtual void set_value(const std::string a) { _value = a; }
+
+  virtual std::string get_type() const {return _type;}
+  virtual void set_type(const std::string a) { _type = a; }
+
+private:
+  std::string _time_stamp;
+  std::string _name;
+  std::string _value;
+  std::string _type;
+
+  ClassDef(SQSlowCont_v1, 1);
+};
+
+#endif /* _H_SQSlowCont_v1_H_ */

--- a/interface_main/SQSlowCont_v1LinkDef.h
+++ b/interface_main/SQSlowCont_v1LinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class SQSlowCont_v1+;
+
+#endif /* __CINT__ */

--- a/interface_main/SQSpill.h
+++ b/interface_main/SQSpill.h
@@ -13,6 +13,7 @@
 #include <iostream>
 #include <limits>
 #include <string>
+class SQStringMap;
 
 class SQSpill : public PHObject {
 
@@ -42,6 +43,23 @@ public:
   virtual short        get_target_pos() const                               {return std::numeric_limits<short>::max();}
   virtual void         set_target_pos(const short a)                          {}
 
+  virtual int  get_bos_coda_id() const {return std::numeric_limits<int>::max();}
+  virtual void set_bos_coda_id(const int a) {};
+
+  virtual int  get_bos_vme_time() const {return std::numeric_limits<int>::max();}
+  virtual void set_bos_vme_time(const int a) {};
+
+  virtual int  get_eos_coda_id() const {return std::numeric_limits<int>::max();}
+  virtual void set_eos_coda_id(const int a) {};
+
+  virtual int  get_eos_vme_time() const {return std::numeric_limits<int>::max();}
+  virtual void set_eos_vme_time(const int a) {};
+
+  virtual SQStringMap* get_bos_scaler_list() { return 0; }
+  virtual SQStringMap* get_eos_scaler_list() { return 0; }
+
+  virtual SQStringMap* get_slow_cont_list() { return 0; }
+  
 protected:
   SQSpill() {}
 

--- a/interface_main/SQSpill_v2.cxx
+++ b/interface_main/SQSpill_v2.cxx
@@ -1,0 +1,52 @@
+/*
+ * SQSpill_v2.C
+ *
+ *  Created on: Oct 29, 2017
+ *      Author: yuhw
+ */
+#include "SQSpill_v2.h"
+#include "SQStringMap_v1.h"
+#include <limits>
+#include <cmath>
+using namespace std;
+
+ClassImp(SQSpill_v2);
+
+SQSpill_v2::SQSpill_v2() :
+  _run_id(std::numeric_limits<int>::max()),
+  _spill_id(std::numeric_limits<int>::max()),
+  _target_pos(std::numeric_limits<short>::max()),
+  _bos_coda_id (std::numeric_limits<int>::max()),
+  _bos_vme_time(std::numeric_limits<int>::max()),
+  _eos_coda_id (std::numeric_limits<int>::max()),
+  _eos_vme_time(std::numeric_limits<int>::max()),
+  _bos_scaler_list(new SQStringMap_v1()),
+  _eos_scaler_list(new SQStringMap_v1()),
+  _slow_cont_list(new SQStringMap_v1())
+{}
+
+SQSpill_v2::~SQSpill_v2()
+{
+  delete _bos_scaler_list;
+  delete _eos_scaler_list;
+  delete _slow_cont_list;
+}
+
+void SQSpill_v2::identify(ostream& os) const {
+  os << "---SQSpill_v2--------------------" << endl;
+  os << " runID: " << get_run_id() << endl;
+  os << " spillID: " << get_spill_id() << endl;
+  os << " liveProton: " << get_target_pos() << endl;
+  os << "---------------------------------" << endl;
+
+  return;
+}
+
+int SQSpill_v2::isValid() const {
+  if (_run_id == std::numeric_limits<int>::max()) return 0;
+  if (_spill_id == std::numeric_limits<int>::max()) return 0;
+  if (_target_pos == std::numeric_limits<short>::max()) return 0;
+  return 1;
+}
+
+

--- a/interface_main/SQSpill_v2.h
+++ b/interface_main/SQSpill_v2.h
@@ -1,0 +1,68 @@
+/*
+ * SQSpill_v2.h
+ */
+#ifndef _H_SQSpill_v2_H_
+#define _H_SQSpill_v2_H_
+#include <phool/PHObject.h>
+#include <iostream>
+#include "SQSpill.h"
+class SQStringMap;
+
+class SQSpill_v2 : public SQSpill {
+
+public:
+
+  SQSpill_v2();
+  virtual ~SQSpill_v2();
+
+  // PHObject virtual overloads
+
+  void         identify(std::ostream& os = std::cout) const;
+  void         Reset() {*this = SQSpill_v2();}
+  int          isValid() const;
+  SQSpill*        Clone() const {return (new SQSpill_v2(*this));}
+
+  virtual int          get_run_id() const                               {return _run_id;}
+  virtual void         set_run_id(const int a)                          {_run_id = a;}
+
+  virtual int          get_spill_id() const                               {return _spill_id;}
+  virtual void         set_spill_id(const int a)                          {_spill_id = a;}
+
+  virtual short        get_target_pos() const                               {return _target_pos;}
+  virtual void         set_target_pos(const short a)                          {_target_pos = a;}
+
+  virtual int  get_bos_coda_id() const { return _bos_coda_id; }
+  virtual void set_bos_coda_id(const int a) { _bos_coda_id = a; }
+
+  virtual int  get_bos_vme_time() const {return _bos_vme_time; }
+  virtual void set_bos_vme_time(const int a) { _bos_vme_time = a; }
+
+  virtual int  get_eos_coda_id() const {return _eos_coda_id; }
+  virtual void set_eos_coda_id(const int a) { _eos_coda_id = a; }
+
+  virtual int  get_eos_vme_time() const {return _eos_vme_time; }
+  virtual void set_eos_vme_time(const int a) { _eos_vme_time = a; }
+  
+  virtual SQStringMap* get_bos_scaler_list() { return _bos_scaler_list; }
+  virtual SQStringMap* get_eos_scaler_list() { return _eos_scaler_list; }
+
+  virtual SQStringMap* get_slow_cont_list() { return _slow_cont_list; }
+
+private:
+
+  int _run_id;
+  int _spill_id;
+  short _target_pos;
+  int _bos_coda_id;
+  int _bos_vme_time;
+  int _eos_coda_id;
+  int _eos_vme_time;
+  SQStringMap* _bos_scaler_list;
+  SQStringMap* _eos_scaler_list;
+  SQStringMap* _slow_cont_list;
+
+  ClassDef(SQSpill_v2, 1);
+};
+
+
+#endif /* _H_SQSpill_v2_H_ */

--- a/interface_main/SQSpill_v2LinkDef.h
+++ b/interface_main/SQSpill_v2LinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class SQSpill_v2+;
+
+#endif /* __CINT__ */

--- a/interface_main/SQStringMap.cxx
+++ b/interface_main/SQStringMap.cxx
@@ -1,0 +1,8 @@
+/*
+ * SQStringMap.C
+ */
+#include "SQStringMap.h"
+
+using namespace std;
+
+ClassImp(SQStringMap)

--- a/interface_main/SQStringMap.h
+++ b/interface_main/SQStringMap.h
@@ -1,0 +1,51 @@
+/*
+ * SQStringMap.h
+ */
+#ifndef _H_SQStringMap_H_
+#define _H_SQStringMap_H_
+
+#include <phool/PHObject.h>
+#include <map>
+#include <iostream>
+
+class SQStringMap : public PHObject {
+public:
+  typedef std::map<std::string, PHObject*> ObjectMap;
+  typedef ObjectMap::const_iterator ConstIter;
+  typedef ObjectMap::iterator            Iter;
+
+  virtual ~SQStringMap() {}
+
+  virtual void identify(std::ostream& os = std::cout) const {
+    os << "SQStringMap base class" << std::endl;
+  }
+  virtual void Reset() {}
+  virtual int  isValid() const {return 0;}
+  virtual SQStringMap* Clone() const {return NULL;}
+
+  virtual bool   empty()                const {return true;}
+  virtual size_t  size()                const {return 0;}
+  virtual size_t count(std::string key) const {return 0;}
+  virtual void   clear()                         {}
+
+  virtual const PHObject* get(std::string key) const {return NULL;}
+  virtual       PHObject* get(std::string key) {return NULL;}
+  virtual       PHObject* insert(const std::string key, const PHObject *item) {return NULL;}
+  virtual       size_t   erase(std::string key) {return 0;}
+
+  virtual ConstIter begin()                const {return ObjectMap().end();}
+  virtual ConstIter  find(std::string key) const {return ObjectMap().end();}
+  virtual ConstIter   end()                const {return ObjectMap().end();}
+
+  virtual Iter begin()                {return ObjectMap().end();}
+  virtual Iter  find(std::string key) {return ObjectMap().end();}
+  virtual Iter   end()                {return ObjectMap().end();}
+
+protected:
+  SQStringMap() {}
+
+private:
+  ClassDef(SQStringMap, 1);
+};
+
+#endif /* _H_SQStringMap_H_ */

--- a/interface_main/SQStringMapLinkDef.h
+++ b/interface_main/SQStringMapLinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class SQStringMap+;
+
+#endif /* __CINT__ */

--- a/interface_main/SQStringMap_v1.cxx
+++ b/interface_main/SQStringMap_v1.cxx
@@ -1,0 +1,59 @@
+/*
+ * SQStringMap_v1.C
+ */
+#include "SQStringMap_v1.h"
+using namespace std;
+
+ClassImp(SQStringMap_v1)
+
+SQStringMap_v1::SQStringMap_v1() : _map()
+{}
+
+SQStringMap_v1::SQStringMap_v1(const SQStringMap_v1& map) : _map()
+{
+  for (ConstIter iter = map.begin(); iter != map.end(); ++iter) {
+    _map.insert(make_pair(iter->first, iter->second->clone()));
+  }
+}
+
+SQStringMap_v1& SQStringMap_v1::operator=(const SQStringMap_v1& map)
+{
+  Reset();
+  for (ConstIter iter = map.begin(); iter != map.end(); ++iter) {
+    _map.insert(make_pair(iter->first, iter->second->clone()));
+  }
+  return *this;
+}
+
+SQStringMap_v1::~SQStringMap_v1() {
+  Reset();
+}
+
+void SQStringMap_v1::Reset() {
+  for (Iter iter = _map.begin(); iter != _map.end(); ++iter) {
+    delete iter->second;
+  }
+  _map.clear();
+}
+
+void SQStringMap_v1::identify(ostream& os) const {
+  os << "SQStringMap_v1: size = " << _map.size() << endl;
+  return;
+}
+
+const PHObject* SQStringMap_v1::get(std::string key) const {
+  ConstIter iter = _map.find(key);
+  if (iter == _map.end()) return NULL;
+  return iter->second;
+}
+
+PHObject* SQStringMap_v1::get(std::string key) {
+  Iter iter = _map.find(key);
+  if (iter == _map.end()) return NULL;
+  return iter->second;
+}
+
+PHObject* SQStringMap_v1::insert(const std::string key, const PHObject *item) {
+  _map.insert(make_pair(key, item->clone() ));
+  return _map[key];
+}

--- a/interface_main/SQStringMap_v1.h
+++ b/interface_main/SQStringMap_v1.h
@@ -1,0 +1,47 @@
+/*
+ * SQStringMap_v1.h
+ */
+#ifndef _H_SQStringMap_v1_H_
+#define _H_SQStringMap_v1_H_
+#include "SQStringMap.h"
+
+class SQStringMap_v1 : public SQStringMap {
+public:
+  SQStringMap_v1();
+  SQStringMap_v1(const SQStringMap_v1& map);
+  SQStringMap_v1& operator=(const SQStringMap_v1& map);
+  virtual ~SQStringMap_v1();
+
+  void identify(std::ostream& os = std::cout) const;
+  void Reset();
+  int  isValid() const {return 1;}
+  SQStringMap* Clone() const {return new SQStringMap_v1(*this);}
+
+  bool   empty()                const {return _map.empty();}
+  size_t  size()                const {return _map.size();}
+  size_t count(std::string key) const {return _map.count(key);}
+  void   clear()                      {Reset();}
+
+  const PHObject* get(std::string key) const;
+        PHObject* get(std::string key);
+        PHObject* insert(std::string key, const PHObject *item);
+        size_t erase(std::string key) {
+	  delete _map[key];
+          return _map.erase(key);
+	}
+
+  ConstIter begin()                const {return _map.begin();}
+  ConstIter  find(std::string key) const {return _map.find(key);}
+  ConstIter   end()                const {return _map.end();}
+
+  Iter begin()                {return _map.begin();}
+  Iter  find(std::string key) {return _map.find(key);}
+  Iter   end()                {return _map.end();}
+
+private:
+  ObjectMap _map;
+
+  ClassDef(SQStringMap_v1, 1);
+};
+
+#endif

--- a/interface_main/SQStringMap_v1LinkDef.h
+++ b/interface_main/SQStringMap_v1LinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class SQStringMap_v1+;
+
+#endif /* __CINT__ */

--- a/macros/Fun4MainDaq.C
+++ b/macros/Fun4MainDaq.C
@@ -1,13 +1,5 @@
 /** Fun4MainDaq.C:  Fun4all macro to decode the MainDAQ data.
  * 
- * If using ROOT version 5, 
- * you can (need?) use "gSystem->Load()" instead of "R__LOAD_LIBRARY()".
- *
- * If using ROOT version 6, 
- * you can manually copy '*_rdict.pcm' files to suppress run-time warnings,
- * for example, by the following command;
- *   find ../build -name '*_rdict.pcm' -exec cp -p {} $MY_INSTALL/lib/ \;
- * 
  * To run this macro on a local computer, you need copy Coda file and also
  *  mapping files.  You can use the following commands;
      RUN=28700
@@ -18,25 +10,15 @@
      scp -p  e906-gat6.fnal.gov:/data3/data/mainDAQ/run_$RUN6.dat $DIR_LOCAL
      scp -pr e906-gat6.fnal.gov:/data2/production/runs/run_$RUN6  $DIR_LOCAL/runs
  */
-R__LOAD_LIBRARY(libdecoder_maindaq)
-
 int Fun4MainDaq(
   const int nevent = 0,
   const char* fn_in  = "/data/e906/run_028700.dat",  
   const char* fn_out = "maindaq.root")
 {
-//  gSystem->Load("libfun4all.so");
-//  gSystem->Load("libevent.so");
-//  gSystem->Load("libdecoder_maindaq.so");
-    
+  gSystem->Load("libdecoder_maindaq.so");
+
   Fun4AllServer* se = Fun4AllServer::instance();
   //se->Verbosity(1);
-
-  //TestAnalyzer *analyzer = new TestAnalyzer();
-  //analyzer->Verbosity(verbosity);
-  //analyzer->set_hit_container_choice("Vector");
-  //analyzer->set_out_name(outeval);
-  //se->registerSubsystem(analyzer);
 
   Fun4AllEVIOInputManager *in = new Fun4AllEVIOInputManager("MainDaq");
   in->Verbosity(1);
@@ -47,6 +29,9 @@ int Fun4MainDaq(
 
   Fun4AllDstOutputManager *out = new Fun4AllDstOutputManager("DSTOUT", fn_out);
   se->registerOutputManager(out);
+
+  SubsysReco* ana = new AnaMainDaq();
+  se->registerSubsystem(ana);
 
   se->run(nevent);
   se->End();

--- a/online/decoder_maindaq/AnaMainDaq.cc
+++ b/online/decoder_maindaq/AnaMainDaq.cc
@@ -1,0 +1,120 @@
+/*
+ * AnaMainDaq.C
+ *
+ *  Created on: Oct 29, 2017
+ *      Author: yuhw
+ */
+#include <iomanip>
+#include <interface_main/SQRun.h>
+#include <interface_main/SQSpillMap.h>
+#include <interface_main/SQSpill.h>
+#include <interface_main/SQStringMap.h>
+#include <interface_main/SQScaler.h>
+#include <interface_main/SQSlowCont.h>
+#include <interface_main/SQEvent.h>
+#include <interface_main/SQHitVector.h>
+#include <fun4all/Fun4AllReturnCodes.h>
+#include <phool/PHNodeIterator.h>
+#include <phool/PHIODataNode.h>
+#include <phool/getClass.h>
+#include "AnaMainDaq.h"
+using namespace std;
+
+AnaMainDaq::AnaMainDaq(const std::string& name) : SubsysReco(name)
+{
+  ;
+}
+
+int AnaMainDaq::Init(PHCompositeNode* topNode)
+{
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int AnaMainDaq::InitRun(PHCompositeNode* topNode)
+{
+  SQRun* run_header = findNode::getClass<SQRun>(topNode, "SQRun");
+  if (!run_header) return Fun4AllReturnCodes::ABORTEVENT;
+  cout << "SQRun: \n"
+       << "  " << run_header->get_run_id()
+       << "  " << run_header->get_spill_count()
+       << endl;
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int AnaMainDaq::process_event(PHCompositeNode* topNode)
+{
+  SQSpillMap*     spill_map = findNode::getClass<SQSpillMap >(topNode, "SQSpillMap");
+  SQEvent*     event_header = findNode::getClass<SQEvent    >(topNode, "SQEvent");
+  SQHitVector*      hit_vec = findNode::getClass<SQHitVector>(topNode, "SQHitVector");
+  SQHitVector* trig_hit_vec = findNode::getClass<SQHitVector>(topNode, "SQTriggerHitVector");
+  if (!spill_map || !event_header || !hit_vec || !trig_hit_vec) return Fun4AllReturnCodes::ABORTEVENT;
+
+  static int spill_id_pre = -1;
+  if (event_header->get_spill_id() != spill_id_pre) {
+    spill_id_pre = event_header->get_spill_id();
+    SQSpill* spi = spill_map->get(spill_id_pre);
+    PrintSpill(spi);
+  }
+
+  static int n_evt_print = 0;
+  if (n_evt_print++ < 3) PrintEvent(event_header, hit_vec, trig_hit_vec);
+  
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int AnaMainDaq::End(PHCompositeNode* topNode)
+{
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+void AnaMainDaq::PrintSpill(SQSpill* spi)
+{
+  cout << "SQSpill:  "
+       << "  " << spi->get_spill_id    ()
+       << "  " << spi->get_run_id      ()
+       << "  " << spi->get_target_pos  ()
+       << "  " << spi->get_bos_coda_id ()
+       << "  " << spi->get_bos_vme_time()
+       << "  " << spi->get_eos_coda_id ()
+       << "  " << spi->get_eos_vme_time()
+       << "  \nBOS Scaler:  " << spi->get_bos_scaler_list()->size() << "\n";
+  for (SQStringMap::ConstIter it = spi->get_bos_scaler_list()->begin(); it != spi->get_bos_scaler_list()->end(); it++) {
+    string name = it->first;
+    SQScaler* sca = dynamic_cast<SQScaler*>(it->second);
+    cout << "    " << setw(20) << name << " " << setw(10) << sca->get_count() << "\n";
+  }
+  cout << "  EOS Scaler:  " << spi->get_eos_scaler_list()->size() << "\n";
+  for (SQStringMap::ConstIter it = spi->get_eos_scaler_list()->begin(); it != spi->get_eos_scaler_list()->end(); it++) {
+    string name = it->first;
+    SQScaler* sca = dynamic_cast<SQScaler*>(it->second);
+    cout << "  " << setw(20) << name << " " << setw(10) << sca->get_count() << "\n";
+  }
+  cout << "  Slow Control  " << spi->get_slow_cont_list()->size() << ":\n";
+  for (SQStringMap::ConstIter it = spi->get_slow_cont_list()->begin(); it != spi->get_slow_cont_list()->end(); it++) {
+    string name = it->first;
+    SQSlowCont* slo = dynamic_cast<SQSlowCont*>(it->second);
+    cout << "  " << setw(20) << name << " " << slo->get_time_stamp() << " " << setw(20) << slo->get_value() << " " << slo->get_type() << "\n";
+  }
+}
+
+void AnaMainDaq::PrintEvent(SQEvent* evt, SQHitVector* v_hit, SQHitVector* v_trig_hit)
+{
+  cout << "SQEvent:  "
+       << "  " << evt->get_run_id       ()
+       << "  " << evt->get_spill_id     ()
+       << "  " << evt->get_event_id     ()
+       << "  " << evt->get_coda_event_id()
+       << "  " << evt->get_data_quality ()
+       << "  " << evt->get_vme_time     ()
+       << "\n";
+
+  cout << "SQHitVector (Taiwan TDC):  " << v_hit->size() << "\n";
+  for (SQHitVector::ConstIter it = v_hit->begin(); it != v_hit->end(); it++) {
+    cout << "    " << (*it)->get_hit_id() << " " << setw(2) << (*it)->get_detector_id() << " " << setw(3) << (*it)->get_element_id() << " " << (*it)->get_tdc_time() << "\n";
+  }
+
+  cout << "SQHitVector (v1495 TDC):  " << v_trig_hit->size() << "\n";
+  for (SQHitVector::ConstIter it = v_trig_hit->begin(); it != v_trig_hit->end(); it++) {
+    cout << "    " << (*it)->get_hit_id() << " " << setw(2) << (*it)->get_detector_id() << " " << setw(3) << (*it)->get_element_id() << " " << (*it)->get_tdc_time() << "\n";
+  }
+}

--- a/online/decoder_maindaq/AnaMainDaq.h
+++ b/online/decoder_maindaq/AnaMainDaq.h
@@ -1,0 +1,27 @@
+/*
+ * AnaMainDaq.h
+ *
+ *  Created on: Oct 29, 2017
+ *      Author: yuhw
+ */
+#ifndef _H_AnaMainDaq_H_
+#define _H_AnaMainDaq_H_
+#include <fun4all/SubsysReco.h>
+class SQSpill;
+class SQEvent;
+class SQHitVector;
+
+class AnaMainDaq: public SubsysReco {
+ public:
+  AnaMainDaq(const std::string &name = "AnaMainDaq");
+  virtual ~AnaMainDaq() {}
+  int Init(PHCompositeNode *topNode);
+  int InitRun(PHCompositeNode *topNode);
+  int process_event(PHCompositeNode *topNode);
+  int End(PHCompositeNode *topNode);
+ private:
+  void PrintSpill(SQSpill* spi);
+  void PrintEvent(SQEvent* evt, SQHitVector* v_hit, SQHitVector* v_trig_hit);
+};
+
+#endif /* _H_AnaMainDaq_H_ */

--- a/online/decoder_maindaq/AnaMainDaqLinkDef.h
+++ b/online/decoder_maindaq/AnaMainDaqLinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class AnaMainDaq-!;
+
+#endif /* __CINT__ */

--- a/online/decoder_maindaq/CMakeLists.txt
+++ b/online/decoder_maindaq/CMakeLists.txt
@@ -10,7 +10,7 @@ foreach(LinkDefh ${LinkDefhs})
 	string(REPLACE "LinkDef.h" "_Dict.C" DictC ${LinkDefh})
 	string(REPLACE "${PROJECT_SOURCE_DIR}/" "" DictC ${DictC})
 	list(APPEND dicts ${DictC})
-	add_custom_command(OUTPUT ${DictC} COMMAND rootcint ARGS -f ${DictC} -c -I$ENV{OFFLINE_MAIN}/include ${Dicth} ${LinkDefh})
+	add_custom_command(OUTPUT ${DictC} COMMAND rootcint ARGS -f ${DictC} -c -I$ENV{MY_INSTALL}/include/ -I$ENV{OFFLINE_MAIN}/include ${Dicth} ${LinkDefh})
 endforeach(LinkDefh)
 
 link_directories("./" "$ENV{MY_INSTALL}/lib/" "$ENV{OFFLINE_MAIN}/lib/")
@@ -30,8 +30,8 @@ execute_process(COMMAND root-config --prefix OUTPUT_VARIABLE ROOT_PREFIX  OUTPUT
 execute_process(COMMAND root-config --cflags OUTPUT_VARIABLE ROOT_CFLAGS  OUTPUT_STRIP_TRAILING_WHITESPACE)
 execute_process(COMMAND root-config --libs   OUTPUT_VARIABLE ROOT_LINK    OUTPUT_STRIP_TRAILING_WHITESPACE)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x -I$ENV{OFFLINE_MAIN}/include/ ${ROOT_CFLAGS}")
-set(CMAKE_C_FLAGS   "${CMAKE_C_FLAGS} -DBIT64      -I$ENV{OFFLINE_MAIN}/include/")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x -I$ENV{MY_INSTALL}/include/ -I$ENV{OFFLINE_MAIN}/include/ ${ROOT_CFLAGS}")
+set(CMAKE_C_FLAGS   "${CMAKE_C_FLAGS}   -DBIT64    -I$ENV{MY_INSTALL}/include/ -I$ENV{OFFLINE_MAIN}/include/")
 
 add_library(decoder_maindaq SHARED ${sources} ${dicts})
 target_link_libraries(decoder_maindaq -linterface_main -lfun4all -lphool -levent)

--- a/online/decoder_maindaq/CodaInputManager.h
+++ b/online/decoder_maindaq/CodaInputManager.h
@@ -56,11 +56,6 @@ enum { BEGIN_SPILL      =  11 };
 enum { END_SPILL        =  12 };
 enum { SPILL_COUNTER    = 129 };
 
-typedef enum {
-  TYPE_BOS = 1,
-  TYPE_EOS = 2
-} SpillType_t;
-
 //
 // Helper function
 //   These are not in CodaInputManager for easier call.

--- a/online/decoder_maindaq/DecoParam.cc
+++ b/online/decoder_maindaq/DecoParam.cc
@@ -47,11 +47,11 @@ int DecoParam::InitMapper()
 void DecoParam::PrintStat()
 {
   cout << "\nDecoParam::PrintStat():\n"
-       << "Flush events:  all = " << n_flush_evt_all << ", ok = " << n_flush_evt_ok << "\n"
-       << "v1495 events:  all = " << n_1495_all << ", ok = " << n_1495_good
+       << "  Flush events:  all = " << n_flush_evt_all << ", ok = " << n_flush_evt_ok << "\n"
+       << "  v1495 events:  all = " << n_1495_all << ", ok = " << n_1495_good
        << ", 0xd1ad = " << n_1495_d1ad << ", 0xd2ad = " << n_1495_d2ad << ", 0xd3ad = " << n_1495_d3ad << "\n"
-       << "Phys. events: all = " << n_phys_evt_all << ", decoded = " << n_phys_evt_dec << "\n"
-       << "TDC   hits: total = " <<  n_hit << ", max/evt = " <<  n_hit_max << ", bad = " << n_hit_bad << "\n"
-       << "v1495 hits: total = " << n_thit << ", max/evt = " << n_thit_max << "\n"
-       << "Real Time: " << (timeEnd - timeStart) << "\n";
+       << "  Phys. events: all = " << n_phys_evt_all << ", decoded = " << n_phys_evt_dec << "\n"
+       << "  TDC   hits: total = " <<  n_hit << ", max/evt = " <<  n_hit_max << ", bad = " << n_hit_bad << "\n"
+       << "  v1495 hits: total = " << n_thit << ", max/evt = " << n_thit_max << "\n"
+       << "  Real Time: " << (timeEnd - timeStart) << "\n";
 }

--- a/online/decoder_maindaq/MainDaqParser.h
+++ b/online/decoder_maindaq/MainDaqParser.h
@@ -67,6 +67,11 @@ class MainDaqParser {
   void SetEventInfo(EventInfo* evt, const int eventID);
 
 public:
+  typedef enum {
+    TYPE_BOS = 1,
+    TYPE_EOS = 2
+  } SpillType_t;
+
   MainDaqParser();
   ~MainDaqParser();
 


### PR DESCRIPTION
This update has extended the interface_main classes (SQSpill etc) to store the decoded MainDAQ data.  Please check if the style of these extensions are OK.  If so, I will continue extending them further.   Below are my key points.

1. A v2 class (SQSpill_v2) was created.  Is it in good manner?  Am I correct that new functions can be added to the abstract class (SQSpill)?

2. Shall we use the general list class (SQStringMap & SQIntMap) instead of, say, SQSpillMap?  It seems too much to write one list class per one object class.  As examples, SQScaler & SQSlowCont are stored in SQString Map.

3. The "online/decoder_maindaq/AnaMainDaq" class will be the main SubsysReco module to qualify and calibrate the decoded data.  The data processing in Fun4AllEVIOInputManager will be as minimum as possible (for easier recalibration etc).  For example, we can move the channel mapping to AnaMainDaq.