### PR TITLE
Fixed extrapolation through FMag - field inconsistency issue

### DIFF
--- a/module_example/TrkEval.cxx
+++ b/module_example/TrkEval.cxx
@@ -268,6 +268,8 @@ int TrkEval::process_event(PHCompositeNode* topNode) {
   			++iter) {
   		PHG4Particle * par = iter->second;
 
+  		pid[n_particles] = par->get_pid();
+
   		int vtx_id =  par->get_vtx_id();
   		PHG4VtxPoint* vtx = _truth->GetVtx(vtx_id);
   		gvx[n_particles] = vtx->get_x();
@@ -326,6 +328,7 @@ int TrkEval::process_event(PHCompositeNode* topNode) {
   			ntruhits[n_particles] = std::get<1>(parID_bestRecID[parID]);
   			int recID = std::get<0>(parID_bestRecID[parID]);
   			SRecTrack recTrack = _recEvent->getTrack(recID);
+  			charge[n_particles] = recTrack.getCharge();
   			TVector3 rec_vtx = recTrack.getTargetPos();
   			vx[n_particles]  = rec_vtx.X();
   			vy[n_particles]  = rec_vtx.Y();
@@ -505,6 +508,7 @@ int TrkEval::InitEvalTree() {
   _tout->Branch("gnprop",        gnprop,              "gnprop[n_particles]/I");
 
   _tout->Branch("ntruhits",      ntruhits,            "ntruhits[n_particles]/I");
+  _tout->Branch("charge",        charge,              "charge[n_particles]/I");
   _tout->Branch("vx",            vx,                  "vx[n_particles]/F");
   _tout->Branch("vy",            vy,                  "vy[n_particles]/F");
   _tout->Branch("vz",            vz,                  "vz[n_particles]/F");
@@ -561,6 +565,7 @@ int TrkEval::ResetEvalVars() {
 
   n_particles = 0;
   for(int i=0; i<1000; ++i) {
+    pid[i]        = std::numeric_limits<float>::max();
     gvx[i]        = std::numeric_limits<float>::max();
     gvy[i]        = std::numeric_limits<float>::max();
     gvz[i]        = std::numeric_limits<float>::max();
@@ -579,6 +584,7 @@ int TrkEval::ResetEvalVars() {
     gnprop[i]     = std::numeric_limits<int>::max();
 
     ntruhits[i]   = std::numeric_limits<int>::max();
+    charge[i]     = std::numeric_limits<int>::max();
     vx[i]         = std::numeric_limits<float>::max();
     vy[i]         = std::numeric_limits<float>::max();
     vz[i]         = std::numeric_limits<float>::max();
@@ -602,6 +608,15 @@ int TrkEval::ResetEvalVars() {
   	dimu_gmass[i]      = std::numeric_limits<float>::max();
   	dimu_geta[i]       = std::numeric_limits<float>::max();
   	dimu_gphi[i]       = std::numeric_limits<float>::max();
+
+  	dimu_nrec[i]       = 0;
+  	dimu_px[i]         = std::numeric_limits<float>::max();
+  	dimu_py[i]         = std::numeric_limits<float>::max();
+  	dimu_pz[i]         = std::numeric_limits<float>::max();
+  	dimu_pt[i]         = std::numeric_limits<float>::max();
+  	dimu_mass[i]       = std::numeric_limits<float>::max();
+  	dimu_eta[i]        = std::numeric_limits<float>::max();
+  	dimu_phi[i]        = std::numeric_limits<float>::max();
   }
 
   return 0;

--- a/module_example/TrkEval.cxx
+++ b/module_example/TrkEval.cxx
@@ -361,7 +361,12 @@ int TrkEval::process_event(PHCompositeNode* topNode) {
 				iter2++;
 				for (;iter2 != _truth->GetPrimaryParticleRange().second; ++iter2) {
 					PHG4Particle* par2 = iter2->second;
-					if(par2->get_pid()+par->get_pid()!=0) continue;
+
+					// Un-like charged
+					if(par->get_pid()+par2->get_pid()!=0) continue;
+
+					// same vtx
+					if(par->get_vtx_id() != par2->get_vtx_id()) continue;
 
 					TLorentzVector par1_mom;
 					par1_mom.SetXYZM(
@@ -383,8 +388,8 @@ int TrkEval::process_event(PHCompositeNode* topNode) {
 					dimu_gpx[gndimu] = vphoton.Px();
 					dimu_gpy[gndimu] = vphoton.Py();
 					dimu_gpz[gndimu] = vphoton.Pz();
-					dimu_gpt[gndimu] = vphoton.M();
-					dimu_gmass[gndimu] = vphoton.Pt();
+					dimu_gpt[gndimu] = vphoton.Pt();
+					dimu_gmass[gndimu] = vphoton.M();
 					dimu_geta[gndimu] = vphoton.Eta();
 					dimu_gphi[gndimu] = vphoton.Phi();
 

--- a/module_example/TrkEval.h
+++ b/module_example/TrkEval.h
@@ -131,6 +131,7 @@ private:
 	int gnhodo[1000];
 	int gnprop[1000];
 	int ntruhits[1000];
+	int charge[1000];
 	float vx[1000];
 	float vy[1000];
 	float vz[1000];

--- a/packages/global_consts/GlobalConsts.h
+++ b/packages/global_consts/GlobalConsts.h
@@ -41,8 +41,8 @@
 #define nHodoPlanes 16
 #define nPropPlanes 8
 
-#define FMAGSTR -1.054
-#define KMAGSTR -0.951
+#define FMAGSTR 1.054
+#define KMAGSTR 0.951
 
 #define Z_KMAG_BEND 1064.26
 #define Z_FMAG_BEND 251.4

--- a/packages/ktracker/KalmanFastTracking.cxx
+++ b/packages/ktracker/KalmanFastTracking.cxx
@@ -1838,7 +1838,8 @@ SRecTrack KalmanFastTracking::processOneTracklet(Tracklet& tracklet)
     TrkPar trkpar_curr;
     trkpar_curr._z = p_geomSvc->getPlanePosition(kmtrk.getNodeList().back().getHit().detectorID);
     //FIXME Debug Testing: sign reverse
-    trkpar_curr._state_kf[0][0] = -tracklet.getCharge()*tracklet.invP/sqrt(1. + tracklet.tx*tracklet.tx + tracklet.ty*tracklet.ty);
+    //TODO seems to be fixed
+    trkpar_curr._state_kf[0][0] = tracklet.getCharge()*tracklet.invP/sqrt(1. + tracklet.tx*tracklet.tx + tracklet.ty*tracklet.ty);
     trkpar_curr._state_kf[1][0] = tracklet.tx;
     trkpar_curr._state_kf[2][0] = tracklet.ty;
     trkpar_curr._state_kf[3][0] = tracklet.getExpPositionX(trkpar_curr._z);


### PR DESCRIPTION
Fixed a bug in extrapolation from station 1 to FMag front face.
Previously there are inconsistency of the field setting in global.h and in the adapted ktracker code.
Made them consistent this time.

Before fix 1k DY, no target field:
![image](https://user-images.githubusercontent.com/10383186/49039681-79728b00-f18e-11e8-93af-d53f40f99ade.png)


After fix 1k DY, no target field:
![image](https://user-images.githubusercontent.com/10383186/49039708-8becc480-f18e-11e8-9972-9ff6006ab3e6.png)


Next step would be implementing the extrapolation with target field on.
