### PR TITLE
Small fix: hide some functions from CINT

### DIFF
--- a/packages/ktracker/KalmanFastTrackingWrapper.cxx
+++ b/packages/ktracker/KalmanFastTrackingWrapper.cxx
@@ -42,6 +42,7 @@
 #include <stdexcept>
 #include <limits>
 #include <memory>
+#include <fstream>
 
 #include <boost/lexical_cast.hpp>
 
@@ -98,7 +99,9 @@ int KalmanFastTrackingWrapper::InitRun(PHCompositeNode* topNode) {
 
   if(verbosity > 2) {
     cout << "PHField check: " << "-------" << endl;
-    field->identify();
+    std::ofstream field_scan("field_scan.csv");
+    field->identify(field_scan);
+    field_scan.close();
   }
 
 	/// init KalmanPrgTrk

--- a/packages/ktracker/KalmanPrgTrk.h
+++ b/packages/ktracker/KalmanPrgTrk.h
@@ -107,7 +107,8 @@ public:
     std::list<SRecTrack>& getSRecTracks() { return stracks; }
     std::list<PropSegment>& getPropSegments(int i) { return propSegs[i]; }
 
-    ///Tool, a simple-minded chi square fit
+    /// Tool, a simple-minded chi square fit
+    /// Y = a*X + b
     void chi2fit(int n, double x[], double y[], double& a, double& b);
 
 private:
@@ -205,15 +206,6 @@ private:
     const bool enable_KF;
 
     std::map< std::string, PHTimer* > _timers;
-
-//    PHTimer* _t_st2;
-//    PHTimer* _t_st3;
-//    PHTimer* _t_st23;
-//    PHTimer* _t_global;
-//    PHTimer* _t_global_st1;
-//    PHTimer* _t_global_link;
-//    PHTimer* _t_global_kalman;
-//    PHTimer* _t_kalman;
 
 };
 

--- a/simulation/g4detectors/DPDigitizer.cc
+++ b/simulation/g4detectors/DPDigitizer.cc
@@ -27,7 +27,9 @@
 #include <TSQLResult.h>
 #include <TSQLRow.h>
 
+#ifndef __CINT__
 #include <boost/lexical_cast.hpp>
+#endif
 
 #define LogDebug(exp)       std::cout<<"DEBUG: "  <<__FUNCTION__<<": "<<__LINE__<<": "<< exp << std::endl
 
@@ -184,11 +186,12 @@ string DPDigitizer::toGroupName(string in) {
 	return "";
 }
 
-DPDigitizer::DPDigitizer(const std::string &name, const int verbo) :
-		SubsysReco(name),
-		p_geomSvc(nullptr)
+#ifndef __CINT__
+int DPDigitizer::Init(PHCompositeNode *topNode)
 {
-	Verbosity(verbo);
+	for(int i=0; i<NDETPLANES+1; ++i) {
+		digiPlanes.push_back(DPDigiPlane());
+	}
 
 	//init map_dname_group
 	map_dname_group["D1U"]      = "D1";
@@ -452,6 +455,16 @@ DPDigitizer::DPDigitizer(const std::string &name, const int verbo) :
       }
     }
   };
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+#endif
+
+DPDigitizer::DPDigitizer(const std::string &name, const int verbo) :
+		SubsysReco(name),
+		p_geomSvc(nullptr)
+{
+	Verbosity(verbo);
 }
 
 DPDigitizer::~DPDigitizer() {

--- a/simulation/g4detectors/DPDigitizer.h
+++ b/simulation/g4detectors/DPDigitizer.h
@@ -6,15 +6,13 @@
 #include <vector>
 #include <string>
 #include <map>
+
+#ifndef __CINT__
 #include <boost/array.hpp>
+#include <Geant4/G4ThreeVector.hh>
+#endif
 
 #include <TSpline.h>
-
-#include <Geant4/G4String.hh>
-#include <Geant4/G4ThreeVector.hh>
-
-//#include "DPMCRawEvent.h"
-//#include "DPVirtualHit.h"
 
 class PHG4Hit;
 class SQHit;
@@ -31,8 +29,10 @@ public:
 	//!calculates all the derived variables
 	void preCalculation();
 
+#ifndef __CINT__
 	//!intercepts with a 3-D straight line
 	bool intercept(double tx, double ty, double x0, double y0, G4ThreeVector& pos, double& w);
+#endif
 
 	//!@name X, Y, U, V conversion
 	//@{
@@ -56,8 +56,8 @@ public:
 
 public:
 	int detectorID;
-	G4String detectorGroupName;     //large detector group that this plane belongs to
-	G4String detectorName;          //its own specific name
+	std::string detectorGroupName;     //large detector group that this plane belongs to
+	std::string detectorName;          //its own specific name
 
 	//!@name geometric specifications
 	//@{
@@ -103,8 +103,11 @@ class DPDigitizer : public SubsysReco
 {
 public:
 	DPDigitizer(const std::string &name = "DPDigitizer", const int verbo = 0);
-
   virtual ~DPDigitizer();
+
+#ifndef __CINT__
+	int Init(PHCompositeNode *topNode);
+#endif
 
   //! module initialization
   int InitRun(PHCompositeNode *topNode);
@@ -119,10 +122,10 @@ public:
 	bool realize(SQHit& dHit);
 
 	//!get the detectorID by detectorName
-	int getDetectorID(G4String detectorName) { return map_detectorID[detectorName]; }
+	int getDetectorID(std::string detectorName) { return map_detectorID[detectorName]; }
 
 	//!get the detectorName by detectorID
-	G4String getDetectorName(int detectorID) { return digiPlanes[detectorID].detectorName; }
+	std::string getDetectorName(int detectorID) { return digiPlanes[detectorID].detectorName; }
 
 	//!Get the trigger level by detectorID
 	int getTriggerLv(int detectorID) { return digiPlanes[detectorID].triggerLv; }
@@ -136,13 +139,15 @@ public:
 private:
 
 	//!array of digi planes
-	boost::array<DPDigiPlane, NDETPLANES+1> digiPlanes;
+	//boost::array<DPDigiPlane, NDETPLANES+1> digiPlanes;
+
+	std::vector<DPDigiPlane> digiPlanes;
 
 	//!map from geant sensitive detector name to the list of detectorIDs
-	std::map<G4String, std::vector<int> > map_groupID;
+	std::map<std::string, std::vector<int> > map_groupID;
 
 	//!map from detectorName to detectorID
-	std::map<G4String, int> map_detectorID;
+	std::map<std::string, int> map_detectorID;
 
 	//!
 	std::map<std::string, std::string> map_g4name_group;


### PR DESCRIPTION
Hide some functions in `DPDigitizer` from CINT to prevent error msg in ROOT dictionary generation.
Thanks to Mindy for pointing this out!

Sorry this PR also has some update in the `KalmanFastTrackingWrapper` for dev purpose.