### PR TITLE
Compile under ROOT5

### DIFF
--- a/online/chan_map/CMakeLists.txt
+++ b/online/chan_map/CMakeLists.txt
@@ -2,14 +2,20 @@
 cmake_minimum_required(VERSION 2.6 FATAL_ERROR)
 project(chan_map CXX)
 
+execute_process(COMMAND root-config --version OUTPUT_VARIABLE ROOT_VER)
+string(SUBSTRING ${ROOT_VER} 0 1 ROOT_VER)
+message("ROOT_VER: ${ROOT_VER}")
+
 # ROOT dict generation
-add_custom_command (
-  OUTPUT ChanMap_Dict.cc
-  COMMAND rootcint
-  ARGS -f ChanMap_Dict.cc -c
-    -I$ENV{OFFLINE_MAIN}/include/ -I${ROOT_PREFIX}/include/
-    ${PROJECT_SOURCE_DIR}/*.h
-)
+if (ROOT_VER GREATER 5)
+  add_custom_command (
+    OUTPUT ChanMap_Dict.cc
+    COMMAND rootcint
+    ARGS -f ChanMap_Dict.cc -c
+      -I$ENV{OFFLINE_MAIN}/include/ -I${ROOT_PREFIX}/include/
+      ${PROJECT_SOURCE_DIR}/*.h
+  )
+endif()
 
 link_directories("./" "$ENV{OFFLINE_MAIN}/lib/")
 include_directories("$ENV{OFFLINE_MAIN}/include/" "${PROJECT_SOURCE_DIR}/")
@@ -40,7 +46,11 @@ execute_process(COMMAND root-config --libs   OUTPUT_VARIABLE ROOT_LINK    OUTPUT
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x -I$ENV{OFFLINE_MAIN}/include/ ${ROOT_CFLAGS} ${MYSQL_CFLAGS}")
 
-add_library(chan_map SHARED ${sources} ChanMap_Dict.cc)
+if (ROOT_VER GREATER 5)
+  add_library(chan_map SHARED ${sources} ChanMap_Dict.cc)
+else ()
+  add_library(chan_map SHARED ${sources})
+endif()
 target_link_libraries(chan_map ${MYSQL_LIBS} ${ROOT_LINK} geom_svc db_svc)
 
 message(${CMAKE_PROJECT_NAME} " will be installed to " ${CMAKE_INSTALL_PREFIX})
@@ -53,8 +63,6 @@ list(REMOVE_ITEM dist_headers ${non_dist_headers})
 install(FILES ${dist_headers} DESTINATION ${CMAKE_INSTALL_PREFIX}/include/${CMAKE_PROJECT_NAME}/)
 
 # Install the pcm files in case of ROOT 6.
-execute_process(COMMAND root-config --version OUTPUT_VARIABLE ROOT_VER)
-string(SUBSTRING ${ROOT_VER} 0 1 ROOT_VER)
 if (ROOT_VER GREATER 5)
    add_custom_target(install_pcm ALL COMMAND mkdir -p ${CMAKE_INSTALL_PREFIX}/lib COMMAND cp -up *_rdict.pcm ${CMAKE_INSTALL_PREFIX}/lib)
    add_dependencies(install_pcm chan_map)


### PR DESCRIPTION
Thanks for this update. I noticed one thing that this package won't compile with ROOT5. For the `tuple` class template could not be used in ROOT5 interpreter. I suggest to make a change in this pull request to skip the ROOT dictionary generation for ROOT5.