### PR TITLE
Channel mapping and database service

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -17,6 +17,7 @@ else
     packages/global_consts
     packages/jobopts_svc
     packages/geom_svc
+    packages/db_svc
     framework/phool
     framework/ffaobjects
     framework/fun4all
@@ -24,25 +25,25 @@ else
     online/chan_map
     online/onlmonserver
     online/decoder_maindaq
-#    packages/Half
-#    packages/vararray
-#    database/pdbcal/base
-#    database/PHParameter
-#    packages/PHGeometry
-#    packages/PHField
-#    generators/phhepmc
-#    generators/PHPythia8
-#    simulation/g4decayer
-#    simulation/g4gdml
-#    simulation/g4main
-#    simulation/g4detectors
-#    simulation/g4dst
-#    simulation/g4eval
-#    packages/db2g4
-#    packages/PHGenFitPkg/GenFitExp
-#    packages/PHGenFitPkg/PHGenFit
-#    packages/ktracker
-#    module_example
+    packages/Half
+    packages/vararray
+    database/pdbcal/base
+    database/PHParameter
+    packages/PHGeometry
+    packages/PHField
+    generators/phhepmc
+    generators/PHPythia8
+    simulation/g4decayer
+    simulation/g4gdml
+    simulation/g4main
+    simulation/g4detectors
+    simulation/g4dst
+    simulation/g4eval
+    packages/db2g4
+    packages/PHGenFitPkg/GenFitExp
+    packages/PHGenFitPkg/PHGenFit
+    packages/ktracker
+    module_example
 	)
 fi
 

--- a/build.sh
+++ b/build.sh
@@ -21,27 +21,28 @@ else
     framework/ffaobjects
     framework/fun4all
     interface_main
+    online/chan_map
     online/onlmonserver
     online/decoder_maindaq
-    packages/Half
-    packages/vararray
-    database/pdbcal/base
-    database/PHParameter
-    packages/PHGeometry
-    packages/PHField
-    generators/phhepmc
-    generators/PHPythia8
-    simulation/g4decayer
-    simulation/g4gdml
-    simulation/g4main
-    simulation/g4detectors
-    simulation/g4dst
-    simulation/g4eval
-    packages/db2g4
-    packages/PHGenFitPkg/GenFitExp
-    packages/PHGenFitPkg/PHGenFit
-    packages/ktracker
-    module_example
+#    packages/Half
+#    packages/vararray
+#    database/pdbcal/base
+#    database/PHParameter
+#    packages/PHGeometry
+#    packages/PHField
+#    generators/phhepmc
+#    generators/PHPythia8
+#    simulation/g4decayer
+#    simulation/g4gdml
+#    simulation/g4main
+#    simulation/g4detectors
+#    simulation/g4dst
+#    simulation/g4eval
+#    packages/db2g4
+#    packages/PHGenFitPkg/GenFitExp
+#    packages/PHGenFitPkg/PHGenFit
+#    packages/ktracker
+#    module_example
 	)
 fi
 

--- a/macros/Fun4MainDaq.C
+++ b/macros/Fun4MainDaq.C
@@ -20,7 +20,7 @@ int Fun4MainDaq(const int nevent = 0, const int run = 28700)
   //const char* dir_in  = "/data/e906",
   const char* dir_in  = "/data2/analysis/kenichi/e1039";
   const char* dir_out = ".";
-  const bool is_online = true;
+  const bool is_online = false; // true;
 
   ostringstream oss;
   oss << setfill('0') 

--- a/online/chan_map/CMakeLists.txt
+++ b/online/chan_map/CMakeLists.txt
@@ -1,0 +1,74 @@
+# Setup the project
+cmake_minimum_required(VERSION 2.6 FATAL_ERROR)
+project(chan_map CXX)
+
+# ROOT dict generation
+#file(GLOB dicts "")
+#file(GLOB LinkDefhs ${PROJECT_SOURCE_DIR}/*LinkDef.h)
+#foreach(LinkDefh ${LinkDefhs})
+#	string(REPLACE "LinkDef.h" ".h" Dicth ${LinkDefh})
+#	string(REPLACE "LinkDef.h" "_Dict.C" DictC ${LinkDefh})
+#	string(REPLACE "${PROJECT_SOURCE_DIR}/" "" DictC ${DictC})
+#	list(APPEND dicts ${DictC})
+#	add_custom_command(OUTPUT ${DictC} COMMAND rootcint ARGS -f ${DictC} -c -I$ENV{OFFLINE_MAIN}/include ${Dicth} ${LinkDefh})
+#endforeach(LinkDefh)
+
+add_custom_command (
+  OUTPUT ChanMap_Dict.cc
+  COMMAND rootcint
+  ARGS -f ChanMap_Dict.cc -c
+  -I$ENV{OFFLINE_MAIN}/include/ -I${ROOT_PREFIX}/include/
+  ${PROJECT_SOURCE_DIR}/ChanMapper.h
+  ${PROJECT_SOURCE_DIR}/ChanMapperTaiwan.h
+  ${PROJECT_SOURCE_DIR}/LinkDef.h
+)
+
+
+link_directories("./" "$ENV{OFFLINE_MAIN}/lib/")
+include_directories("$ENV{OFFLINE_MAIN}/include/" "${PROJECT_SOURCE_DIR}/")
+
+file(GLOB sources ${PROJECT_SOURCE_DIR}/*.cc ${PROJECT_SOURCE_DIR}/*.c)
+file(GLOB headers ${PROJECT_SOURCE_DIR}/*.h)
+
+# MySQL
+find_program(MYSQL_CONF "mysql_config")
+if(MYSQL_CONF)
+  message("-- Detecting MySQL:    found at ${MYSQL_CONF}")
+else()
+  message(FATAL_ERROR "-- Detecting MySQL:    not found")
+endif()
+execute_process(COMMAND mysql_config --cflags OUTPUT_VARIABLE MYSQL_CFLAGS  OUTPUT_STRIP_TRAILING_WHITESPACE)
+execute_process(COMMAND mysql_config --libs   OUTPUT_VARIABLE MYSQL_LIBS    OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+
+# ROOT
+find_program(ROOTCONF "root-config")
+if(ROOTCONF)
+  message("-- Detecting ROOT:    found at ${ROOTCONF}")
+else()
+  message(FATAL_ERROR "-- Detecting ROOT:    not found")
+endif()
+execute_process(COMMAND root-config --cflags OUTPUT_VARIABLE ROOT_CFLAGS  OUTPUT_STRIP_TRAILING_WHITESPACE)
+execute_process(COMMAND root-config --libs   OUTPUT_VARIABLE ROOT_LINK    OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x -I$ENV{OFFLINE_MAIN}/include/ ${ROOT_CFLAGS} ${MYSQL_CFLAGS}")
+
+add_library(chan_map SHARED ${sources} ChanMap_Dict.cc)
+target_link_libraries(chan_map ${MYSQL_LIBS} ${ROOT_LINK})
+
+message(${CMAKE_PROJECT_NAME} " will be installed to " ${CMAKE_INSTALL_PREFIX})
+
+install(TARGETS chan_map DESTINATION ${CMAKE_INSTALL_PREFIX}/lib)
+
+file(GLOB dist_headers ${PROJECT_SOURCE_DIR}/*.h)
+file(GLOB non_dist_headers ${PROJECT_SOURCE_DIR}/*LinkDef.h)
+list(REMOVE_ITEM dist_headers ${non_dist_headers})
+install(FILES ${dist_headers} DESTINATION ${CMAKE_INSTALL_PREFIX}/include/${CMAKE_PROJECT_NAME}/)
+
+# Install the pcm files in case of ROOT 6.
+execute_process(COMMAND root-config --version OUTPUT_VARIABLE ROOT_VER)
+string(SUBSTRING ${ROOT_VER} 0 1 ROOT_VER)
+if (ROOT_VER GREATER 5)
+   add_custom_target(install_pcm ALL COMMAND mkdir -p ${CMAKE_INSTALL_PREFIX}/lib COMMAND cp -up *_rdict.pcm ${CMAKE_INSTALL_PREFIX}/lib)
+   add_dependencies(install_pcm chan_map)
+endif()

--- a/online/chan_map/CMakeLists.txt
+++ b/online/chan_map/CMakeLists.txt
@@ -3,27 +3,13 @@ cmake_minimum_required(VERSION 2.6 FATAL_ERROR)
 project(chan_map CXX)
 
 # ROOT dict generation
-#file(GLOB dicts "")
-#file(GLOB LinkDefhs ${PROJECT_SOURCE_DIR}/*LinkDef.h)
-#foreach(LinkDefh ${LinkDefhs})
-#	string(REPLACE "LinkDef.h" ".h" Dicth ${LinkDefh})
-#	string(REPLACE "LinkDef.h" "_Dict.C" DictC ${LinkDefh})
-#	string(REPLACE "${PROJECT_SOURCE_DIR}/" "" DictC ${DictC})
-#	list(APPEND dicts ${DictC})
-#	add_custom_command(OUTPUT ${DictC} COMMAND rootcint ARGS -f ${DictC} -c -I$ENV{OFFLINE_MAIN}/include ${Dicth} ${LinkDefh})
-#endforeach(LinkDefh)
-
 add_custom_command (
   OUTPUT ChanMap_Dict.cc
   COMMAND rootcint
   ARGS -f ChanMap_Dict.cc -c
-  -I$ENV{OFFLINE_MAIN}/include/ -I${ROOT_PREFIX}/include/
-  ${PROJECT_SOURCE_DIR}/ChanMapperRange.h
-  ${PROJECT_SOURCE_DIR}/ChanMapper.h
-  ${PROJECT_SOURCE_DIR}/ChanMapperTaiwan.h
-  ${PROJECT_SOURCE_DIR}/LinkDef.h
+    -I$ENV{OFFLINE_MAIN}/include/ -I${ROOT_PREFIX}/include/
+    ${PROJECT_SOURCE_DIR}/*.h
 )
-
 
 link_directories("./" "$ENV{OFFLINE_MAIN}/lib/")
 include_directories("$ENV{OFFLINE_MAIN}/include/" "${PROJECT_SOURCE_DIR}/")

--- a/online/chan_map/CMakeLists.txt
+++ b/online/chan_map/CMakeLists.txt
@@ -18,6 +18,7 @@ add_custom_command (
   COMMAND rootcint
   ARGS -f ChanMap_Dict.cc -c
   -I$ENV{OFFLINE_MAIN}/include/ -I${ROOT_PREFIX}/include/
+  ${PROJECT_SOURCE_DIR}/ChanMapperRange.h
   ${PROJECT_SOURCE_DIR}/ChanMapper.h
   ${PROJECT_SOURCE_DIR}/ChanMapperTaiwan.h
   ${PROJECT_SOURCE_DIR}/LinkDef.h

--- a/online/chan_map/CMakeLists.txt
+++ b/online/chan_map/CMakeLists.txt
@@ -13,7 +13,8 @@ if (ROOT_VER GREATER 5)
     COMMAND rootcint
     ARGS -f ChanMap_Dict.cc -c
       -I$ENV{OFFLINE_MAIN}/include/ -I${ROOT_PREFIX}/include/
-      ${PROJECT_SOURCE_DIR}/*.h
+      ${PROJECT_SOURCE_DIR}/ChanMapper*.h
+      ${PROJECT_SOURCE_DIR}/LinkDef.h
   )
 endif()
 

--- a/online/chan_map/CMakeLists.txt
+++ b/online/chan_map/CMakeLists.txt
@@ -41,7 +41,7 @@ execute_process(COMMAND root-config --libs   OUTPUT_VARIABLE ROOT_LINK    OUTPUT
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x -I$ENV{OFFLINE_MAIN}/include/ ${ROOT_CFLAGS} ${MYSQL_CFLAGS}")
 
 add_library(chan_map SHARED ${sources} ChanMap_Dict.cc)
-target_link_libraries(chan_map ${MYSQL_LIBS} ${ROOT_LINK})
+target_link_libraries(chan_map ${MYSQL_LIBS} ${ROOT_LINK} geom_svc)
 
 message(${CMAKE_PROJECT_NAME} " will be installed to " ${CMAKE_INSTALL_PREFIX})
 

--- a/online/chan_map/ChanMapper.cc
+++ b/online/chan_map/ChanMapper.cc
@@ -20,6 +20,26 @@ ChanMapper::~ChanMapper()
   ;
 }
 
+void ChanMapper::SetMapIDbyFile(const std::string map_id)
+{
+  m_range.ReadFromFile(RangeFileName().c_str());
+  if (! m_range.Find(map_id)) {
+    cout << "  !WARNING!  SetMapIDbyFile():  This map ID '" << map_id
+         << "' is not included in the run-range table.  OK?" << endl;
+  }
+  m_map_id = map_id;
+}
+
+void ChanMapper::SetMapIDbyDB(const std::string map_id)
+{
+  m_range.ReadFromDB(RangeFileName().c_str());
+  if (! m_range.Find(map_id)) {
+    cout << "  !WARNING!  SetMapIDbyDB():  This map ID '" << map_id
+         << "' is not included in the run-range table.  OK?" << endl;
+  }
+  m_map_id = map_id;
+}
+
 void ChanMapper::SetMapIDbyFile(const int run)
 {
   m_range.ReadFromFile(RangeFileName().c_str());
@@ -30,34 +50,6 @@ void ChanMapper::SetMapIDbyDB(const int run)
 {
   m_range.ReadFromDB(SchemaName());
   m_map_id = m_range.Find(run);
-}
-
-std::string ChanMapper::RangeFileName()
-{
-  ostringstream oss;
-  oss << m_dir_base << "/" << m_label << "/run_range.tsv";
-  return oss.str();
-}
-
-std::string ChanMapper::MapFileName()
-{
-  ostringstream oss;
-  oss << m_dir_base << "/" << m_label << "/" << m_map_id << "/chan_map.tsv";
-  return oss.str();
-}
-
-std::string ChanMapper::SchemaName()
-{
-  string ret = "user_e1039_chan_map_";
-  ret += m_label;
-  return ret;
-}
-
-std::string ChanMapper::MapTableName()
-{
-  string ret = "chan_map_";
-  ret += m_map_id;
-  return ret;
 }
 
 void ChanMapper::ReadFromFile()
@@ -117,7 +109,7 @@ void ChanMapper::ReadFromDB()
 
   DbSvc db(DbSvc::DB1);
   db.UseSchema(name_schema);
-  db.AssureTable(name_table);
+  db.HasTable(name_table, true);
   ReadDbTable(db);
 }
 
@@ -150,6 +142,46 @@ void ChanMapper::Print(std::ostream& os)
   cout << "  virtual function called." << endl;
 }
 
+std::string ChanMapper::RangeFileName()
+{
+  ostringstream oss;
+  oss << m_dir_base << "/" << m_label << "/run_range.tsv";
+  return oss.str();
+}
+
+std::string ChanMapper::MapFileName()
+{
+  ostringstream oss;
+  oss << m_dir_base << "/" << m_label << "/" << m_map_id << "/chan_map.tsv";
+  return oss.str();
+}
+
+std::string ChanMapper::SchemaName()
+{
+  string ret = "user_e1039_chan_map_";
+  ret += m_label;
+  return ret;
+}
+
+std::string ChanMapper::MapTableName()
+{
+  string ret = "chan_map_";
+  ret += m_map_id;
+  return ret;
+}
+
+int ChanMapper::ReadFileCont(LineList& lines)
+{
+  cout << "  virtual function called." << endl;
+  return 0;
+}
+
+int ChanMapper::WriteFileCont(std::ostream& os)
+{
+  cout << "  virtual function called." << endl;
+  return 0;
+}
+
 void ChanMapper::ReadDbTable(DbSvc& db)
 {
   cout << "  virtual function called." << endl;
@@ -159,4 +191,3 @@ void ChanMapper::WriteDbTable(DbSvc& db)
 {
   cout << "  virtual function called." << endl;
 }
-

--- a/online/chan_map/ChanMapper.cc
+++ b/online/chan_map/ChanMapper.cc
@@ -1,0 +1,121 @@
+#include <iostream>
+#include <iomanip>
+#include <sstream>
+#include <cstdlib>
+#include <fstream>
+#include "DbSvc.h"
+#include "ChanMapperRange.h"
+#include "ChanMapper.h"
+using namespace std;
+
+ChanMapper::ChanMapper()
+{
+  m_dir_base = "/data2/analysis/kenichi/e1039/chan_map";
+  m_label    = "base";
+  m_map_id   = "";
+  m_header   = "";
+}
+
+std::string ChanMapper::RangeFileName()
+{
+  ostringstream oss;
+  oss << m_dir_base << "/" << m_label << "/run_range.tsv";
+  return oss.str();
+}
+
+std::string ChanMapper::SchemaName()
+{
+  string ret = "user_e1039_chan_map_";
+  ret += m_label;
+  return ret;
+}
+
+std::string ChanMapper::TableName()
+{
+  string ret = "chan_map_";
+  ret += m_map_id;
+  return ret;
+}
+
+void ChanMapper::ReadFromFile(const int run)
+{
+  ostringstream oss;
+  oss << m_dir_base << "/" << m_label << "/run_range.tsv";
+  ChanMapperRange range;
+  range.ReadFromFile(oss.str().c_str());
+
+  m_map_id = range.Find(run);
+  oss.str("");
+  oss << m_dir_base << "/" << m_label << "/" << m_map_id << "/chan_map.tsv";
+  ReadFromFile(oss.str());
+}
+
+void ChanMapper::ReadFromDB(const int run)
+{
+  ChanMapperRange range;
+  range.ReadFromDB(SchemaName());
+  m_map_id = range.Find(run);
+  ReadFromDB();
+}
+
+void ChanMapper::ReadFromFile(const string fn_tsv)
+{
+  ;
+}
+
+void ChanMapper::WriteToFile(const string fn_tsv)
+{
+  ;
+}
+
+void ChanMapper::ReadFromDB()
+{
+  if (m_map_id.length() == 0) {
+    cerr << "  ERROR:  The map ID is not set.  Abort." << endl;
+    exit(1);
+  }
+  string name_schema = SchemaName();
+  string name_table  =  TableName();
+  cout <<   "  Schema = " << name_schema
+       << "\n  Table  = " << name_table << "\n";
+
+  DbSvc db(DbSvc::DB1);
+  db.UseSchema(name_schema);
+  db.AssureTable(name_table);
+  ReadDbTable(db);
+}
+
+void ChanMapper::WriteToDB()
+{
+  cout << "ChanMapper::WriteToDB()\n";
+  if (m_map_id.length() == 0) {
+    cerr << "  ERROR:  The map ID is not set.  Abort." << endl;
+    exit(1);
+  }
+  string name_schema = SchemaName();
+  string name_table  =  TableName();
+  cout <<   "  Schema = " << name_schema
+       << "\n  Table  = " << name_table << "\n";
+
+  DbSvc db(DbSvc::DB1);
+  db.UseSchema(name_schema, true);
+  db.DropTable(name_table);
+  WriteDbTable(db);
+  cout <<   "  ...done." << endl;
+}
+
+void ChanMapper::Print(std::ostream& os)
+{
+  cout << "  virtual function called." << endl;
+}
+
+void ChanMapper::ReadDbTable(DbSvc& db)
+{
+  cout << "  virtual function called." << endl;
+}
+
+void ChanMapper::WriteDbTable(DbSvc& db)
+{
+  cout << "  virtual function called." << endl;
+}
+

--- a/online/chan_map/ChanMapper.cc
+++ b/online/chan_map/ChanMapper.cc
@@ -104,8 +104,10 @@ void ChanMapper::ReadFromDB()
   }
   string name_schema =   SchemaName();
   string name_table  = MapTableName();
-  cout <<   "  Schema = " << name_schema
-       << "\n  Table  = " << name_table << "\n";
+  cout << "Read channel map from "
+       << name_schema << "." << name_table << ".\n";
+  //cout <<   "  Schema = " << name_schema
+  //     << "\n  Table  = " << name_table << "\n";
 
   DbSvc db(DbSvc::DB1);
   db.UseSchema(name_schema);

--- a/online/chan_map/ChanMapper.cc
+++ b/online/chan_map/ChanMapper.cc
@@ -3,7 +3,7 @@
 #include <sstream>
 #include <cstdlib>
 #include <fstream>
-#include "DbSvc.h"
+#include <db_svc/DbSvc.h>
 #include "ChanMapper.h"
 using namespace std;
 

--- a/online/chan_map/ChanMapper.h
+++ b/online/chan_map/ChanMapper.h
@@ -5,6 +5,7 @@
 #include <vector>
 #include <map>
 #include <string>
+#include "ChanMapperRange.h"
 class DbSvc;
 
 class ChanMapper {
@@ -13,29 +14,38 @@ class ChanMapper {
   std::string m_label;
   std::string m_map_id;
   std::string m_header;
+  ChanMapperRange m_range;
 
  public:
   ChanMapper();
-  virtual ~ChanMapper() {;}
+  virtual ~ChanMapper();
 
   std::string GetMapID() { return m_map_id; }
   void        SetMapID(const std::string map_id) { m_map_id = map_id; }
+  void SetMapIDbyFile(const int run);
+  void SetMapIDbyDB  (const int run);
+
   std::string RangeFileName();
+  std::string MapFileName();
   std::string SchemaName();
-  std::string TableName();
+  std::string MapTableName();
 
-  void ReadFromFile(const int run);
-  void ReadFromDB  (const int run);
-
-  virtual void ReadFromFile(const std::string fn_tsv);
-  virtual void WriteToFile (const std::string fn_tsv);
+  void ReadFromFile();
+  void  WriteToFile();
+  void ReadFromLocalFile(const std::string fn_tsv);
+  void  WriteToLocalFile(const std::string fn_tsv);
 
   void ReadFromDB();
   void WriteToDB ();
+  void WriteRangeToDB();
 
   virtual void Print(std::ostream& os);
 
  protected:
+  typedef std::vector<std::string> LineList;
+  virtual int  ReadFileCont(LineList& lines) {;}
+  virtual int WriteFileCont(std::ostream& os) {;}
+
   virtual void  ReadDbTable(DbSvc& db);
   virtual void WriteDbTable(DbSvc& db);
 };

--- a/online/chan_map/ChanMapper.h
+++ b/online/chan_map/ChanMapper.h
@@ -4,11 +4,14 @@
 #include <map>
 #include <vector>
 #include <string>
+#include <tuple>
 #include "ChanMapperRange.h"
 class DbSvc;
 
 class ChanMapper {
  protected:
+  typedef std::tuple<short, short, short> RocBoardChan_t;
+
   std::string m_dir_base;
   std::string m_label;
   std::string m_map_id;

--- a/online/chan_map/ChanMapper.h
+++ b/online/chan_map/ChanMapper.h
@@ -1,9 +1,8 @@
 #ifndef __CHAN_MAPPER_H__
 #define __CHAN_MAPPER_H__
-#include <cstdlib>
 #include <iostream>
-#include <vector>
 #include <map>
+#include <vector>
 #include <string>
 #include "ChanMapperRange.h"
 class DbSvc;
@@ -22,13 +21,10 @@ class ChanMapper {
 
   std::string GetMapID() { return m_map_id; }
   void        SetMapID(const std::string map_id) { m_map_id = map_id; }
+  void SetMapIDbyFile(const std::string map_id);
+  void SetMapIDbyDB  (const std::string map_id);
   void SetMapIDbyFile(const int run);
   void SetMapIDbyDB  (const int run);
-
-  std::string RangeFileName();
-  std::string MapFileName();
-  std::string SchemaName();
-  std::string MapTableName();
 
   void ReadFromFile();
   void  WriteToFile();
@@ -42,9 +38,14 @@ class ChanMapper {
   virtual void Print(std::ostream& os);
 
  protected:
+  std::string RangeFileName();
+  std::string MapFileName();
+  std::string SchemaName();
+  std::string MapTableName();
+
   typedef std::vector<std::string> LineList;
-  virtual int  ReadFileCont(LineList& lines) {;}
-  virtual int WriteFileCont(std::ostream& os) {;}
+  virtual int  ReadFileCont(LineList& lines);
+  virtual int WriteFileCont(std::ostream& os);
 
   virtual void  ReadDbTable(DbSvc& db);
   virtual void WriteDbTable(DbSvc& db);

--- a/online/chan_map/ChanMapper.h
+++ b/online/chan_map/ChanMapper.h
@@ -1,0 +1,43 @@
+#ifndef __CHAN_MAPPER_H__
+#define __CHAN_MAPPER_H__
+#include <cstdlib>
+#include <iostream>
+#include <vector>
+#include <map>
+#include <string>
+class DbSvc;
+
+class ChanMapper {
+ protected:
+  std::string m_dir_base;
+  std::string m_label;
+  std::string m_map_id;
+  std::string m_header;
+
+ public:
+  ChanMapper();
+  virtual ~ChanMapper() {;}
+
+  std::string GetMapID() { return m_map_id; }
+  void        SetMapID(const std::string map_id) { m_map_id = map_id; }
+  std::string RangeFileName();
+  std::string SchemaName();
+  std::string TableName();
+
+  void ReadFromFile(const int run);
+  void ReadFromDB  (const int run);
+
+  virtual void ReadFromFile(const std::string fn_tsv);
+  virtual void WriteToFile (const std::string fn_tsv);
+
+  void ReadFromDB();
+  void WriteToDB ();
+
+  virtual void Print(std::ostream& os);
+
+ protected:
+  virtual void  ReadDbTable(DbSvc& db);
+  virtual void WriteDbTable(DbSvc& db);
+};
+
+#endif // __CHAN_MAPPER_H__

--- a/online/chan_map/ChanMapperRange.cc
+++ b/online/chan_map/ChanMapperRange.cc
@@ -1,0 +1,104 @@
+#include <iostream>
+#include <iomanip>
+#include <sstream>
+#include <cstdlib>
+#include <fstream>
+#include "DbSvc.h"
+#include "ChanMapperRange.h"
+using namespace std;
+
+void ChanMapperRange::Add(const int run_b, const int run_e, const std::string map_id)
+{
+  RangeItem item;
+  item.run_b  = run_b ;
+  item.run_e  = run_e ;
+  item.map_id = map_id;
+  m_list.push_back(item);
+}
+
+std::string ChanMapperRange::Find(const int run, const bool exit_on_error)
+{
+  for (RangeList::iterator it = m_list.begin(); it != m_list.end(); it++) {
+    if (it->run_b <= run && run <= it->run_e) return it->map_id;
+  }
+  if (exit_on_error) {
+    cerr << "\n!!ERROR!!  ChanMapperRange::Find():  Cannot find a range for run=" << run << ".  Abort." << endl;
+    exit(1);
+  }
+  return "";
+}
+
+void ChanMapperRange::ReadFromFile(const std::string fn_tsv)
+{
+  cout << "  ChanMapperRange::ReadFromFile(): " << fn_tsv << "...\n";
+  ifstream ifs(fn_tsv);
+  if (! ifs) {
+    cerr << "\n!!ERROR!!  Cannot open the map file '" << fn_tsv << "'." << endl;
+    exit(1);
+  } 
+  m_list.clear();
+
+  string buffer;
+  istringstream iss;
+  while ( getline(ifs, buffer) ) {
+    if (buffer[0] == '#') continue;
+    iss.clear(); // clear any error flags
+    iss.str(buffer);
+
+    int  run_b, run_e;
+    string map_id;
+    if (! (iss >> run_b >> run_e >> map_id)) continue;
+    cout << "    " << run_b << " " << run_e << " " << map_id << endl;
+    Add(run_b, run_e, map_id);
+  }
+  ifs.close();
+}
+
+void ChanMapperRange::ReadFromDB(const std::string schema)
+{
+  m_list.clear();
+  DbSvc db(DbSvc::DB1);
+  db.UseSchema(schema);
+  db.AssureTable("run_range");
+  TSQLStatement* stmt = db.Process("select run_b, run_e, map_id from run_range");
+  while (stmt->NextResultRow()) {
+    int    run_b  = stmt->GetInt   (0);
+    int    run_e  = stmt->GetInt   (1);
+    string map_id = stmt->GetString(2);
+    Add(run_b, run_e, map_id);
+  }
+  delete stmt;
+}
+
+void ChanMapperRange::WriteToDB(const std::string schema)
+{
+  cout << "ChanMapperRange::WriteToDB()\n";
+  cout <<   "  Schema = " << schema << "\n";
+
+  DbSvc db(DbSvc::DB1);
+  db.UseSchema(schema, true);
+  db.DropTable("run_range");
+
+  const char* query_create = "create table run_range ("
+    "  run_b  INT, "
+    "  run_e  INT, "
+    "  map_id VARCHAR(64) )";
+  if (! db.Con()->Exec(query_create)) {
+    cerr << "  ERROR in create.  Abort." << endl;
+    exit(1);
+  }
+
+  ostringstream oss;
+  oss << "insert into run_range (run_b, run_e, map_id) values";
+  for (RangeList::iterator it = m_list.begin(); it != m_list.end(); it++) {
+    oss << " (" << it->run_b << ", " << it->run_e << ", '" << it->map_id << "'),";
+  }
+  string query = oss.str();
+  query.erase(query.length()-1, 1); // Remove the last ',' char.
+  if (! db.Con()->Exec(query.c_str())) {
+    cerr << "  ERROR in insert.  Abort." << endl;
+    exit(1);
+  }
+
+  cout <<   "  ...done." << endl;
+}

--- a/online/chan_map/ChanMapperRange.cc
+++ b/online/chan_map/ChanMapperRange.cc
@@ -5,7 +5,7 @@
 #include <fstream>
 #include <TSQLServer.h>
 #include <TSQLStatement.h>
-#include "DbSvc.h"
+#include <db_svc/DbSvc.h>
 #include "ChanMapperRange.h"
 using namespace std;
 

--- a/online/chan_map/ChanMapperRange.h
+++ b/online/chan_map/ChanMapperRange.h
@@ -1,0 +1,30 @@
+#ifndef __CHAN_MAPPER_RANGE_H__
+#define __CHAN_MAPPER_RANGE_H__
+#include <cstdlib>
+#include <iostream>
+#include <vector>
+#include <map>
+#include <tuple>
+#include <string>
+
+class ChanMapperRange {
+  struct RangeItem {
+    int run_b;
+    int run_e;
+    std::string map_id;
+  };
+  typedef std::vector<RangeItem> RangeList;
+  RangeList m_list;
+
+ public:
+  ChanMapperRange() {;}
+  ~ChanMapperRange() {;}
+  void Add(const int run_b, const int run_e, const std::string map_id);
+  std::string Find(const int run, const bool exit_on_error=true);
+
+  void ReadFromFile(const std::string fn_tsv);
+  void ReadFromDB  (const std::string schema);
+  void WriteToDB   (const std::string schema);
+};
+
+#endif // __CHAN_MAPPER_RANGE_H__

--- a/online/chan_map/ChanMapperRange.h
+++ b/online/chan_map/ChanMapperRange.h
@@ -1,10 +1,7 @@
 #ifndef __CHAN_MAPPER_RANGE_H__
 #define __CHAN_MAPPER_RANGE_H__
-#include <cstdlib>
 #include <iostream>
 #include <vector>
-#include <map>
-#include <tuple>
 #include <string>
 
 class ChanMapperRange {
@@ -20,6 +17,7 @@ class ChanMapperRange {
   ChanMapperRange() {;}
   ~ChanMapperRange() {;}
   void Add(const int run_b, const int run_e, const std::string map_id);
+  bool Find(const std::string map_id);
   std::string Find(const int run, const bool exit_on_error=true);
 
   void ReadFromFile(const std::string fn_tsv);

--- a/online/chan_map/ChanMapperScaler.cc
+++ b/online/chan_map/ChanMapperScaler.cc
@@ -1,0 +1,113 @@
+#include <iostream>
+#include <iomanip>
+#include <sstream>
+#include <cstdlib>
+#include <fstream>
+#include <TSQLServer.h>
+#include <TSQLStatement.h>
+#include "DbSvc.h"
+#include "ChanMapperScaler.h"
+using namespace std;
+
+ChanMapperScaler::ChanMapperScaler()
+{
+  m_label = "scaler";
+  m_header = "name\troc\tboard\tchan";
+}
+
+int ChanMapperScaler::ReadFileCont(LineList& lines)
+{
+  istringstream iss;
+  int nn = 0;
+  for (LineList::iterator it = lines.begin(); it != lines.end(); it++) {
+    iss.clear(); // clear any error flags
+    iss.str(*it);
+    string name;
+    short  roc, board, chan;
+    if (! (iss >> name >> roc >> board >> chan)) continue;
+    Add(roc, board, chan, name);
+    nn++;
+  }
+  return nn;
+}
+
+int ChanMapperScaler::WriteFileCont(std::ostream& os)
+{
+  int nn = 0;
+  for (Map_t::iterator it = m_map.begin(); it != m_map.end(); it++) {
+    RocBoardChan_t key = it->first;
+    string         val = it->second;
+    os << val << "\t"
+       << std::get<0>(key) << "\t" << std::get<1>(key) << "\t" << std::get<2>(key) << "\n";
+    nn++;
+  }
+  return nn;
+}
+
+void ChanMapperScaler::ReadDbTable(DbSvc& db)
+{
+  ostringstream oss;
+  oss << "select roc, board, chan, name from " << MapTableName();
+  TSQLStatement* stmt = db.Process(oss.str());
+  while (stmt->NextResultRow()) {
+    short  roc   = stmt->GetInt   (0);
+    short  board = stmt->GetInt   (1);
+    short  chan  = stmt->GetInt   (2);
+    string name  = stmt->GetString(3);
+    Add(roc, board, chan, name);
+  }
+  delete stmt;
+}
+
+void ChanMapperScaler::WriteDbTable(DbSvc& db)
+{
+  string name_table = MapTableName();
+
+  const char* list_var [] = {      "roc",    "board",     "chan",        "name" };
+  const char* list_type[] = { "SMALLINT", "SMALLINT", "SMALLINT", "VARCHAR(64)" };
+  db.CreateTable(name_table, 4, list_var, list_type);
+
+  ostringstream oss;
+  oss << "insert into " << name_table << "(roc, board, chan, name) values";
+  for (Map_t::iterator it = m_map.begin(); it != m_map.end(); it++) {
+    RocBoardChan_t key = it->first;
+    string         val = it->second;
+    oss << " (" << std::get<0>(key) << ", " << std::get<1>(key) << ", " << std::get<2>(key) 
+        << ", '" << val << "'),";
+  }
+  string query = oss.str();
+  query.erase(query.length()-1, 1); // Remove the last ',' char.
+  if (! db.Con()->Exec(query.c_str())) {
+    cerr << "!!ERROR!!  ChanMapperScaler::WriteToDB():  in insert.  Abort." << endl;
+    exit(1);
+  }
+}
+
+void ChanMapperScaler::Add(const short roc, const short board, const short chan, const std::string name)
+{
+  m_map[RocBoardChan_t(roc, board, chan)] = name;
+}
+
+bool ChanMapperScaler::Find(const short roc, const short board, const short chan,  std::string& name)
+{
+  RocBoardChan_t key(roc, board, chan);
+  if (m_map.find(key) != m_map.end()) {
+    name = m_map[key];
+    return true;
+  }
+  name = "";
+  return false;
+}  
+
+void ChanMapperScaler::Print(std::ostream& os)
+{
+  int n_ent = 0;
+  for (Map_t::iterator it = m_map.begin(); it != m_map.end(); it++) {
+    RocBoardChan_t key = it->first;
+    string         val = it->second;
+    os << val << "\t"
+       << std::get<0>(key) << "\t" << std::get<1>(key) << "\t" << std::get<2>(key) << "\n";
+    n_ent++;
+  }
+  cout << n_ent << endl;
+}

--- a/online/chan_map/ChanMapperScaler.cc
+++ b/online/chan_map/ChanMapperScaler.cc
@@ -34,11 +34,9 @@ int ChanMapperScaler::ReadFileCont(LineList& lines)
 int ChanMapperScaler::WriteFileCont(std::ostream& os)
 {
   int nn = 0;
-  for (Map_t::iterator it = m_map.begin(); it != m_map.end(); it++) {
-    RocBoardChan_t key = it->first;
-    string         val = it->second;
-    os << val << "\t"
-       << std::get<0>(key) << "\t" << std::get<1>(key) << "\t" << std::get<2>(key) << "\n";
+  for (List_t::iterator it = m_list.begin(); it != m_list.end(); it++) {
+    os << it->name 
+       << it->roc << "\t" << it->board << "\t" << it->chan << "\n";
     nn++;
   }
   return nn;
@@ -65,15 +63,14 @@ void ChanMapperScaler::WriteDbTable(DbSvc& db)
 
   const char* list_var [] = {      "roc",    "board",     "chan",        "name" };
   const char* list_type[] = { "SMALLINT", "SMALLINT", "SMALLINT", "VARCHAR(64)" };
-  db.CreateTable(name_table, 4, list_var, list_type);
+  const int   n_var       = 4;
+  db.CreateTable(name_table, n_var, list_var, list_type);
 
   ostringstream oss;
   oss << "insert into " << name_table << "(roc, board, chan, name) values";
-  for (Map_t::iterator it = m_map.begin(); it != m_map.end(); it++) {
-    RocBoardChan_t key = it->first;
-    string         val = it->second;
-    oss << " (" << std::get<0>(key) << ", " << std::get<1>(key) << ", " << std::get<2>(key) 
-        << ", '" << val << "'),";
+  for (List_t::iterator it = m_list.begin(); it != m_list.end(); it++) {
+    oss << " (" << it->roc << ", " << it->board << ", " << it->chan
+        << ", '" << it->name << "'),";
   }
   string query = oss.str();
   query.erase(query.length()-1, 1); // Remove the last ',' char.
@@ -85,6 +82,12 @@ void ChanMapperScaler::WriteDbTable(DbSvc& db)
 
 void ChanMapperScaler::Add(const short roc, const short board, const short chan, const std::string name)
 {
+  MapItem item;
+  item.roc   = roc;
+  item.board = board;
+  item.chan  = chan;
+  item.name  = name;
+  m_list.push_back(item);
   m_map[RocBoardChan_t(roc, board, chan)] = name;
 }
 
@@ -102,11 +105,9 @@ bool ChanMapperScaler::Find(const short roc, const short board, const short chan
 void ChanMapperScaler::Print(std::ostream& os)
 {
   int n_ent = 0;
-  for (Map_t::iterator it = m_map.begin(); it != m_map.end(); it++) {
-    RocBoardChan_t key = it->first;
-    string         val = it->second;
-    os << val << "\t"
-       << std::get<0>(key) << "\t" << std::get<1>(key) << "\t" << std::get<2>(key) << "\n";
+  for (List_t::iterator it = m_list.begin(); it != m_list.end(); it++) {
+    os << it->name << "\t" 
+       << it->roc << "\t" << it->board << "\t" << it->chan << "\n";
     n_ent++;
   }
   cout << n_ent << endl;

--- a/online/chan_map/ChanMapperScaler.cc
+++ b/online/chan_map/ChanMapperScaler.cc
@@ -5,7 +5,7 @@
 #include <fstream>
 #include <TSQLServer.h>
 #include <TSQLStatement.h>
-#include "DbSvc.h"
+#include <db_svc/DbSvc.h>
 #include "ChanMapperScaler.h"
 using namespace std;
 

--- a/online/chan_map/ChanMapperScaler.h
+++ b/online/chan_map/ChanMapperScaler.h
@@ -1,0 +1,27 @@
+#ifndef __CHAN_MAPPER_SCALER_H__
+#define __CHAN_MAPPER_SCALER_H__
+#include <tuple>
+#include "ChanMapper.h"
+
+class ChanMapperScaler : public ChanMapper {
+  typedef std::tuple<short, short, short> RocBoardChan_t;
+  typedef std::map<RocBoardChan_t, std::string> Map_t;
+  Map_t m_map;
+
+ public:
+  ChanMapperScaler();
+  virtual ~ChanMapperScaler() {;}
+
+  void Add (const short roc, const short board, const short chan, const std::string name);
+  bool Find(const short roc, const short board, const short chan,  std::string& name);
+  void Print(std::ostream& os);
+
+ protected:
+  int  ReadFileCont(LineList& lines);
+  int WriteFileCont(std::ostream& os);
+
+  void  ReadDbTable(DbSvc& db);
+  void WriteDbTable(DbSvc& db);
+};
+
+#endif // __CHAN_MAPPER_SCALER_H__

--- a/online/chan_map/ChanMapperScaler.h
+++ b/online/chan_map/ChanMapperScaler.h
@@ -1,12 +1,19 @@
 #ifndef __CHAN_MAPPER_SCALER_H__
 #define __CHAN_MAPPER_SCALER_H__
-#include <tuple>
 #include "ChanMapper.h"
 
 class ChanMapperScaler : public ChanMapper {
-  typedef std::tuple<short, short, short> RocBoardChan_t;
+  struct MapItem {
+    short roc;
+    short board;
+    short chan;
+    std::string name;
+  };
+  typedef std::vector<MapItem> List_t;
+  List_t m_list; ///< Used to keep all information in the added order.
+
   typedef std::map<RocBoardChan_t, std::string> Map_t;
-  Map_t m_map;
+  Map_t m_map; ///< Used in Find() for better speed.
 
  public:
   ChanMapperScaler();

--- a/online/chan_map/ChanMapperTaiwan.cc
+++ b/online/chan_map/ChanMapperTaiwan.cc
@@ -6,7 +6,7 @@
 #include <TSQLServer.h>
 #include <TSQLStatement.h>
 #include <geom_svc/GeomSvc.h>
-#include "DbSvc.h"
+#include <db_svc/DbSvc.h>
 #include "ChanMapperTaiwan.h"
 using namespace std;
 

--- a/online/chan_map/ChanMapperTaiwan.cc
+++ b/online/chan_map/ChanMapperTaiwan.cc
@@ -3,6 +3,8 @@
 #include <sstream>
 #include <cstdlib>
 #include <fstream>
+#include <TSQLServer.h>
+#include <TSQLStatement.h>
 #include "DbSvc.h"
 #include "ChanMapperTaiwan.h"
 using namespace std;
@@ -62,19 +64,12 @@ void ChanMapperTaiwan::ReadDbTable(DbSvc& db)
 void ChanMapperTaiwan::WriteDbTable(DbSvc& db)
 {
   string name_table = MapTableName();
-  ostringstream oss;
-  oss << "create table " << name_table << "("
-    "  roc   SMALLINT, "
-    "  board SMALLINT, "
-    "  chan  SMALLINT, "
-    "  det   VARCHAR(8), "
-    "  ele   SMALLINT )";
-  if (! db.Con()->Exec(oss.str().c_str())) {
-    cerr << "!!ERROR!!  ChanMapperTaiwan::WriteToDB():  in create.  Abort." << endl;
-    exit(1);
-  }
 
-  oss.str("");
+  const char* list_var [] = {      "roc",    "board",     "chan",        "det",      "ele" };
+  const char* list_type[] = { "SMALLINT", "SMALLINT", "SMALLINT", "VARCHAR(8)", "SMALLINT" };
+  db.CreateTable(name_table, 5, list_var, list_type);
+
+  ostringstream oss;
   oss << "insert into " << name_table << "(roc, board, chan, det, ele) values";
   for (Map_t::iterator it = m_map.begin(); it != m_map.end(); it++) {
     RocBoardChan_t key = it->first;

--- a/online/chan_map/ChanMapperTaiwan.cc
+++ b/online/chan_map/ChanMapperTaiwan.cc
@@ -1,0 +1,246 @@
+#include <iostream>
+#include <iomanip>
+#include <sstream>
+#include <cstdlib>
+#include <fstream>
+#include "DbSvc.h"
+#include "ChanMapperTaiwan.h"
+using namespace std;
+
+//ClassImp(ChanMapperTaiwan)
+
+ChanMapperTaiwan::ChanMapperTaiwan()
+{
+  m_label = "taiwan";
+  m_header = "det\tele\troc\tboard\tchan";
+  InitNameMap();
+}
+
+void ChanMapperTaiwan::ReadFromFile(const string fn_tsv)
+{
+  cout << "  ChanMapperTaiwan::ReadFile(): " << fn_tsv << "... ";
+  ifstream ifs(fn_tsv.c_str());
+  if (! ifs) {
+    cerr << "\n!!ERROR!!  Cannot open the map file '" << fn_tsv << "'." << endl;
+    exit(1);
+  } 
+
+  string buffer;
+  istringstream iss;
+  //getline(ifs, buffer); // discard the 1st line
+  unsigned int nn = 0;
+  while ( getline(ifs, buffer) ) {
+    if (buffer[0] == '#') continue;
+    iss.clear(); // clear any error flags
+    iss.str(buffer);
+    string det;
+    short  ele, roc, board, chan;
+    if (! (iss >> det >> ele >> roc >> board >> chan)) continue;
+    Add(roc, board, chan, det, ele);
+    nn++;
+  }
+  ifs.close();
+  cout << nn << " read in." << endl;
+}
+
+void ChanMapperTaiwan::WriteToFile(const string fn_tsv)
+{
+  cout << "  ChanMapper::WriteFile(): " << fn_tsv << "... ";
+  ofstream ofs(fn_tsv.c_str());
+  if (! ofs) {
+    cerr << "\n!!ERROR!!  Cannot open the map file '" << fn_tsv << "'." << endl;
+    exit(1);
+  } 
+  ofs << "#" << m_header << "\n";
+  for (Map_t::iterator it = m_map.begin(); it != m_map.end(); it++) {
+    RocBoardChan_t key = it->first;
+    DetEle_t       val = it->second;
+    ofs << val.first << "\t" << val.second << "\t"
+        << std::get<0>(key) << "\t" << std::get<1>(key) << "\t" << std::get<2>(key) << "\n";
+  }
+  ofs.close();
+}
+
+void ChanMapperTaiwan::ReadDbTable(DbSvc& db)
+{
+  ostringstream oss;
+  oss << "select roc, board, chan, det, ele from " << TableName();
+  TSQLStatement* stmt = db.Process(oss.str());
+  while (stmt->NextResultRow()) {
+    short  roc   = stmt->GetInt   (0);
+    short  board = stmt->GetInt   (1);
+    short  chan  = stmt->GetInt   (2);
+    string det   = stmt->GetString(3);
+    short  ele   = stmt->GetInt   (4);
+    Add(roc, board, chan, det, ele);
+  }
+  delete stmt;
+}
+
+void ChanMapperTaiwan::WriteDbTable(DbSvc& db)
+{
+  string name_table = TableName();
+  ostringstream oss;
+  oss << "create table " << name_table << "("
+    "  roc   SMALLINT, "
+    "  board SMALLINT, "
+    "  chan  SMALLINT, "
+    "  det   VARCHAR(8), "
+    "  ele   SMALLINT )";
+  if (! db.Con()->Exec(oss.str().c_str())) {
+    cerr << "!!ERROR!!  ChanMapperTaiwan::WriteToDB():  in create.  Abort." << endl;
+    exit(1);
+  }
+
+  oss.str("");
+  oss << "insert into " << name_table << "(roc, board, chan, det, ele) values";
+  for (Map_t::iterator it = m_map.begin(); it != m_map.end(); it++) {
+    RocBoardChan_t key = it->first;
+    DetEle_t       val = it->second;
+    oss << " (" << std::get<0>(key) << ", " << std::get<1>(key) << ", " << std::get<2>(key) 
+        << ", '" << val.first << "', " << val.second << "),";
+  }
+  string query = oss.str();
+  query.erase(query.length()-1, 1); // Remove the last ',' char.
+  if (! db.Con()->Exec(query.c_str())) {
+    cerr << "!!ERROR!!  ChanMapperTaiwan::WriteToDB():  in insert.  Abort." << endl;
+    exit(1);
+  }
+}
+
+void ChanMapperTaiwan::Add(const short roc, const short board, const short chan, const std::string det, const short ele)
+{
+  m_map[RocBoardChan_t(roc, board, chan)] = DetEle_t(det, ele);
+}
+
+bool ChanMapperTaiwan::Find(const short roc, const short board, const short chan,  std::string& det, short& ele)
+{
+  RocBoardChan_t key(roc, board, chan);
+  if (m_map.find(key) != m_map.end()) {
+    DetEle_t* det_ele = &m_map[key];
+    det = det_ele->first;
+    ele = det_ele->second;
+    return true;
+  }
+  det = "";
+  ele = 0;
+  return false;
+}  
+
+bool ChanMapperTaiwan::Find(const short roc, const short board, const short chan,  short& det, short& ele)
+{
+  string det_str;
+  if (! Find(roc, board, chan, det_str, ele)) return false;
+  if (m_map_name2id.find(det_str) != m_map_name2id.end()) {
+    det = m_map_name2id[det_str];
+    return true;
+  }
+  det = ele = 0;
+  return false;
+}
+
+
+void ChanMapperTaiwan::Print(std::ostream& os)
+{
+  int n_ent = 0;
+  for (Map_t::iterator it = m_map.begin(); it != m_map.end(); it++) {
+    RocBoardChan_t key = it->first;
+    DetEle_t       val = it->second;
+    os << val.first << "\t" << val.second << "\t"
+       << std::get<0>(key) << "\t" << std::get<1>(key) << "\t" << std::get<2>(key) << "\n";
+    n_ent++;
+  }
+  cout << n_ent << endl;
+}
+
+void ChanMapperTaiwan::InitNameMap()
+{
+  m_map_name2id["D0U"  ] =   1;
+  m_map_name2id["D0Up" ] =   2;
+  m_map_name2id["D0X"  ] =   3;
+  m_map_name2id["D0Xp" ] =   4;
+  m_map_name2id["D0V"  ] =   5;
+  m_map_name2id["D0Vp" ] =   6;
+  m_map_name2id["D1U"  ] =   1+6;
+  m_map_name2id["D1Up" ] =   2+6;
+  m_map_name2id["D1X"  ] =   3+6;
+  m_map_name2id["D1Xp" ] =   4+6;
+  m_map_name2id["D1V"  ] =   5+6;
+  m_map_name2id["D1Vp" ] =   6+6;
+  m_map_name2id["D2V"  ] =   7+6;
+  m_map_name2id["D2Vp" ] =   8+6;
+  m_map_name2id["D2Xp" ] =   9+6;
+  m_map_name2id["D2X"  ] =  10+6;
+  m_map_name2id["D2U"  ] =  11+6;
+  m_map_name2id["D2Up" ] =  12+6;
+  m_map_name2id["D3pVp"] =  13+6;
+  m_map_name2id["D3pV" ] =  14+6;
+  m_map_name2id["D3pXp"] =  15+6;
+  m_map_name2id["D3pX" ] =  16+6;
+  m_map_name2id["D3pUp"] =  17+6;
+  m_map_name2id["D3pU" ] =  18+6;
+  m_map_name2id["D3mVp"] =  19+6;
+  m_map_name2id["D3mV" ] =  20+6;
+  m_map_name2id["D3mXp"] =  21+6;
+  m_map_name2id["D3mX" ] =  22+6;
+  m_map_name2id["D3mUp"] =  23+6;
+  m_map_name2id["D3mU" ] =  24+6;
+  m_map_name2id["H1B"  ] =  25+6;
+  m_map_name2id["H1T"  ] =  26+6;
+  m_map_name2id["H1L"  ] =  27+6;
+  m_map_name2id["H1R"  ] =  28+6;
+  m_map_name2id["H2L"  ] =  29+6;
+  m_map_name2id["H2R"  ] =  30+6;
+  m_map_name2id["H2B"  ] =  31+6;
+  m_map_name2id["H2T"  ] =  32+6;
+  m_map_name2id["H3B"  ] =  33+6;
+  m_map_name2id["H3T"  ] =  34+6;
+  m_map_name2id["H4Y1L"] =  35+6;
+  m_map_name2id["H4Y1R"] =  36+6;
+  m_map_name2id["H4Y2L"] =  37+6;
+  m_map_name2id["H4Y2R"] =  38+6;
+  m_map_name2id["H4B"  ] =  39+6;
+  m_map_name2id["H4T"  ] =  40+6;
+  m_map_name2id["P1Hf" ] =  41+6;
+  m_map_name2id["P1Hb" ] =  42+6;
+  m_map_name2id["P1Vf" ] =  43+6;
+  m_map_name2id["P1Vb" ] =  44+6;
+  m_map_name2id["P2Vf" ] =  45+6;
+  m_map_name2id["P2Vb" ] =  46+6;
+  m_map_name2id["P2Hf" ] =  47+6;
+  m_map_name2id["P2Hb" ] =  48+6;
+
+  m_map_name2id["H4Bu"  ] = 39+6;
+  m_map_name2id["H4Bd"  ] = 39+6;
+  m_map_name2id["H4Tu"  ] = 40+6;
+  m_map_name2id["H4Td"  ] = 40+6;
+  m_map_name2id["H4Y1Ll"] = 35+6;
+  m_map_name2id["H4Y1Lr"] = 35+6;
+  m_map_name2id["H4Y1Rl"] = 36+6;
+  m_map_name2id["H4Y1Rr"] = 36+6;
+  m_map_name2id["H4Y2Ll"] = 37+6;
+  m_map_name2id["H4Y2Lr"] = 37+6;
+  m_map_name2id["H4Y2Rl"] = 38+6;
+  m_map_name2id["H4Y2Rr"] = 38+6;
+
+  for (int ipl = 1; ipl <= 9; ipl++) {
+    char tmpName[8][10];
+    sprintf(tmpName[0], "P1H%df", ipl);
+    sprintf(tmpName[1], "P1H%db", ipl);
+    sprintf(tmpName[2], "P1V%df", ipl);
+    sprintf(tmpName[3], "P1V%db", ipl);
+    sprintf(tmpName[4], "P2V%df", ipl);
+    sprintf(tmpName[5], "P2V%db", ipl);
+    sprintf(tmpName[6], "P2H%df", ipl);
+    sprintf(tmpName[7], "P2H%db", ipl);
+    
+    m_map_name2id[tmpName[0]] = 41+6;
+    m_map_name2id[tmpName[1]] = 42+6;
+    m_map_name2id[tmpName[2]] = 43+6;
+    m_map_name2id[tmpName[3]] = 44+6;
+    m_map_name2id[tmpName[4]] = 45+6;
+    m_map_name2id[tmpName[5]] = 46+6;
+    m_map_name2id[tmpName[6]] = 47+6;
+    m_map_name2id[tmpName[7]] = 48+6;
+  }
+}

--- a/online/chan_map/ChanMapperTaiwan.h
+++ b/online/chan_map/ChanMapperTaiwan.h
@@ -17,21 +17,19 @@ class ChanMapperTaiwan : public ChanMapper {
   using ChanMapper::ReadFromFile;
   using ChanMapper::ReadFromDB;
 
-  void ReadFromFile(const std::string fn_tsv);
-  void WriteToFile (const std::string fn_tsv);
-
   void Add (const short roc, const short board, const short chan, const std::string det, const short ele);
   bool Find(const short roc, const short board, const short chan,  std::string& det, short& ele);
   bool Find(const short roc, const short board, const short chan,        short& det, short& ele);
   void Print(std::ostream& os);
 
- private:
+ protected:
+  int  ReadFileCont(LineList& lines);
+  int WriteFileCont(std::ostream& os);
+
   void  ReadDbTable(DbSvc& db);
   void WriteDbTable(DbSvc& db);
 
   void InitNameMap();
-
-  //ClassDef(ChanMapperTaiwan, 1);
 };
 
 #endif // __CHAN_MAPPER_TAIWAN_H__

--- a/online/chan_map/ChanMapperTaiwan.h
+++ b/online/chan_map/ChanMapperTaiwan.h
@@ -14,9 +14,6 @@ class ChanMapperTaiwan : public ChanMapper {
   ChanMapperTaiwan();
   virtual ~ChanMapperTaiwan() {;}
 
-  using ChanMapper::ReadFromFile;
-  using ChanMapper::ReadFromDB;
-
   void Add (const short roc, const short board, const short chan, const std::string det, const short ele);
   bool Find(const short roc, const short board, const short chan,  std::string& det, short& ele);
   bool Find(const short roc, const short board, const short chan,        short& det, short& ele);

--- a/online/chan_map/ChanMapperTaiwan.h
+++ b/online/chan_map/ChanMapperTaiwan.h
@@ -1,0 +1,37 @@
+#ifndef __CHAN_MAPPER_TAIWAN_H__
+#define __CHAN_MAPPER_TAIWAN_H__
+#include <tuple>
+#include "ChanMapper.h"
+
+class ChanMapperTaiwan : public ChanMapper {
+  typedef std::tuple<short, short, short> RocBoardChan_t;
+  typedef std::pair<std::string, short> DetEle_t;
+  typedef std::map<RocBoardChan_t, DetEle_t> Map_t;
+  Map_t m_map;
+  std::map<std::string, short> m_map_name2id;
+
+ public:
+  ChanMapperTaiwan();
+  virtual ~ChanMapperTaiwan() {;}
+
+  using ChanMapper::ReadFromFile;
+  using ChanMapper::ReadFromDB;
+
+  void ReadFromFile(const std::string fn_tsv);
+  void WriteToFile (const std::string fn_tsv);
+
+  void Add (const short roc, const short board, const short chan, const std::string det, const short ele);
+  bool Find(const short roc, const short board, const short chan,  std::string& det, short& ele);
+  bool Find(const short roc, const short board, const short chan,        short& det, short& ele);
+  void Print(std::ostream& os);
+
+ private:
+  void  ReadDbTable(DbSvc& db);
+  void WriteDbTable(DbSvc& db);
+
+  void InitNameMap();
+
+  //ClassDef(ChanMapperTaiwan, 1);
+};
+
+#endif // __CHAN_MAPPER_TAIWAN_H__

--- a/online/chan_map/ChanMapperTaiwan.h
+++ b/online/chan_map/ChanMapperTaiwan.h
@@ -1,21 +1,33 @@
 #ifndef __CHAN_MAPPER_TAIWAN_H__
 #define __CHAN_MAPPER_TAIWAN_H__
-#include <tuple>
 #include "ChanMapper.h"
 
 class ChanMapperTaiwan : public ChanMapper {
-  typedef std::tuple<short, short, short> RocBoardChan_t;
-  typedef std::pair<std::string, short> DetEle_t;
+  struct MapItem {
+    short roc;
+    short board;
+    short chan;
+    std::string det_name;
+    short det;
+    short ele;
+  };
+  typedef std::vector<MapItem> List_t;
+  List_t m_list; ///< Used to keep all information in the added order.
+
+  typedef std::pair<short, short> DetEle_t;
   typedef std::map<RocBoardChan_t, DetEle_t> Map_t;
-  Map_t m_map;
+  Map_t m_map; ///< Used in Find() for better speed.
+
   std::map<std::string, short> m_map_name2id;
 
  public:
   ChanMapperTaiwan();
   virtual ~ChanMapperTaiwan() {;}
 
-  void Add (const short roc, const short board, const short chan, const std::string det, const short ele);
-  bool Find(const short roc, const short board, const short chan,  std::string& det, short& ele);
+  void Add(const short roc, const short board, const short chan, const std::string det, const short ele);
+  void Add(const short roc, const short board, const short chan, const std::string det_name, const short det_id, const short ele);
+
+  //bool Find(const short roc, const short board, const short chan,  std::string& det, short& ele);
   bool Find(const short roc, const short board, const short chan,        short& det, short& ele);
   void Print(std::ostream& os);
 

--- a/online/chan_map/ChanMapperV1495.cc
+++ b/online/chan_map/ChanMapperV1495.cc
@@ -1,0 +1,166 @@
+#include <iostream>
+#include <iomanip>
+#include <sstream>
+#include <cstdlib>
+#include <fstream>
+#include <TSQLServer.h>
+#include <TSQLStatement.h>
+#include "DbSvc.h"
+#include "ChanMapperV1495.h"
+using namespace std;
+
+ChanMapperV1495::ChanMapperV1495()
+{
+  m_label = "v1495";
+  m_header = "det\tele\tlvl\troc\tboard\tchan";
+  InitNameMap();
+}
+
+int ChanMapperV1495::ReadFileCont(LineList& lines)
+{
+  istringstream iss;
+  int nn = 0;
+  for (LineList::iterator it = lines.begin(); it != lines.end(); it++) {
+    iss.clear(); // clear any error flags
+    iss.str(*it);
+    string det;
+    short  ele, lvl, roc, board, chan;
+    if (! (iss >> det >> ele >> lvl >> roc >> board >> chan)) continue;
+    Add(roc, board, chan, det, ele, lvl);
+    nn++;
+  }
+  return nn;
+}
+
+int ChanMapperV1495::WriteFileCont(std::ostream& os)
+{
+  int nn = 0;
+  for (Map_t::iterator it = m_map.begin(); it != m_map.end(); it++) {
+    RocBoardChan_t key = it->first;
+    DetEleLvl_t    val = it->second;
+    os << std::get<0>(val) << "\t" << std::get<1>(val) << "\t" << std::get<2>(val) << "\t"
+       << std::get<0>(key) << "\t" << std::get<1>(key) << "\t" << std::get<2>(key) << "\n";
+    nn++;
+  }
+  return nn;
+}
+
+void ChanMapperV1495::ReadDbTable(DbSvc& db)
+{
+  ostringstream oss;
+  oss << "select roc, board, chan, det, ele, lvl from " << MapTableName();
+  TSQLStatement* stmt = db.Process(oss.str());
+  while (stmt->NextResultRow()) {
+    short  roc   = stmt->GetInt   (0);
+    short  board = stmt->GetInt   (1);
+    short  chan  = stmt->GetInt   (2);
+    string det   = stmt->GetString(3);
+    short  ele   = stmt->GetInt   (4);
+    short  lvl   = stmt->GetInt   (5);
+    Add(roc, board, chan, det, ele, lvl);
+  }
+  delete stmt;
+}
+
+void ChanMapperV1495::WriteDbTable(DbSvc& db)
+{
+  string name_table = MapTableName();
+
+  const char* list_var [] = {      "roc",    "board",     "chan",        "det",      "ele",      "lvl" };
+  const char* list_type[] = { "SMALLINT", "SMALLINT", "SMALLINT", "VARCHAR(8)", "SMALLINT", "SMALLINT" };
+  db.CreateTable(name_table, 6, list_var, list_type);
+
+  ostringstream oss;
+  oss << "insert into " << name_table << "(roc, board, chan, det, ele, lvl) values";
+  for (Map_t::iterator it = m_map.begin(); it != m_map.end(); it++) {
+    RocBoardChan_t key = it->first;
+    DetEleLvl_t    val = it->second;
+    oss << " ("  << std::get<0>(key) <<  ", " << std::get<1>(key) << ", " << std::get<2>(key) 
+        << ", '" << std::get<0>(val) << "', " << std::get<1>(val) << ", " << std::get<2>(val) 
+        << "),";
+  }
+  string query = oss.str();
+  query.erase(query.length()-1, 1); // Remove the last ',' char.
+  if (! db.Con()->Exec(query.c_str())) {
+    cerr << "!!ERROR!!  ChanMapperV1495::WriteToDB():  in insert.  Abort." << endl;
+    exit(1);
+  }
+}
+
+void ChanMapperV1495::Add(const short roc, const short board, const short chan, const std::string det, const short ele, const short lvl)
+{
+  m_map[RocBoardChan_t(roc, board, chan)] = DetEleLvl_t(det, ele, lvl);
+}
+
+bool ChanMapperV1495::Find(const short roc, const short board, const short chan,  std::string& det, short& ele, short& lvl)
+{
+  RocBoardChan_t key(roc, board, chan);
+  if (m_map.find(key) != m_map.end()) {
+    DetEleLvl_t val = m_map[key];
+    det = std::get<0>(val);
+    ele = std::get<1>(val);
+    lvl = std::get<2>(val);
+    return true;
+  }
+  det = "";
+  ele = lvl = 0;
+  return false;
+}  
+
+bool ChanMapperV1495::Find(const short roc, const short board, const short chan,  short& det, short& ele, short& lvl)
+{
+  string det_str;
+  if (! Find(roc, board, chan, det_str, ele, lvl)) return false;
+  if (m_map_name2id.find(det_str) != m_map_name2id.end()) {
+    det = m_map_name2id[det_str];
+    return true;
+  }
+  det = ele = lvl = 0;
+  return false;
+}
+
+void ChanMapperV1495::Print(std::ostream& os)
+{
+  int n_ent = 0;
+  for (Map_t::iterator it = m_map.begin(); it != m_map.end(); it++) {
+    RocBoardChan_t key = it->first;
+    DetEleLvl_t    val = it->second;
+    os << std::get<0>(val) << "\t" << std::get<1>(val) << "\t" << std::get<2>(val) << "\t"
+       << std::get<0>(key) << "\t" << std::get<1>(key) << "\t" << std::get<2>(key) << "\n";
+    n_ent++;
+  }
+  cout << n_ent << endl;
+}
+
+void ChanMapperV1495::InitNameMap()
+{
+  m_map_name2id["H1B"  ] =  25+6;
+  m_map_name2id["H1T"  ] =  26+6;
+  m_map_name2id["H1L"  ] =  27+6;
+  m_map_name2id["H1R"  ] =  28+6;
+  m_map_name2id["H2L"  ] =  29+6;
+  m_map_name2id["H2R"  ] =  30+6;
+  m_map_name2id["H2B"  ] =  31+6;
+  m_map_name2id["H2T"  ] =  32+6;
+  m_map_name2id["H3B"  ] =  33+6;
+  m_map_name2id["H3T"  ] =  34+6;
+  m_map_name2id["H4Y1L"] =  35+6;
+  m_map_name2id["H4Y1R"] =  36+6;
+  m_map_name2id["H4Y2L"] =  37+6;
+  m_map_name2id["H4Y2R"] =  38+6;
+  m_map_name2id["H4B"  ] =  39+6;
+  m_map_name2id["H4T"  ] =  40+6;
+
+  m_map_name2id["H4Bu"  ] = 39+6;
+  m_map_name2id["H4Bd"  ] = 39+6;
+  m_map_name2id["H4Tu"  ] = 40+6;
+  m_map_name2id["H4Td"  ] = 40+6;
+  m_map_name2id["H4Y1Ll"] = 35+6;
+  m_map_name2id["H4Y1Lr"] = 35+6;
+  m_map_name2id["H4Y1Rl"] = 36+6;
+  m_map_name2id["H4Y1Rr"] = 36+6;
+  m_map_name2id["H4Y2Ll"] = 37+6;
+  m_map_name2id["H4Y2Lr"] = 37+6;
+  m_map_name2id["H4Y2Rl"] = 38+6;
+  m_map_name2id["H4Y2Rr"] = 38+6;
+}

--- a/online/chan_map/ChanMapperV1495.cc
+++ b/online/chan_map/ChanMapperV1495.cc
@@ -6,7 +6,7 @@
 #include <TSQLServer.h>
 #include <TSQLStatement.h>
 #include <geom_svc/GeomSvc.h>
-#include "DbSvc.h"
+#include <db_svc/DbSvc.h>
 #include "ChanMapperV1495.h"
 using namespace std;
 

--- a/online/chan_map/ChanMapperV1495.h
+++ b/online/chan_map/ChanMapperV1495.h
@@ -1,0 +1,32 @@
+#ifndef __CHAN_MAPPER_V1495_H__
+#define __CHAN_MAPPER_V1495_H__
+#include <tuple>
+#include "ChanMapper.h"
+
+class ChanMapperV1495 : public ChanMapper {
+  typedef std::tuple<short, short, short> RocBoardChan_t;
+  typedef std::tuple<std::string, short, short> DetEleLvl_t;
+  typedef std::map<RocBoardChan_t, DetEleLvl_t> Map_t;
+  Map_t m_map;
+  std::map<std::string, short> m_map_name2id;
+
+ public:
+  ChanMapperV1495();
+  virtual ~ChanMapperV1495() {;}
+
+  void Add (const short roc, const short board, const short chan, const std::string det, const short ele, const short lvl);
+  bool Find(const short roc, const short board, const short chan,  std::string& det, short& ele, short& lvl);
+  bool Find(const short roc, const short board, const short chan,        short& det, short& ele, short& lvl);
+  void Print(std::ostream& os);
+
+ protected:
+  int  ReadFileCont(LineList& lines);
+  int WriteFileCont(std::ostream& os);
+
+  void  ReadDbTable(DbSvc& db);
+  void WriteDbTable(DbSvc& db);
+
+  void InitNameMap();
+};
+
+#endif // __CHAN_MAPPER_V1495_H__

--- a/online/chan_map/ChanMapperV1495.h
+++ b/online/chan_map/ChanMapperV1495.h
@@ -1,13 +1,24 @@
 #ifndef __CHAN_MAPPER_V1495_H__
 #define __CHAN_MAPPER_V1495_H__
-#include <tuple>
 #include "ChanMapper.h"
 
 class ChanMapperV1495 : public ChanMapper {
-  typedef std::tuple<short, short, short> RocBoardChan_t;
-  typedef std::tuple<std::string, short, short> DetEleLvl_t;
+  struct MapItem {
+    short roc;
+    short board;
+    short chan;
+    std::string det_name;
+    short det;
+    short ele;
+    short lvl;
+  };
+  typedef std::vector<MapItem> List_t;
+  List_t m_list; ///< Used to keep all information in the added order.
+
+  typedef std::tuple<short, short, short> DetEleLvl_t;
   typedef std::map<RocBoardChan_t, DetEleLvl_t> Map_t;
-  Map_t m_map;
+  Map_t m_map; ///< Used in Find() for better speed.
+
   std::map<std::string, short> m_map_name2id;
 
  public:
@@ -15,7 +26,9 @@ class ChanMapperV1495 : public ChanMapper {
   virtual ~ChanMapperV1495() {;}
 
   void Add (const short roc, const short board, const short chan, const std::string det, const short ele, const short lvl);
-  bool Find(const short roc, const short board, const short chan,  std::string& det, short& ele, short& lvl);
+  void Add (const short roc, const short board, const short chan, const std::string det_name, const short det_id, const short ele, const short lvl);
+
+  //bool Find(const short roc, const short board, const short chan,  std::string& det, short& ele, short& lvl);
   bool Find(const short roc, const short board, const short chan,        short& det, short& ele, short& lvl);
   void Print(std::ostream& os);
 

--- a/online/chan_map/DbSvc.cc
+++ b/online/chan_map/DbSvc.cc
@@ -1,0 +1,133 @@
+#include <iostream>
+#include <iomanip>
+#include <sstream>
+#include <cstdlib>
+#include <TSQLResult.h>
+#include <TSQLRow.h>
+#include "DbSvc.h"
+using namespace std;
+
+DbSvc::DbSvc(const SvrId_t svr_id)
+{
+  m_svr_id = svr_id;
+  SelectServer();
+  ConnectServer();
+}
+
+DbSvc::~DbSvc()
+{
+  if (m_con) delete m_con;
+}
+
+void DbSvc::UseSchema(const char* name, const bool do_create, const bool do_drop)
+{
+  bool found = false;
+  TSQLResult* res = m_con->GetDataBases(name);
+  TSQLRow* row = 0;
+  while ( (row = res->Next()) != 0 ) {
+    string val = row->GetField(0);
+    delete row;
+    if (val == name) found = true;
+  }
+  delete res;
+
+  int ret = -1; // non-zero
+  if (found) {
+    if (do_drop) {
+      ret = m_con->DropDataBase(name);
+      if (ret == 0) ret = m_con->CreateDataBase(name);
+    } else {
+      ret = 0; // OK just as found.
+    }
+  } else {
+    if (do_create) ret = m_con->CreateDataBase(name);
+  }
+  if (ret == 0) ret = m_con->SelectDataBase(name);
+  if (ret != 0) {
+    cerr << "!!ERROR!!  DbSvc::UseSchema:  Failed to select '" << name << "'.  Abort." << endl;
+    exit(1);
+  }
+}
+
+//void DbSvc::UseSchema(const char* schema, const bool do_create)
+//{
+//  int ret = m_con->SelectDataBase(schema);
+//  if (ret != 0 && do_create) { // Try to create it.
+//    ret = m_con->CreateDataBase(schema);
+//    if (ret == 0) ret = m_con->SelectDataBase(schema);
+//  }
+//  if (ret != 0) {
+//    cerr << "!!ERROR!!  DbSvc::UseSchema:  Failed to select the schema (" << schema << ").  Abort." << endl;
+//    exit(1);
+//  }
+//}
+
+void DbSvc::DropTable(const char* name)
+{
+  string query = "drop table if exists ";
+  query += name;
+  if (! m_con->Exec(query.c_str())) {
+    cerr << "!!ERROR!!  DbSvc::DropTable():  Failed on " << name << ".  Abort." << endl;
+    exit(1);
+  }
+}
+
+bool DbSvc::AssureTable(const char* name, const bool exit_on_error)
+{
+  if (m_con->HasTable(name)) return true;
+  if (exit_on_error) {
+    cerr << "!!ERROR!!  DbSvc:  The table '" << name << "' does not exist.  Abort." << endl;
+    exit(1);
+  }
+  return false;
+}
+
+/** This function runs Statement(), Process() and StoreResult() with error check.
+ *  The return object (TSQLStatement*) must be deleted by user.
+ *  Example:
+ *   TSQLStatement* stmt = db_svc->Process(query);
+ *   while (stmt->NextResultRow()) {
+ *     int id    = stmt->GetInt(0);
+ *     int event = stmt->GetInt(1);
+ *   }
+ *   delete stmt;
+ */
+TSQLStatement* DbSvc::Process(const char* query)
+{
+  TSQLStatement* stmt = m_con->Statement(query);
+  if (! stmt->Process()) {
+    cerr << "!!ERROR!!  DbSvc::Process():  Failed to execute a statement:  " << stmt << ".\n"
+         << "Abort." << endl;
+    exit(1);
+  }
+  stmt->StoreResult();
+  return stmt;
+}
+
+void DbSvc::SelectServer()
+{
+  if      (m_svr_id == DB1 ) m_svr = "e906-db1.fnal.gov";
+  else if (m_svr_id == DB2 ) m_svr = "e906-db2.fnal.gov";
+  else if (m_svr_id == DB3 ) m_svr = "e906-db3.fnal.gov";
+  else if (m_svr_id == DB01) m_svr = "seaquestdb01.fnal.gov:3310";
+  else if (m_svr_id == UIUC) m_svr = "seaquel.physics.illinois.edu:3283";
+  else {
+    cerr << "!!ERROR!!  DbSvc():  Unsupported server ID.  Abort.\n";
+    exit(1);
+  }
+}
+
+void DbSvc::ConnectServer()
+{
+   //cout << "DB server: " << m_svr << endl;
+   string uri = "mysql://";
+   uri += m_svr;
+   // todo: follow https://root.cern.ch/doc/master/classTMySQLServer.html to use my.cnf.
+   // see also /data2/chambers/hvmon_cham/fy2018/src/DBC.cc
+
+   m_con = TMySQLServer::Connect(uri.c_str(), "seaguest", "qqbar2mu+mu-");
+   if (! (m_con && m_con->IsConnected())) {
+      cerr << "!!ERROR!!  DbSvc::ConnectServer():  Failed.  Abort." << endl;
+      exit(1);
+   }
+}

--- a/online/chan_map/DbSvc.h
+++ b/online/chan_map/DbSvc.h
@@ -1,0 +1,37 @@
+#ifndef __DB_SVC_H__
+#define __DB_SVC_H__
+#include <string>
+#include <sstream>
+#include <TMySQLServer.h>
+#include <TSQLStatement.h>
+
+class DbSvc {
+ public:
+  typedef enum { DB1, DB2, DB3, DB01, UIUC, UNDEF } SvrId_t;
+
+  DbSvc(const SvrId_t svr_id=DB1);
+  ~DbSvc();
+
+  void UseSchema(const char*       name, const bool do_create=false, const bool do_drop=false);
+  void UseSchema(const std::string name, const bool do_create=false, const bool do_drop=false) { UseSchema(name.c_str(), do_create, do_drop); }
+  //void UseSchema(const char* schema, const bool do_create=true);
+  //void UseSchema(const std::string schema, const bool do_create=true) { UseSchema(schema.c_str(), do_create);}
+
+  void DropTable  (const char* name);
+  void DropTable  (const std::string name) { DropTable(name.c_str()); }
+  bool AssureTable(const char* name, const bool exit_on_error=true);
+  bool AssureTable(const std::string name, const bool exit_on_error=true) { AssureTable(name.c_str(), exit_on_error); }
+  
+  TSQLServer* Con() { return m_con; }
+  TSQLStatement* Process(const char*             query);
+  TSQLStatement* Process(const std::string       query) { return Process(query.c_str()); }
+  
+ private:
+  SvrId_t     m_svr_id;
+  std::string m_svr;
+  TSQLServer* m_con;
+
+  void SelectServer();
+  void ConnectServer();
+};
+#endif // __DB_SVC_H__

--- a/online/chan_map/DbSvc.h
+++ b/online/chan_map/DbSvc.h
@@ -1,15 +1,19 @@
 #ifndef __DB_SVC_H__
 #define __DB_SVC_H__
+#include <vector>
 #include <string>
 #include <sstream>
-#include <TMySQLServer.h>
-#include <TSQLStatement.h>
+class TSQLServer;
+class TSQLStatement;
+//#include <TMySQLServer.h>
+//#include <TSQLStatement.h>
 
 class DbSvc {
  public:
-  typedef enum { DB1, DB2, DB3, DB01, UIUC, UNDEF } SvrId_t;
+  typedef enum { DB1, DB2, DB3, DB01, UIUC } SvrId_t;
+  typedef enum { Guest, Prod } UsrId_t;
 
-  DbSvc(const SvrId_t svr_id=DB1);
+  DbSvc(const SvrId_t svr_id=DB1, const UsrId_t usr_id=Guest, const std::string my_cnf="");
   ~DbSvc();
 
   void UseSchema(const char*       name, const bool do_create=false, const bool do_drop=false);
@@ -19,16 +23,20 @@ class DbSvc {
 
   void DropTable  (const char* name);
   void DropTable  (const std::string name) { DropTable(name.c_str()); }
-  bool AssureTable(const char* name, const bool exit_on_error=true);
-  bool AssureTable(const std::string name, const bool exit_on_error=true) { AssureTable(name.c_str(), exit_on_error); }
+  bool HasTable(const char* name, const bool exit_on_false=false);
+  bool HasTable(const std::string name, const bool exit_on_false=false) { HasTable(name.c_str(), exit_on_false); }
+  void CreateTable(const std::string name, const std::vector<std::string> list_var, const std::vector<std::string> list_type);
+  void CreateTable(const std::string name, const int n_var, const char** list_var, const char** list_type);
   
   TSQLServer* Con() { return m_con; }
-  TSQLStatement* Process(const char*             query);
-  TSQLStatement* Process(const std::string       query) { return Process(query.c_str()); }
+  TSQLStatement* Process(const char*       query);
+  TSQLStatement* Process(const std::string query) { return Process(query.c_str()); }
   
  private:
   SvrId_t     m_svr_id;
+  UsrId_t     m_usr_id;
   std::string m_svr;
+  std::string m_my_cnf;
   TSQLServer* m_con;
 
   void SelectServer();

--- a/online/chan_map/LinkDef.h
+++ b/online/chan_map/LinkDef.h
@@ -1,0 +1,9 @@
+#ifdef __CINT__
+#pragma link off all class;
+#pragma link off all function;
+#pragma link off all global;
+
+#pragma link C++ class ChanMapper;
+#pragma link C++ class ChanMapperTaiwan;
+
+#endif /* __CINT__ */

--- a/online/chan_map/LinkDef.h
+++ b/online/chan_map/LinkDef.h
@@ -3,6 +3,7 @@
 #pragma link off all function;
 #pragma link off all global;
 
+#pragma link C++ class ChanMapperRange;
 #pragma link C++ class ChanMapper;
 #pragma link C++ class ChanMapperTaiwan;
 

--- a/online/chan_map/LinkDef.h
+++ b/online/chan_map/LinkDef.h
@@ -6,5 +6,7 @@
 #pragma link C++ class ChanMapperRange;
 #pragma link C++ class ChanMapper;
 #pragma link C++ class ChanMapperTaiwan;
+#pragma link C++ class ChanMapperV1495;
+#pragma link C++ class ChanMapperScaler;
 
 #endif /* __CINT__ */

--- a/online/chan_map/macros/CheckChanMap.C
+++ b/online/chan_map/macros/CheckChanMap.C
@@ -1,11 +1,11 @@
 /// CheckChanMap.C:  Macro to check one of the channel mappings on MySQL DB.
 R__LOAD_LIBRARY(libchan_map)
 
-int CheckChanMap()
+int CheckChanMap(const int run=25000)
 {
   gSystem->Load("libchan_map.so");
   ChanMapperTaiwan map;
-  map.SetMapIDbyDB(15000);
+  map.SetMapIDbyDB(run);
   map.ReadFromDB();
 
   //map.Print(cout);

--- a/online/chan_map/macros/CheckChanMap.C
+++ b/online/chan_map/macros/CheckChanMap.C
@@ -1,0 +1,14 @@
+/// CheckChanMap.C:  Macro to check one of the channel mappings on MySQL DB.
+R__LOAD_LIBRARY(libchan_map)
+
+int CheckChanMap()
+{
+  gSystem->Load("libchan_map.so");
+  ChanMapperTaiwan map;
+  map.SetMapIDbyDB(15000);
+  map.ReadFromDB();
+
+  //map.Print(cout);
+  map.WriteToLocalFile("test.tsv");
+  return 0;
+}

--- a/online/chan_map/macros/MakeChanMap.C
+++ b/online/chan_map/macros/MakeChanMap.C
@@ -1,0 +1,17 @@
+/// MakeChanMap.C:  Macro to create a channel mapping.
+R__LOAD_LIBRARY(libchan_map)
+
+int MakeChanMap()
+{
+  gSystem->Load("libchan_map.so");
+  ChanMapperTaiwan map;
+  map.SetMapIDbyDB(15000);
+
+  /// roc, board chan, det, ele
+  map.Add(10, 100, 1, "D1X", 123);
+  map.Add(11, 101, 2, "D2X", 321);
+
+  map.Print(cout);
+  map.WriteToLocalFile("test.tsv");
+  return 0;
+}

--- a/online/chan_map/macros/MakeChanMap.C
+++ b/online/chan_map/macros/MakeChanMap.C
@@ -5,13 +5,12 @@ int MakeChanMap()
 {
   gSystem->Load("libchan_map.so");
   ChanMapperTaiwan map;
-  map.SetMapIDbyDB(15000);
 
   /// roc, board chan, det, ele
   map.Add(10, 100, 1, "D1X", 123);
   map.Add(11, 101, 2, "D2X", 321);
 
   map.Print(cout);
-  map.WriteToLocalFile("test.tsv");
+  map.WriteToLocalFile("chan_map_new.tsv");
   return 0;
 }

--- a/online/chan_map/macros/UploadChanMap.C
+++ b/online/chan_map/macros/UploadChanMap.C
@@ -5,11 +5,13 @@ int UploadChanMap()
 {
   gSystem->Load("libchan_map.so");
   ChanMapperTaiwan map;
-  map.ReadFromFile(15000);
-  //map.ReadFromFile("/data2/analysis/kenichi/e1039/chan_map/chamber/test/chamberInfo_v22.tsv");
+  map.SetMapIDbyFile(15000); // todo: use map_id to select the map to be uploaded...
+  map.ReadFromFile();
+
   //map.Print(cout);
-  //map.WriteToFile("test.tsv");
+  map.WriteToLocalFile("test.tsv");
   map.WriteToDB();
+  map.WriteRangeToDB();
 
   return 0;
 }

--- a/online/chan_map/macros/UploadChanMap.C
+++ b/online/chan_map/macros/UploadChanMap.C
@@ -4,15 +4,15 @@ R__LOAD_LIBRARY(libchan_map)
 int UploadChanMap(const std::string map_id="e906run28740")
 {
   gSystem->Load("libchan_map.so");
-  //ChanMapperTaiwan map;
-  ChanMapperV1495  map;
+  ChanMapperTaiwan map;
+  //ChanMapperV1495  map;
   //ChanMapperScaler map;
 
   map.SetMapIDbyFile(map_id);
   map.ReadFromFile();
 
   //map.Print(cout);
-  map.WriteToLocalFile("test.tsv");
+  map.WriteToLocalFile("output_for_check.tsv");
   map.WriteToDB();
   map.WriteRangeToDB();
 

--- a/online/chan_map/macros/UploadChanMap.C
+++ b/online/chan_map/macros/UploadChanMap.C
@@ -1,0 +1,15 @@
+/// UploadChanMap.C:  Macro to upload the channel mapping from tsv file to MySQL DB.
+R__LOAD_LIBRARY(libchan_map)
+
+int UploadChanMap()
+{
+  gSystem->Load("libchan_map.so");
+  ChanMapperTaiwan map;
+  map.ReadFromFile(15000);
+  //map.ReadFromFile("/data2/analysis/kenichi/e1039/chan_map/chamber/test/chamberInfo_v22.tsv");
+  //map.Print(cout);
+  //map.WriteToFile("test.tsv");
+  map.WriteToDB();
+
+  return 0;
+}

--- a/online/chan_map/macros/UploadChanMap.C
+++ b/online/chan_map/macros/UploadChanMap.C
@@ -1,11 +1,14 @@
 /// UploadChanMap.C:  Macro to upload the channel mapping from tsv file to MySQL DB.
 R__LOAD_LIBRARY(libchan_map)
 
-int UploadChanMap()
+int UploadChanMap(const std::string map_id="e906run28740")
 {
   gSystem->Load("libchan_map.so");
-  ChanMapperTaiwan map;
-  map.SetMapIDbyFile(15000); // todo: use map_id to select the map to be uploaded...
+  //ChanMapperTaiwan map;
+  ChanMapperV1495  map;
+  //ChanMapperScaler map;
+
+  map.SetMapIDbyFile(map_id);
   map.ReadFromFile();
 
   //map.Print(cout);

--- a/online/decoder_maindaq/CMakeLists.txt
+++ b/online/decoder_maindaq/CMakeLists.txt
@@ -34,7 +34,7 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x -I$ENV{MY_INSTALL}/include/ -
 set(CMAKE_C_FLAGS   "${CMAKE_C_FLAGS}   -DBIT64    -I$ENV{MY_INSTALL}/include/ -I$ENV{OFFLINE_MAIN}/include/")
 
 add_library(decoder_maindaq SHARED ${sources} ${dicts})
-target_link_libraries(decoder_maindaq -linterface_main -lfun4all -lphool)
+target_link_libraries(decoder_maindaq -linterface_main -lfun4all -lphool -lchan_map)
 
 message(${CMAKE_PROJECT_NAME} " will be installed to " ${CMAKE_INSTALL_PREFIX})
 

--- a/online/decoder_maindaq/DecoParam.cc
+++ b/online/decoder_maindaq/DecoParam.cc
@@ -27,20 +27,28 @@ int DecoParam::InitMapper()
     cout << "!!ERROR!!  DecoParam::InitMapper(): runID = 0.\n";
     return 1;
   }
-  ostringstream oss;
-  oss << dir_param << "/run_" << setfill('0') << setw(6) << runID;
-  string dir_map = oss.str();
-  oss << "/chamber/chamberInfo.tsv";
-  map_taiwan.ReadFile(oss.str().c_str());
-  oss.str("");
-  oss << dir_map << "/hodoscope/hodoInfo.tsv";
-  map_taiwan.ReadFile(oss.str().c_str());
-  oss.str("");
-  oss << dir_map << "/trigger/triggerInfo.tsv";
-  map_v1495 .ReadFile(oss.str().c_str());
-  oss.str("");
-  oss << dir_map << "/scaler/scalerInfo.tsv";
-  map_scaler.ReadFile(oss.str().c_str());
+  //ostringstream oss;
+  //oss << dir_param << "/run_" << setfill('0') << setw(6) << runID;
+  //string dir_map = oss.str();
+  //oss << "/chamber/chamberInfo.tsv";
+  //map_taiwan.ReadFile(oss.str().c_str());
+  //oss.str("");
+  //oss << dir_map << "/hodoscope/hodoInfo.tsv";
+  //map_taiwan.ReadFile(oss.str().c_str());
+  //oss.str("");
+  //oss << dir_map << "/trigger/triggerInfo.tsv";
+  //map_v1495 .ReadFile(oss.str().c_str());
+  //oss.str("");
+  //oss << dir_map << "/scaler/scalerInfo.tsv";
+  //map_scaler.ReadFile(oss.str().c_str());
+
+  chan_map_taiwan.SetMapIDbyDB(runID);
+  chan_map_taiwan.ReadFromDB();
+  chan_map_v1495 .SetMapIDbyDB(runID);
+  chan_map_v1495 .ReadFromDB();
+  chan_map_scaler.SetMapIDbyDB(runID);
+  chan_map_scaler.ReadFromDB();
+
   return 0;
 }
 

--- a/online/decoder_maindaq/DecoParam.h
+++ b/online/decoder_maindaq/DecoParam.h
@@ -3,6 +3,9 @@
 #include "MapperTaiwan.h"
 #include "MapperV1495.h"
 #include "MapperScaler.h"
+#include <chan_map/ChanMapperTaiwan.h>
+#include <chan_map/ChanMapperV1495.h>
+#include <chan_map/ChanMapperScaler.h>
 //#include "assert.h"
 class EventInfo;
 
@@ -24,6 +27,9 @@ struct DecoParam {
   MapperV1495  map_v1495;
   MapperScaler map_scaler;
 
+  ChanMapperTaiwan chan_map_taiwan;
+  ChanMapperV1495  chan_map_v1495;
+  ChanMapperScaler chan_map_scaler;
 
   ///
   /// Monitoring parameters

--- a/online/decoder_maindaq/MainDaqParser.cc
+++ b/online/decoder_maindaq/MainDaqParser.cc
@@ -649,7 +649,8 @@ int MainDaqParser::ProcessBoardScaler (int* words, int idx)
       data.board = boardID;
       data.chan  = ii;
       data.value = value;
-      if (! dec_par.map_scaler.Find(data.roc, data.board, data.chan, data.name)) {
+      //if (! dec_par.map_scaler.Find(data.roc, data.board, data.chan, data.name)) {
+      if (! dec_par.chan_map_scaler.Find(data.roc, data.board, data.chan, data.name)) {
 	if (dec_par.verbose > 1) cout << "  Unmapped Scaler: " << data.roc << " " << data.board << " " << data.chan << "\n";
 	continue;
       }
@@ -1109,14 +1110,16 @@ int MainDaqParser::PackOneSpillData()
     /// since it takes the longest process time per event.
     for (unsigned int ih = 0; ih < n_taiwan; ih++) {
       HitData* hd = &ed->list_hit[ih];
-      if (! dec_par.map_taiwan.Find(hd->roc, hd->board, hd->chan, hd->det, hd->ele)) {
-        if (dec_par.verbose > 1) cout << "  Unmapped v1495: " << hd->roc << " " << hd->board << " " << hd->chan << "\n";
+      //if (! dec_par.map_taiwan.Find(hd->roc, hd->board, hd->chan, hd->det, hd->ele)) {
+      if (! dec_par.chan_map_taiwan.Find(hd->roc, hd->board, hd->chan, hd->det, hd->ele)) {
+        if (dec_par.verbose > 1) cout << "  Unmapped Taiwan: " << hd->roc << " " << hd->board << " " << hd->chan << "\n";
       }
     }
     for (unsigned int ih = 0; ih < n_v1495; ih++) {
       HitData* hd = &ed->list_hit_trig[ih];
       short level; // not stored for now
-      if (! dec_par.map_v1495.Find(hd->roc, hd->board, hd->chan, hd->det, hd->ele, level)) {
+      //if (! dec_par.map_v1495.Find(hd->roc, hd->board, hd->chan, hd->det, hd->ele, level)) {
+      if (! dec_par.chan_map_v1495.Find(hd->roc, hd->board, hd->chan, hd->det, hd->ele, level)) {
         if (dec_par.verbose > 1) cout << "  Unmapped v1495: " << hd->roc << " " << hd->board << " " << hd->chan << "\n";
       }
     }

--- a/packages/db_svc/CMakeLists.txt
+++ b/packages/db_svc/CMakeLists.txt
@@ -1,12 +1,12 @@
 # Setup the project
 cmake_minimum_required(VERSION 2.6 FATAL_ERROR)
-project(chan_map CXX)
+project(db_svc CXX)
 
 # ROOT dict generation
 add_custom_command (
-  OUTPUT ChanMap_Dict.cc
+  OUTPUT DbSvc_Dict.cc
   COMMAND rootcint
-  ARGS -f ChanMap_Dict.cc -c
+  ARGS -f DbSvc_Dict.cc -c
     -I$ENV{OFFLINE_MAIN}/include/ -I${ROOT_PREFIX}/include/
     ${PROJECT_SOURCE_DIR}/*.h
 )
@@ -27,7 +27,6 @@ endif()
 execute_process(COMMAND mysql_config --cflags OUTPUT_VARIABLE MYSQL_CFLAGS  OUTPUT_STRIP_TRAILING_WHITESPACE)
 execute_process(COMMAND mysql_config --libs   OUTPUT_VARIABLE MYSQL_LIBS    OUTPUT_STRIP_TRAILING_WHITESPACE)
 
-
 # ROOT
 find_program(ROOTCONF "root-config")
 if(ROOTCONF)
@@ -40,12 +39,12 @@ execute_process(COMMAND root-config --libs   OUTPUT_VARIABLE ROOT_LINK    OUTPUT
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x -I$ENV{OFFLINE_MAIN}/include/ ${ROOT_CFLAGS} ${MYSQL_CFLAGS}")
 
-add_library(chan_map SHARED ${sources} ChanMap_Dict.cc)
-target_link_libraries(chan_map ${MYSQL_LIBS} ${ROOT_LINK} geom_svc db_svc)
+add_library(db_svc SHARED ${sources} DbSvc_Dict.cc)
+target_link_libraries(db_svc ${MYSQL_LIBS} ${ROOT_LINK})
 
 message(${CMAKE_PROJECT_NAME} " will be installed to " ${CMAKE_INSTALL_PREFIX})
 
-install(TARGETS chan_map DESTINATION ${CMAKE_INSTALL_PREFIX}/lib)
+install(TARGETS db_svc DESTINATION ${CMAKE_INSTALL_PREFIX}/lib)
 
 file(GLOB dist_headers ${PROJECT_SOURCE_DIR}/*.h)
 file(GLOB non_dist_headers ${PROJECT_SOURCE_DIR}/*LinkDef.h)
@@ -57,5 +56,5 @@ execute_process(COMMAND root-config --version OUTPUT_VARIABLE ROOT_VER)
 string(SUBSTRING ${ROOT_VER} 0 1 ROOT_VER)
 if (ROOT_VER GREATER 5)
    add_custom_target(install_pcm ALL COMMAND mkdir -p ${CMAKE_INSTALL_PREFIX}/lib COMMAND cp -up *_rdict.pcm ${CMAKE_INSTALL_PREFIX}/lib)
-   add_dependencies(install_pcm chan_map)
+   add_dependencies(install_pcm db_svc)
 endif()

--- a/packages/db_svc/CMakeLists.txt
+++ b/packages/db_svc/CMakeLists.txt
@@ -8,7 +8,8 @@ add_custom_command (
   COMMAND rootcint
   ARGS -f DbSvc_Dict.cc -c
     -I$ENV{OFFLINE_MAIN}/include/ -I${ROOT_PREFIX}/include/
-    ${PROJECT_SOURCE_DIR}/*.h
+    ${PROJECT_SOURCE_DIR}/DbSvc.h
+    ${PROJECT_SOURCE_DIR}/LinkDef.h
 )
 
 link_directories("./" "$ENV{OFFLINE_MAIN}/lib/")

--- a/packages/db_svc/DbSvc.cc
+++ b/packages/db_svc/DbSvc.cc
@@ -58,19 +58,6 @@ void DbSvc::UseSchema(const char* name, const bool do_create, const bool do_drop
   }
 }
 
-//void DbSvc::UseSchema(const char* schema, const bool do_create)
-//{
-//  int ret = m_con->SelectDataBase(schema);
-//  if (ret != 0 && do_create) { // Try to create it.
-//    ret = m_con->CreateDataBase(schema);
-//    if (ret == 0) ret = m_con->SelectDataBase(schema);
-//  }
-//  if (ret != 0) {
-//    cerr << "!!ERROR!!  DbSvc::UseSchema:  Failed to select the schema (" << schema << ").  Abort." << endl;
-//    exit(1);
-//  }
-//}
-
 void DbSvc::DropTable(const char* name)
 {
   string query = "drop table if exists ";

--- a/packages/db_svc/DbSvc.h
+++ b/packages/db_svc/DbSvc.h
@@ -5,8 +5,6 @@
 #include <sstream>
 class TSQLServer;
 class TSQLStatement;
-//#include <TMySQLServer.h>
-//#include <TSQLStatement.h>
 
 class DbSvc {
  public:
@@ -18,13 +16,11 @@ class DbSvc {
 
   void UseSchema(const char*       name, const bool do_create=false, const bool do_drop=false);
   void UseSchema(const std::string name, const bool do_create=false, const bool do_drop=false) { UseSchema(name.c_str(), do_create, do_drop); }
-  //void UseSchema(const char* schema, const bool do_create=true);
-  //void UseSchema(const std::string schema, const bool do_create=true) { UseSchema(schema.c_str(), do_create);}
 
   void DropTable  (const char* name);
   void DropTable  (const std::string name) { DropTable(name.c_str()); }
   bool HasTable(const char* name, const bool exit_on_false=false);
-  bool HasTable(const std::string name, const bool exit_on_false=false) { HasTable(name.c_str(), exit_on_false); }
+  bool HasTable(const std::string name, const bool exit_on_false=false) { return HasTable(name.c_str(), exit_on_false); }
   void CreateTable(const std::string name, const std::vector<std::string> list_var, const std::vector<std::string> list_type);
   void CreateTable(const std::string name, const int n_var, const char** list_var, const char** list_type);
   

--- a/packages/db_svc/LinkDef.h
+++ b/packages/db_svc/LinkDef.h
@@ -1,0 +1,8 @@
+#ifdef __CINT__
+#pragma link off all class;
+#pragma link off all function;
+#pragma link off all global;
+
+#pragma link C++ class DbSvc;
+
+#endif /* __CINT__ */

--- a/setup-e1039-core.sh
+++ b/setup-e1039-core.sh
@@ -1,8 +1,9 @@
+DIR_E1039_CORE=$(dirname $(readlink -f $BASH_SOURCE))
 
 if [ $HOSTNAME = 'seaquestdaq01.fnal.gov' ] ; then
     source /opt/e1039-share/this-share.sh
     export OFFLINE_MAIN=$DIR_E1039_SHARE/inst
-    export MY_INSTALL=~/tmp/e1039-core
+    export MY_INSTALL=$(dirname $DIR_E1039_CORE)/e1039-core-build/inst # ~/tmp/e1039-core
 
     export            PATH=$MY_INSTALL/bin:$PATH
     export           CPATH=$MY_INSTALL/include:$CPATH


### PR DESCRIPTION
I added several classes (like ChanMapperTaiwan) for the channel mapping.  These classes can read the mapping info from MySQL DB, as well as writing to DB and also reading/writing tsv file.  They can handle multiple mappings for multiple run ranges.  I updated the MainDAQ decoder to use these new classes.

I also added a class (DbSvc) for the database service.  For now it is used by only the channel-mapping classes, but I expect all other classes can/should use it because of the following advantages;
 * The host, user and password are defined and switchable.
 * The password is kept outside the git repository.
 * Functions to create and drop schema and table are defined.

Details will be presented at the coming meeting, but this branch can be safely merged as the changes don't interfere with the other packages.