### PR TITLE
Fun4AllSRawEventInputManager, L-R resolving bug fix and introducing the recoConst

### DIFF
--- a/framework/phool/recoConsts.cc
+++ b/framework/phool/recoConsts.cc
@@ -10,6 +10,7 @@ recoConsts::Print() const
   // methods from PHFlag
   PrintCharFlags();
   PrintFloatFlags();
+  PrintDoubleFlags();
   PrintIntFlags();
 
   return;

--- a/generators/phhepmc/CMakeLists.txt
+++ b/generators/phhepmc/CMakeLists.txt
@@ -19,21 +19,20 @@ foreach(LinkDefh ${LinkDefhs})
 	list(APPEND dicts ${DictC})
   #message("Dicth: " ${Dicth})
   #message("DictC: " ${DictC})
-	add_custom_command(OUTPUT ${DictC} COMMAND rootcint ARGS -f ${DictC} -c -I$ENV{OFFLINE_MAIN}/include ${Dicth} ${LinkDefh} DEPENDS ${LinkDefh})
+	add_custom_command(OUTPUT ${DictC} COMMAND rootcint ARGS -f ${DictC} -c -p ${Dicth} ${LinkDefh} DEPENDS ${LinkDefh})
 endforeach(LinkDefh)
 
 add_custom_command (
   OUTPUT PHHepMC_io_Dict.C
   COMMAND rootcint
-  ARGS -f PHHepMC_io_Dict.C -c
-  -I$ENV{OFFLINE_MAIN}/include
+  ARGS -f PHHepMC_io_Dict.C -c -p
   ${PROJECT_SOURCE_DIR}/PHGenEvent.h
   ${PROJECT_SOURCE_DIR}/PHGenEventv1.h
   ${PROJECT_SOURCE_DIR}/PHGenEventList.h
   ${PROJECT_SOURCE_DIR}/PHGenEventListv1.h
   ${PROJECT_SOURCE_DIR}/PHHepMCGenEvent.h
   ${PROJECT_SOURCE_DIR}/PHHepMCGenEventMap.h
-  $ENV{OFFLINE_MAIN}/include/HepMC/*.h
+	$ENV{DIR_E1039_SHARE}/include/HepMC/*.h
   ${PROJECT_SOURCE_DIR}/PHHepMCLinkDef.h
 	)
 

--- a/generators/phhepmc/CMakeLists.txt
+++ b/generators/phhepmc/CMakeLists.txt
@@ -32,7 +32,7 @@ add_custom_command (
   ${PROJECT_SOURCE_DIR}/PHGenEventListv1.h
   ${PROJECT_SOURCE_DIR}/PHHepMCGenEvent.h
   ${PROJECT_SOURCE_DIR}/PHHepMCGenEventMap.h
-	$ENV{DIR_E1039_SHARE}/include/HepMC/*.h
+	$ENV{E1039_SHARE}/include/HepMC/*.h
   ${PROJECT_SOURCE_DIR}/PHHepMCLinkDef.h
 	)
 

--- a/packages/global_consts/GlobalConsts.h
+++ b/packages/global_consts/GlobalConsts.h
@@ -41,14 +41,14 @@
 #define nHodoPlanes 16
 #define nPropPlanes 8
 
-#define FMAGSTR 1.054
-#define KMAGSTR 0.951
+//#define FMAGSTR 1.054
+//#define KMAGSTR 0.951
 
 #define Z_KMAG_BEND 1064.26
 #define Z_FMAG_BEND 251.4
 #define Z_KFMAG_BEND 375.
-#define PT_KICK_FMAG 2.909*FMAGSTR
-#define PT_KICK_KMAG 0.4016*KMAGSTR
+//#define PT_KICK_FMAG 2.909*FMAGSTR
+//#define PT_KICK_KMAG 0.4016*KMAGSTR
 #define ELOSS_KFMAG 8.12
 #define ELOSS_ABSORBER 1.81
 #define Z_ST2 1347.36

--- a/packages/jobopts_svc/JobOptsSvc.cxx
+++ b/packages/jobopts_svc/JobOptsSvc.cxx
@@ -380,8 +380,8 @@ void JobOptsSvc::save(TFile* saveFile, TString name)
 
     TString s_fmagFile = m_fMagFile;
     TString s_kmagFile = m_kMagFile;
-    TString s_fmagStr  = Form("%.3f", FMAGSTR);
-    TString s_kmagStr  = Form("%.3f", KMAGSTR);
+    //TString s_fmagStr  = Form("%.3f", FMAGSTR);
+    //TString s_kmagStr  = Form("%.3f", KMAGSTR);
 
     TString s_st0Reject = Form("%.4f", m_st0_reject);
     TString s_st1Reject = Form("%.4f", m_st1_reject);
@@ -433,8 +433,8 @@ void JobOptsSvc::save(TFile* saveFile, TString name)
     saveTree->Branch("Calibration", &s_calibrationFile);
     saveTree->Branch("FMag", &s_fmagFile);
     saveTree->Branch("KMag", &s_kmagFile);
-    saveTree->Branch("FMagStr", &s_fmagStr);
-    saveTree->Branch("KMagStr", &s_kmagStr);
+    //saveTree->Branch("FMagStr", &s_fmagStr);
+    //saveTree->Branch("KMagStr", &s_kmagStr);
     saveTree->Branch("Geometry", &s_geomVersion);
     saveTree->Branch("TimingOffset", &s_timingOffset);
     saveTree->Branch("kTrackerVer", &s_softver);

--- a/packages/ktracker/EventReducer.cxx
+++ b/packages/ktracker/EventReducer.cxx
@@ -124,9 +124,7 @@ int EventReducer::reduceEvent(SRawEvent* rawEvent)
 
     //apply hodoscope mask
     hodohitlist.sort();
-    LogInfo(hitlist.size());
     if(hodomask) hodoscopeMask(hitlist, hodohitlist);
-    LogInfo(hitlist.size());
 
     //Remove after hits
     hitlist.sort();

--- a/packages/ktracker/FastTracklet.cxx
+++ b/packages/ktracker/FastTracklet.cxx
@@ -448,7 +448,7 @@ Tracklet::Tracklet() : stationID(-1), nXHits(0), nUHits(0), nVHits(0), chisq(999
     kmag_on = JobOptsSvc::instance()->m_enableKMag;
     FMAGSTR = recoConsts::instance()->get_DoubleFlag("FMAGSTR");
     KMAGSTR = recoConsts::instance()->get_DoubleFlag("KMAGSTR");
-    PT_KICK_FMAG = 2.909*FMAGSTR
+    PT_KICK_FMAG = 2.909*FMAGSTR;
     PT_KICK_KMAG = 0.4016*KMAGSTR;
 }
 

--- a/packages/ktracker/FastTracklet.cxx
+++ b/packages/ktracker/FastTracklet.cxx
@@ -432,7 +432,11 @@ namespace {
 	static bool kmag_on = true;
 
 	//static flag of kmag strength
-	static double kmag_str = 1.0;
+	static double FMAGSTR = 1.0;
+	static double KMAGSTR = 1.0;
+
+	static double PT_KICK_FMAG = 2.909;
+	static double PT_KICK_KMAG = 0.4016;
 }
 //@}
 
@@ -442,7 +446,10 @@ Tracklet::Tracklet() : stationID(-1), nXHits(0), nUHits(0), nVHits(0), chisq(999
 
     p_geomSvc = GeomSvc::instance();
     kmag_on = JobOptsSvc::instance()->m_enableKMag;
-    kmag_str = recoConsts::instance()->get_DoubleFlag("KMAGSTR");
+    FMAGSTR = recoConsts::instance()->get_DoubleFlag("FMAGSTR");
+    KMAGSTR = recoConsts::instance()->get_DoubleFlag("KMAGSTR");
+    PT_KICK_FMAG = 2.909*FMAGSTR
+    PT_KICK_KMAG = 0.4016*KMAGSTR;
 }
 
 bool Tracklet::isValid()
@@ -770,7 +777,7 @@ double Tracklet::getMomentum() const
 
 int Tracklet::getCharge() const
 {
-	return x0*kmag_str > tx ? 1 : -1;
+	return x0*KMAGSTR > tx ? 1 : -1;
 }
 
 void Tracklet::getXZInfoInSt1(double& tx_st1, double& x0_st1)
@@ -1115,5 +1122,5 @@ void Tracklet::print()
 
     cout << "KMAG projection: X =  " << getExpPositionX(Z_KMAG_BEND) << " +/- " << getExpPosErrorX(Z_KMAG_BEND) << endl;
     cout << "KMAG projection: Y =  " << getExpPositionY(Z_KMAG_BEND) << " +/- " << getExpPosErrorY(Z_KMAG_BEND) << endl;
-    cout << "kmag_str =  " << kmag_str << endl;
+    cout << "KMAGSTR =  " << KMAGSTR << endl;
 }

--- a/packages/ktracker/FastTracklet.cxx
+++ b/packages/ktracker/FastTracklet.cxx
@@ -7,6 +7,8 @@ Author: Kun Liu, liuk@fnal.gov
 Created: 05-28-2013
 */
 
+#include <phool/recoConsts.h>
+
 #include <iostream>
 #include <algorithm>
 #include <cmath>
@@ -415,8 +417,24 @@ void PropSegment::linearFit_iterative()
 }
 
 //General tracklet part
+
+//<TODO improve this part
+//@{
+// Original imp.
 //const GeomSvc* Tracklet::p_geomSvc = GeomSvc::instance();
 //const bool Tracklet::kmag_on = JobOptsSvc::instance()->m_enableKMag;
+
+namespace {
+	//static pointer to geomtry service
+	static GeomSvc* p_geomSvc = nullptr;
+
+	//static flag of kmag on/off
+	static bool kmag_on = true;
+
+	//static flag of kmag strength
+	static double kmag_str = 1.0;
+}
+//@}
 
 Tracklet::Tracklet() : stationID(-1), nXHits(0), nUHits(0), nVHits(0), chisq(9999.), chisq_vtx(9999.), tx(0.), ty(0.), x0(0.), y0(0.), invP(0.1), err_tx(-1.), err_ty(-1.), err_x0(-1.), err_y0(-1.), err_invP(-1.)
 {
@@ -424,6 +442,7 @@ Tracklet::Tracklet() : stationID(-1), nXHits(0), nUHits(0), nVHits(0), chisq(999
 
     p_geomSvc = GeomSvc::instance();
     kmag_on = JobOptsSvc::instance()->m_enableKMag;
+    kmag_str = recoConsts::instance()->get_DoubleFlag("KMAGSTR");
 }
 
 bool Tracklet::isValid()
@@ -747,6 +766,11 @@ double Tracklet::getMomentum() const
     }
 
     return p;
+}
+
+int Tracklet::getCharge() const
+{
+	return x0*kmag_str > tx ? 1 : -1;
 }
 
 void Tracklet::getXZInfoInSt1(double& tx_st1, double& x0_st1)
@@ -1091,4 +1115,5 @@ void Tracklet::print()
 
     cout << "KMAG projection: X =  " << getExpPositionX(Z_KMAG_BEND) << " +/- " << getExpPosErrorX(Z_KMAG_BEND) << endl;
     cout << "KMAG projection: Y =  " << getExpPositionY(Z_KMAG_BEND) << " +/- " << getExpPosErrorY(Z_KMAG_BEND) << endl;
+    cout << "kmag_str =  " << kmag_str << endl;
 }

--- a/packages/ktracker/FastTracklet.h
+++ b/packages/ktracker/FastTracklet.h
@@ -168,7 +168,8 @@ public:
     double getMomentum() const;
 
     //Decide charge by KMag bending direction
-    int getCharge() const { return x0*KMAGSTR > tx ? 1 : -1; }
+    //int getCharge() const { return x0*KMAGSTR > tx ? 1 : -1; }
+    int getCharge() const;
 
     //Get the slope and intersection in station 1
     void getXZInfoInSt1(double& tx_st1, double& x0_st1);
@@ -229,16 +230,6 @@ public:
 
     //Residuals of all pos
     double residual[nChamberPlanes];
-
-#ifndef __CINT__
-    //static pointer to geomtry service
-    //static const GeomSvc* p_geomSvc;
-    GeomSvc* p_geomSvc;
-
-    //static flag of kmag on/off
-    //static const bool kmag_on;
-    bool kmag_on;
-#endif
 
     ClassDef(Tracklet, 4)
 };

--- a/packages/ktracker/Fun4AllSRawEventInputManager.cxx
+++ b/packages/ktracker/Fun4AllSRawEventInputManager.cxx
@@ -159,20 +159,12 @@ int Fun4AllSRawEventInputManager::run(const int nevents)
 	}
   
 	_tin->GetEntry(events_thisfile);
-	rawEvent = _b_srawEvent->Clone();
+	rawEvent->DeepClone(_b_srawEvent);
 	events_thisfile++;
 	events_total++;
 
-	if (verbosity > 1) {
-		cout << ThisName << ":  run " << _b_srawEvent->getRunID()
-				<< ", spill " << _b_srawEvent->getSpillID()
-				<< ", event " << _b_srawEvent->getEventID() << endl;
-	}
-
-	if (verbosity > 1) {
-		cout << ThisName << ":  run " << rawEvent->getRunID()
-				<< ", spill " << rawEvent->getSpillID()
-				<< ", event " << rawEvent->getEventID() << endl;
+	if (verbosity > Fun4AllBase::VERBOSITY_A_LOT) {
+		rawEvent->identify();
 	}
 
   SetRunNumber                (rawEvent->getRunID());

--- a/packages/ktracker/Fun4AllSRawEventInputManager.cxx
+++ b/packages/ktracker/Fun4AllSRawEventInputManager.cxx
@@ -1,0 +1,363 @@
+#include "Fun4AllSRawEventInputManager.h"
+
+#include "SRawEvent.h"
+
+//#include <event/EVIO_Event.h>
+//#include <interface_main/SQHit_v1.h>
+//#include <interface_main/SQHitVector_v1.h>
+//#include <interface_main/SQEvent_v1.h>
+//#include <interface_main/SQRun_v1.h>
+//#include <interface_main/SQSpill_v2.h>
+//#include <interface_main/SQSpillMap_v1.h>
+//#include <interface_main/SQStringMap.h>
+//#include <interface_main/SQScaler_v1.h>
+//#include <interface_main/SQSlowCont_v1.h>
+ 
+#include <fun4all/Fun4AllServer.h>
+#include <fun4all/Fun4AllSyncManager.h>
+#include <fun4all/Fun4AllReturnCodes.h>
+#include <fun4all/Fun4AllUtils.h>
+#include <fun4all/PHTFileServer.h>
+
+#include <ffaobjects/RunHeader.h>
+#include <ffaobjects/SyncObjectv2.h>
+
+#include <phool/getClass.h>
+#include <phool/PHCompositeNode.h>
+#include <phool/PHDataNode.h>
+#include <phool/recoConsts.h>
+#include <cstdlib>
+#include <memory>
+
+#include <TFile.h>
+#include <TTree.h>
+
+//#include <boost/tokenizer.hpp>
+//#include <boost/foreach.hpp>
+//#include <boost/lexical_cast.hpp>
+
+using namespace std;
+
+Fun4AllSRawEventInputManager::Fun4AllSRawEventInputManager(const string &name, const string &topnodename) :
+ Fun4AllInputManager(name, ""),
+ segment(-999),
+ isopen(0),
+ events_total(0),
+ events_thisfile(0),
+ topNodeName(topnodename),
+ _tree_name("save"),
+ _branch_name("rawEvent")
+{
+  Fun4AllServer *se = Fun4AllServer::instance();
+  topNode = se->topNode(topNodeName.c_str());
+  PHNodeIterator iter(topNode);
+
+  PHCompositeNode* runNode = static_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "RUN"));
+  if (!runNode) {
+    runNode = new PHCompositeNode("RUN");
+    topNode->addNode(runNode);
+  }
+  
+  PHCompositeNode* eventNode = static_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "DST"));
+  if (!eventNode) {
+    eventNode = new PHCompositeNode("DST");
+    topNode->addNode(eventNode);
+  }
+  
+	PHIODataNode<PHObject>* rawEventNode = new PHIODataNode<PHObject>(new SRawEvent(),"SRawEvent", "PHObject");
+	eventNode->addNode(rawEventNode);
+  
+  syncobject = new SyncObjectv2();
+  return ;
+}
+
+Fun4AllSRawEventInputManager::~Fun4AllSRawEventInputManager()
+{
+  if (isopen)
+    {
+      fileclose();
+    }
+  delete syncobject;
+}
+
+int Fun4AllSRawEventInputManager::fileopen(const string &filenam)
+{
+  if (isopen)
+    {
+      cout << "Closing currently open file "
+           << filename
+           << " and opening " << filenam << endl;
+      fileclose();
+    }
+  filename = filenam;
+  //FROG frog;
+  //string fname = frog.location(filename.c_str());
+  string fname = filename;
+  if (verbosity > 0)
+    {
+      cout << ThisName << ": opening file " << filename.c_str() << endl;
+    }
+
+  events_thisfile = 0;
+
+  //PHTFileServer::get().open(filenam.c_str(), "READ");
+  _fin = TFile::Open(filenam.c_str(), "READ");
+  _tin = (TTree*) _fin->Get(_tree_name.c_str());
+
+  if (!_tin) {
+    cerr << "!!ERROR!! Failed at file open (" << filenam.c_str() << ").  Exit.\n";
+    cout << PHWHERE << ThisName << ": could not open file " << fname << endl;
+    return -1;
+  }
+
+  _b_srawEvent = new SRawEvent();
+  _tin->SetBranchAddress(_branch_name.c_str(), &_b_srawEvent);
+
+  //TODO check branch status
+
+  //pair<int, int> runseg = Fun4AllUtils::GetRunSegment(fname);
+  //segment = runseg.second;
+  segment = 0;
+  isopen = 1;
+  AddToFileOpened(fname); // add file to the list of files which were opened
+  return 0;
+}
+
+int Fun4AllSRawEventInputManager::run(const int nevents)
+{
+  //cout << "Fun4AllSRawEventInputManager::run(): " << nevents << endl;
+  readagain:
+  if (!isopen) {
+		if (filelist.empty())
+
+		{
+			if (verbosity > 0) {
+				cout << Name() << ": No Input file open" << endl;
+			}
+			return -1;
+		} else {
+			if (OpenNextFile()) {
+				cout << Name() << ": No Input file from filelist opened" << endl;
+				return -1;
+			}
+		}
+	}
+	if (verbosity > 3) {
+		cout << "Getting Event from " << Name() << endl;
+	}
+  //  cout << "running event " << nevents << endl;
+  //PHNodeIterator iter(topNode);
+
+  SRawEvent* rawEvent = findNode::getClass<SRawEvent>(topNode, "SRawEvent");
+  if (!rawEvent) {
+    return Fun4AllReturnCodes::ABORTEVENT;
+  }
+
+	if (events_thisfile>=_tin->GetEntries()) {
+		fileclose();
+		goto readagain;
+	}
+  
+	_tin->GetEntry(events_thisfile);
+	rawEvent = _b_srawEvent->Clone();
+	events_thisfile++;
+	events_total++;
+
+	if (verbosity > 1) {
+		cout << ThisName << ":  run " << _b_srawEvent->getRunID()
+				<< ", spill " << _b_srawEvent->getSpillID()
+				<< ", event " << _b_srawEvent->getEventID() << endl;
+	}
+
+	if (verbosity > 1) {
+		cout << ThisName << ":  run " << rawEvent->getRunID()
+				<< ", spill " << rawEvent->getSpillID()
+				<< ", event " << rawEvent->getEventID() << endl;
+	}
+
+  SetRunNumber                (rawEvent->getRunID());
+  mySyncManager->PrdfEvents   (events_thisfile);
+  mySyncManager->SegmentNumber(rawEvent->getSpillID());
+  mySyncManager->CurrentEvent (rawEvent->getEventID());
+
+  syncobject->RunNumber       (rawEvent->getRunID());
+  syncobject->EventCounter    (events_thisfile);
+  syncobject->SegmentNumber   (rawEvent->getSpillID());
+  syncobject->EventNumber     (rawEvent->getEventID());
+
+  // check if the local SubsysReco discards this event
+  if (RejectEvent() != Fun4AllReturnCodes::EVENT_OK)
+    {
+      ResetEvent();
+      goto readagain;
+    }
+  return 0;
+}
+
+int Fun4AllSRawEventInputManager::fileclose()
+{
+	if (!isopen) {
+		cout << Name() << ": fileclose: No Input file open" << endl;
+		return -1;
+	}
+
+	_fin->Close();
+	isopen = 0;
+
+	// if we have a file list, move next entry to top of the list
+	// or repeat the same entry again
+	if (!filelist.empty()) {
+		if (repeat) {
+			filelist.push_back(*(filelist.begin()));
+			if (repeat > 0) {
+				repeat--;
+			}
+		}
+		filelist.pop_front();
+	}
+
+	return 0;
+}
+
+
+void
+Fun4AllSRawEventInputManager::Print(const string &what) const
+{
+  Fun4AllInputManager::Print(what);
+  return ;
+}
+
+int
+Fun4AllSRawEventInputManager::OpenNextFile()
+{
+  while (!filelist.empty())
+    {
+      list<string>::const_iterator iter = filelist.begin();
+      if (verbosity)
+        {
+          cout << PHWHERE << " opening next file: " << *iter << endl;
+        }
+      if (fileopen(*iter))
+        {
+          cout << PHWHERE << " could not open file: " << *iter << endl;
+          filelist.pop_front();
+        }
+      else
+        {
+          return 0;
+        }
+
+    }
+  return -1;
+}
+
+int
+Fun4AllSRawEventInputManager::ResetEvent()
+{
+  //PHNodeIterator iter(topNode);
+  //PHDataNode<Event> *PrdfNode = dynamic_cast<PHDataNode<Event> *>(iter.findFirst("PHDataNode","EVIO"));
+  //PrdfNode->setData(NULL); // set pointer in Node to NULL before deleting it
+  //delete evt;
+  //evt = NULL;
+  syncobject->Reset();
+  return 0;
+}
+
+int
+Fun4AllSRawEventInputManager::PushBackEvents(const int i)
+{
+  cerr << "!!ERROR!!  PushBackEvents():  Not implemented yet." << endl;
+  // PushBackEvents is supposedly pushing events back on the stack which works
+  // easily with root trees (just grab a different entry) but hard in these HepMC ASCII files.
+  // A special case is when the synchronization fails and we need to only push back a single
+  // event. In this case we save the evt pointer as save_evt which is used in the run method
+  // instead of getting the next event.
+//  if (i > 0)
+//    {
+//      if (i == 1 && evt) // check on evt pointer makes sure it is not done from the cmd line
+//	{
+//	  save_evt = evt;
+//	  return 0;
+//	}
+//      cout << PHWHERE << ThisName
+//           << " Fun4AllSRawEventInputManager cannot push back " << i << " events into file"
+//           << endl;
+//      return -1;
+//    }
+//  if (!parser->coda)
+//    {
+//      cout << PHWHERE << ThisName
+//	   << " no file open" << endl;
+//      return -1;
+//    }
+  // Skipping events is implemented as
+  // pushing a negative number of events on the stack, so in order to implement
+  // the skipping of events we read -i events.
+//  int nevents = -i; // negative number of events to push back -> skip num events
+//  int errorflag = 0;
+//  while (nevents > 0 && ! errorflag)
+//    {
+//			int * data_ptr = NULL;
+//			unsigned int coda_id = 0;
+//			if(parser->coda->NextCodaEvent(coda_id, data_ptr))
+//				evt = new EVIO_Event(data_ptr);
+//      if (! evt)
+//	{
+//	  cout << "Error after skipping " << i - nevents 
+//	       << " file exhausted?" << endl;
+//	  errorflag = -1;
+//          fileclose();
+//	}
+//      else
+//	{
+//	  if (verbosity > 3)
+//	    {
+//	  		//TODO implement this
+//	      //cout << "Skipping evt no: " << evt->getEvtSequence() << endl;
+//	    }
+//	}
+//      delete evt;
+//      nevents--;
+//    }
+//  return errorflag;
+  return -1;
+}
+
+int
+Fun4AllSRawEventInputManager::GetSyncObject(SyncObject **mastersync)
+{
+  // here we copy the sync object from the current file to the
+  // location pointed to by mastersync. If mastersync is a 0 pointer
+  // the syncobject is cloned. If mastersync allready exists the content
+  // of syncobject is copied
+  if (!(*mastersync))
+    {
+      if (syncobject) *mastersync = syncobject->clone();
+    }
+  else
+    {
+      *(*mastersync) = *syncobject; // copy syncobject content
+    }
+  return Fun4AllReturnCodes::SYNC_OK;
+}
+
+int
+Fun4AllSRawEventInputManager::SyncIt(const SyncObject *mastersync)
+{
+  if (!mastersync)
+    {
+      cout << PHWHERE << Name() << " No MasterSync object, cannot perform synchronization" << endl;
+      cout << "Most likely your first file does not contain a SyncObject and the file" << endl;
+      cout << "opened by the Fun4AllDstInputManager with Name " << Name() << " has one" << endl;
+      cout << "Change your macro and use the file opened by this input manager as first input" << endl;
+      cout << "and you will be okay. Fun4All will not process the current configuration" << endl << endl;
+      return Fun4AllReturnCodes::SYNC_FAIL;
+    }
+  int iret = syncobject->Different(mastersync);
+  if (iret)
+    {
+      cout << "big problem" << endl;
+      exit(1);
+    }
+  return Fun4AllReturnCodes::SYNC_OK;
+}

--- a/packages/ktracker/Fun4AllSRawEventInputManager.h
+++ b/packages/ktracker/Fun4AllSRawEventInputManager.h
@@ -1,0 +1,67 @@
+#ifndef Fun4AllSRawEventInputManager_H_
+#define Fun4AllSRawEventInputManager_H_
+
+#include <fun4all/Fun4AllInputManager.h>
+
+#include <string>
+#include <map>
+
+
+class PHCompositeNode;
+class SyncObject;
+
+class TFile;
+class TTree;
+class SRawEvent;
+
+class Fun4AllSRawEventInputManager : public Fun4AllInputManager
+{
+ public:
+  Fun4AllSRawEventInputManager(const std::string &name = "DUMMY", const std::string &topnodename = "TOP");
+  virtual ~Fun4AllSRawEventInputManager();
+  int fileopen(const std::string &filenam);
+  int fileclose();
+  int run(const int nevents = 0);
+  int isOpen() {return isopen;}
+
+  void Print(const std::string &what = "ALL") const;
+  int ResetEvent();
+  int PushBackEvents(const int i);
+  int GetSyncObject(SyncObject **mastersync);
+  int SyncIt(const SyncObject *mastersync);
+
+	const std::string& get_branch_name() const {
+		return _branch_name;
+	}
+
+	void set_branch_name(const std::string& branchName) {
+		_branch_name = branchName;
+	}
+
+	const std::string& get_tree_name() const {
+		return _tree_name;
+	}
+
+	void set_tree_name(const std::string& treeName) {
+		_tree_name = treeName;
+	}
+
+ protected:
+  int OpenNextFile();
+  int segment;
+  int isopen;
+  int events_total;
+  int events_thisfile;
+  std::string topNodeName;
+  PHCompositeNode *topNode;
+  SyncObject* syncobject;
+
+  std::string _tree_name;
+  std::string _branch_name;
+
+  TFile* _fin;
+  TTree* _tin;
+  SRawEvent* _b_srawEvent;
+};
+
+#endif /* __Fun4AllSRawEventInputManager_H_ */

--- a/packages/ktracker/Fun4AllSRawEventInputManagerLinkDef.h
+++ b/packages/ktracker/Fun4AllSRawEventInputManagerLinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class Fun4AllSRawEventInputManager-!;
+
+#endif /* __CINT__ */

--- a/packages/ktracker/KalmanDSTrk.cxx
+++ b/packages/ktracker/KalmanDSTrk.cxx
@@ -1615,9 +1615,10 @@ void KalmanDSTrk::buildTrackletsInStation(int stationID, int listID, double* pos
                 {
                     continue;
                 }
-
 #ifdef _DEBUG_ON
-                tracklet_new.print();
+                if(Verbosity()>=Fun4AllBase::VERBOSITY_A_LOT) {
+                	tracklet_new.print();
+                }
 #endif
                 if(acceptTracklet(tracklet_new))
                 {

--- a/packages/ktracker/KalmanDSTrk.cxx
+++ b/packages/ktracker/KalmanDSTrk.cxx
@@ -868,11 +868,13 @@ void KalmanDSTrk::buildBackPartialTracks()
     _timers["st23"]->stop();
 
 #ifdef _DEBUG_YUHW_
-  	LogInfo("");
-  	std::cout
-		<< counter["in"] << " => "
-		<< counter["DS"] << " => "
-		<< counter["out"] << std::endl;
+    if(Verbosity() >= Fun4AllBase::VERBOSITY_A_LOT) {
+			LogInfo("");
+			std::cout
+			<< counter["in"] << " => "
+			<< counter["DS"] << " => "
+			<< counter["out"] << std::endl;
+    }
 
     if(_ana_mode) {
 			float tana_data[] = {
@@ -1112,11 +1114,13 @@ void KalmanDSTrk::buildGlobalTracks()
     _timers["global"]->stop();
 
 #ifdef _DEBUG_YUHW_
-		LogInfo("");
-		std::cout
-		<< counter["in"] << " => "
-		<< counter["DS"] << " => "
-		<< counter["out"] << std::endl;
+    if(Verbosity() >= Fun4AllBase::VERBOSITY_A_LOT) {
+			LogInfo("");
+			std::cout
+			<< counter["in"] << " => "
+			<< counter["DS"] << " => "
+			<< counter["out"] << std::endl;
+    }
 
 		if(_ana_mode) {
 			float tana_data[] = {
@@ -1214,15 +1218,10 @@ void KalmanDSTrk::resolveLeftRight(Tracklet& tracklet, double threshold)
             //LogInfo("Final: " << index_min << "  " << pull_min);
             if(index_min >= 0 && pull_min < threshold)//((tracklet.stationID == 5 && pull_min < 25.) || (tracklet.stationID == 6 && pull_min < 100.)))
             {
-            	//FIXME temp for debug purpose
-							//hit1->sign = possibility[index_min][0];
-							//hit2->sign = possibility[index_min][1];
-
-            	//FIXME temp for debug purpose
-            	hit1->sign = hit1->hit.driftDistance > 0 ? 1 : -1;
-            	hit2->sign = hit2->hit.driftDistance > 0 ? 1 : -1;
-
-                isUpdated = true;
+            	//Origin imp.
+							hit1->sign = possibility[index_min][0];
+							hit2->sign = possibility[index_min][1];
+              isUpdated = true;
             }
         }
 
@@ -1234,8 +1233,13 @@ void KalmanDSTrk::resolveLeftRight(Tracklet& tracklet, double threshold)
         ++hit2;
         ++hit2;
     }
-
+#ifdef _DEBUG_ON
+    tracklet.print();
+#endif
     if(isUpdated) fitTracklet(tracklet);
+#ifdef _DEBUG_ON
+    tracklet.print();
+#endif
 }
 
 void KalmanDSTrk::resolveSingleLeftRight(Tracklet& tracklet)
@@ -1633,11 +1637,13 @@ void KalmanDSTrk::buildTrackletsInStation(int stationID, int listID, double* pos
     }
 
 #ifdef _DEBUG_YUHW_
-  	LogInfo("");
-  	std::cout
-		<< counter["in"] << " => "
-		<< counter["DS"] << " => "
-		<< counter["out"] << std::endl;
+    if(Verbosity() >= Fun4AllBase::VERBOSITY_A_LOT) {
+			LogInfo("");
+			std::cout
+			<< counter["in"] << " => "
+			<< counter["DS"] << " => "
+			<< counter["out"] << std::endl;
+    }
 
     if(_ana_mode) {
 			float tana_data[] = {

--- a/packages/ktracker/KalmanFastTrackingWrapper.cxx
+++ b/packages/ktracker/KalmanFastTrackingWrapper.cxx
@@ -56,6 +56,7 @@ using namespace std;
 
 KalmanFastTrackingWrapper::KalmanFastTrackingWrapper(const std::string& name) :
 SubsysReco(name),
+ _input_type(KalmanFastTrackingWrapper::E1039),
 _enable_KF(true),
 _enable_event_reducer(false),
 _DS_level(KalmanDSTrk::NO_DS),
@@ -321,23 +322,25 @@ int KalmanFastTrackingWrapper::process_event(PHCompositeNode* topNode) {
 
 	if(!_hit_vector) {
 		LogDebug("!_hit_vector");
-		return Fun4AllReturnCodes::ABORTRUN;
+		//return Fun4AllReturnCodes::ABORTRUN;
 	}
 
-	auto up_raw_event = std::unique_ptr<SRawEvent>(BuildSRawEvent());
-	SRawEvent* sraw_event = up_raw_event.get();
+	if(_input_type == KalmanFastTrackingWrapper::E1039) {
+		auto up_raw_event = std::unique_ptr<SRawEvent>(BuildSRawEvent());
+		_rawEvent = up_raw_event.get();
+	}
+
+	_rawEvent->identify();
 
   if(_enable_event_reducer){
-	  eventReducer->reduceEvent(sraw_event);
-		ReMaskHits(sraw_event);
+	  eventReducer->reduceEvent(_rawEvent);
+		ReMaskHits(_rawEvent);
   }
-
-	_rawEvent = sraw_event;
 
 	//auto up_recEvent = std::unique_ptr<SRecEvent>(new SRecEvent());
 	//_recEvent = up_recEvent.get();
 
-	_recEvent->setRecStatus(fastfinder->setRawEvent(sraw_event));
+	_recEvent->setRecStatus(fastfinder->setRawEvent(_rawEvent));
 
   if(verbosity >= 2)
   	fastfinder->printTimers();
@@ -373,7 +376,6 @@ int KalmanFastTrackingWrapper::process_event(PHCompositeNode* topNode) {
 	}
 #endif
 
-
 	_tout->Fill();
 
 	if(Verbosity() >= Fun4AllBase::VERBOSITY_SOME)
@@ -397,13 +399,13 @@ int KalmanFastTrackingWrapper::End(PHCompositeNode* topNode) {
 
 int KalmanFastTrackingWrapper::InitEvalTree() {
 
-	_rawEvent = nullptr;
+	//_rawEvent = nullptr;
 	_recEvent = nullptr;
 
 	PHTFileServer::get().open(_out_name.c_str(), "RECREATE");
 
 	_tout = new TTree("T", "save");
-	_tout->Branch("rawEvent", &_rawEvent, 256000, 99);
+	//_tout->Branch("rawEvent", &_rawEvent, 256000, 99);
 	_tout->Branch("recEvent", &_recEvent, 256000, 99);
 
 	return 0;
@@ -426,6 +428,26 @@ int KalmanFastTrackingWrapper::MakeNodes(PHCompositeNode* topNode) {
 		eventNode = new PHCompositeNode("DST");
 		topNode->addNode(eventNode);
 	}
+
+//	_rawEvent_orig = findNode::getClass<SRecEvent>(topNode, "SRawEvent");
+//	if (_rawEvent_orig) {
+//		if(Verbosity() > 0) LogInfo("Using SRawEvent as input!");
+//		_input_type = KalmanFastTrackingWrapper::E906;
+//	}
+//	else {
+//		_input_type = KalmanFastTrackingWrapper::E1039;
+//		_rawEvent_orig = new SRawEvent();
+//		PHIODataNode<PHObject>* rawEventNode = new PHIODataNode<PHObject>(_rawEvent_orig,"SRawEvent", "PHObject");
+//		eventNode->addNode(rawEventNode);
+//		if (verbosity >= Fun4AllBase::VERBOSITY_SOME)
+//			LogInfo("DST/SRawEvent Added");
+//	}
+
+//	_rawEvent_redu = new SRawEvent();
+//	PHIODataNode<PHObject>* rawreduEventNode = new PHIODataNode<PHObject>(_rawEvent_redu,"SRawEventReduced", "PHObject");
+//	eventNode->addNode(rawreduEventNode);
+//	if (verbosity >= Fun4AllBase::VERBOSITY_SOME)
+//		LogInfo("DST/SRawEventReduced Added");
 
 	_recEvent = new SRecEvent();
 	PHIODataNode<PHObject>* recEventNode = new PHIODataNode<PHObject>(_recEvent,"SRecEvent", "PHObject");
@@ -460,7 +482,7 @@ int KalmanFastTrackingWrapper::GetNodes(PHCompositeNode* topNode) {
 		_hit_map = findNode::getClass<SQHitMap>(topNode, "SQHitMap");
 		if (!_hit_map) {
 			LogError("!_hit_map");
-			return Fun4AllReturnCodes::ABORTEVENT;
+			//return Fun4AllReturnCodes::ABORTEVENT;
 		}
 	}
 
@@ -468,7 +490,7 @@ int KalmanFastTrackingWrapper::GetNodes(PHCompositeNode* topNode) {
 		_hit_vector = findNode::getClass<SQHitVector>(topNode, "SQHitVector");
 		if (!_hit_vector) {
 			LogError("!_hit_vector");
-			return Fun4AllReturnCodes::ABORTEVENT;
+			//return Fun4AllReturnCodes::ABORTEVENT;
 		}
 
 		_triggerhit_vector = findNode::getClass<SQHitVector>(topNode, "SQTriggerHitVector");
@@ -478,11 +500,28 @@ int KalmanFastTrackingWrapper::GetNodes(PHCompositeNode* topNode) {
 		}
 	}
 
+	_rawEvent = findNode::getClass<SRawEvent>(topNode, "SRawEvent");
+	if (_rawEvent) {
+		if(Verbosity() > 0) LogInfo("Using SRawEvent as input!");
+		_input_type = KalmanFastTrackingWrapper::E906;
+	}
+
 	_recEvent = findNode::getClass<SRecEvent>(topNode, "SRecEvent");
 	if (!_recEvent) {
 		if(Verbosity() > 2) LogError("!_recEvent");
 		return Fun4AllReturnCodes::ABORTEVENT;
 	}
+
+//	_rawEvent = findNode::getClass<SRecEvent>(topNode, "SRecEvent");
+//	if (!_rawEvent_orig) {
+//		if(Verbosity() > 2) LogError("!_rawEvent_orig");
+//		return Fun4AllReturnCodes::ABORTEVENT;
+//	}
+//	_rawEvent_redu = findNode::getClass<SRecEvent>(topNode, "SRawEventReduced");
+//	if (!_rawEvent_redu) {
+//		if(Verbosity() > 2) LogError("!_rawEvent_redu");
+//		return Fun4AllReturnCodes::ABORTEVENT;
+//	}
 
 	return Fun4AllReturnCodes::EVENT_OK;
 }

--- a/packages/ktracker/KalmanFastTrackingWrapper.cxx
+++ b/packages/ktracker/KalmanFastTrackingWrapper.cxx
@@ -334,7 +334,8 @@ int KalmanFastTrackingWrapper::process_event(PHCompositeNode* topNode) {
 
   if(_enable_event_reducer){
 	  eventReducer->reduceEvent(_rawEvent);
-		ReMaskHits(_rawEvent);
+	  if(_input_type == KalmanFastTrackingWrapper::E1039)
+	  	ReMaskHits(_rawEvent);
   }
 
 	//auto up_recEvent = std::unique_ptr<SRecEvent>(new SRecEvent());

--- a/packages/ktracker/KalmanFastTrackingWrapper.cxx
+++ b/packages/ktracker/KalmanFastTrackingWrapper.cxx
@@ -330,7 +330,10 @@ int KalmanFastTrackingWrapper::process_event(PHCompositeNode* topNode) {
 		_rawEvent = up_raw_event.get();
 	}
 
-	_rawEvent->identify();
+	if(verbosity > Fun4AllBase::VERBOSITY_A_LOT) {
+		LogInfo("SRawEvent before the Reducer");
+		_rawEvent->identify();
+	}
 
   if(_enable_event_reducer){
 	  eventReducer->reduceEvent(_rawEvent);
@@ -338,12 +341,17 @@ int KalmanFastTrackingWrapper::process_event(PHCompositeNode* topNode) {
 	  	ReMaskHits(_rawEvent);
   }
 
+	if(verbosity > Fun4AllBase::VERBOSITY_A_LOT) {
+	  LogInfo("SRawEvent after the Reducer");
+		_rawEvent->identify();
+	}
+
 	//auto up_recEvent = std::unique_ptr<SRecEvent>(new SRecEvent());
 	//_recEvent = up_recEvent.get();
 
 	_recEvent->setRecStatus(fastfinder->setRawEvent(_rawEvent));
 
-  if(verbosity >= 2)
+  if(verbosity >= Fun4AllBase::VERBOSITY_A_LOT)
   	fastfinder->printTimers();
 
   _recEvent->setRawEvent(_rawEvent);

--- a/packages/ktracker/KalmanFastTrackingWrapper.cxx
+++ b/packages/ktracker/KalmanFastTrackingWrapper.cxx
@@ -323,8 +323,9 @@ int KalmanFastTrackingWrapper::process_event(PHCompositeNode* topNode) {
 		//return Fun4AllReturnCodes::ABORTRUN;
 	}
 
+	std::unique_ptr<SRawEvent> up_raw_event;
 	if(_input_type == KalmanFastTrackingWrapper::E1039) {
-		auto up_raw_event = std::unique_ptr<SRawEvent>(BuildSRawEvent());
+		up_raw_event = std::unique_ptr<SRawEvent>(BuildSRawEvent());
 		_rawEvent = up_raw_event.get();
 	}
 

--- a/packages/ktracker/KalmanFastTrackingWrapper.cxx
+++ b/packages/ktracker/KalmanFastTrackingWrapper.cxx
@@ -71,9 +71,7 @@ _triggerhit_vector(nullptr),
 _out_name("ktracker_eval.root"),
 _geom_file_name("")
 {
-	//p_jobOptsSvc = new JobOptsSvc();
 	p_jobOptsSvc = JobOptsSvc::instance();
-	p_jobOptsSvc->init("default.opts");
 	LogDebug(p_jobOptsSvc->m_geomVersion);
 }
 

--- a/packages/ktracker/KalmanFastTrackingWrapper.cxx
+++ b/packages/ktracker/KalmanFastTrackingWrapper.cxx
@@ -255,7 +255,7 @@ SRawEvent* KalmanFastTrackingWrapper::BuildSRawEvent() {
     h.detectorID = sq_hit->get_detector_id();
     h.elementID = sq_hit->get_element_id();
     h.tdcTime = sq_hit->get_tdc_time();
-    h.driftDistance = sq_hit->get_drift_distance();
+    h.driftDistance = fabs(sq_hit->get_drift_distance()); //MC L-R info removed here
     h.pos = sq_hit->get_pos();
 
     if(sq_hit->is_in_time()) h.setInTime();

--- a/packages/ktracker/KalmanFastTrackingWrapper.h
+++ b/packages/ktracker/KalmanFastTrackingWrapper.h
@@ -45,6 +45,7 @@ class TGeoManager;
 class KalmanFastTrackingWrapper: public SubsysReco {
 
 public:
+	enum INPUPT_TYPE {E1039, E906};
 
 	KalmanFastTrackingWrapper(const std::string &name = "KalmanFastTrackingWrapper");
 	virtual ~KalmanFastTrackingWrapper() {
@@ -120,6 +121,7 @@ private:
 
 	int ReMaskHits(SRawEvent *sraw_event);
 
+	KalmanFastTrackingWrapper::INPUPT_TYPE _input_type;
 	bool _enable_KF;
 	bool _enable_event_reducer;
 	int _DS_level;

--- a/packages/ktracker/SRawEvent.cxx
+++ b/packages/ktracker/SRawEvent.cxx
@@ -95,6 +95,33 @@ SRawEvent::~SRawEvent()
 {
 }
 
+void SRawEvent::DeepClone(SRawEvent *c)
+{
+    fRunID       = c->getRunID();
+    fEventID     = c->getEventID();
+    fSpillID     = c->getSpillID();
+
+    fTriggerBits = c->getTriggerBits();
+
+    fTargetPos   = c->getTargetPos();
+
+    fTurnID      = c->getTurnID();
+    fRFID        = c->getRFID();
+    for(int i=0; i<33; ++i) fIntensity[i] = c->getIntensity(i);
+
+    setTriggerEmu(c->isEmuTriggered());
+    for(int i=0; i<4; ++i)  fNRoads[i]    = c->getNRoads()[i];
+
+
+    for(Short_t i = 0; i < nChamberPlanes+nHodoPlanes+nPropPlanes+1; i++) {
+        fNHits[i] = c->getNHitsInDetector(i);
+    }
+    fAllHits      = c->getAllHits();
+    fTriggerHits  = c->getTriggerHits();
+
+    return;
+}
+
 void SRawEvent::setEventInfo(Int_t runID, Int_t spillID, Int_t eventID)
 {
     fRunID = runID;

--- a/packages/ktracker/SRawEvent.cxx
+++ b/packages/ktracker/SRawEvent.cxx
@@ -615,19 +615,19 @@ bool SRawEvent::isFPGATriggered()
     return isTriggeredBy(MATRIX1) || isTriggeredBy(MATRIX2) || isTriggeredBy(MATRIX3) || isTriggeredBy(MATRIX4) || isTriggeredBy(MATRIX5);
 }
 
-void SRawEvent::print()
+void SRawEvent::print(std::ostream& os) const
 {
-    std::cout << "RunID: " << fRunID << ", EventID: " << fEventID << "===============" << std::endl;
+    os << "RunID: " << fRunID << ", EventID: " << fEventID << "===============" << std::endl;
     for(Int_t i = 1; i <= nChamberPlanes; i++)
     {
-        std::cout << "Layer " << i << " has " << fNHits[i] << " hits." << std::endl;
+        os << "Layer " << i << " has " << fNHits[i] << " hits." << std::endl;
     }
-    std::cout << "===================================================================" << std::endl;
+    os << "===================================================================" << std::endl;
 
     return;
-    for(std::vector<Hit>::iterator iter = fAllHits.begin(); iter != fAllHits.end(); ++iter)
+    for(auto iter = fAllHits.begin(); iter != fAllHits.end(); ++iter)
     {
         iter->print();
     }
-    std::cout << "===================================================================" << std::endl;
+    os << "===================================================================" << std::endl;
 }

--- a/packages/ktracker/SRawEvent.h
+++ b/packages/ktracker/SRawEvent.h
@@ -105,6 +105,8 @@ public:
     int          isValid() const {return true;}
     SRawEvent*   Clone() const {return (new SRawEvent(*this));}
 
+    void         DeepClone(SRawEvent *c);
+
     ///Gets
     //Hit lists
     std::list<Int_t> getHitsIndexInDetector(Short_t detectorID);

--- a/packages/ktracker/SRawEvent.h
+++ b/packages/ktracker/SRawEvent.h
@@ -14,6 +14,8 @@ Created: 07-02-2012
 
 #include "GlobalConsts.h"
 
+#include <phool/PHObject.h>
+
 #include <iostream>
 #include <vector>
 #include <list>
@@ -29,7 +31,7 @@ Created: 07-02-2012
 class EventReducer;
 
 ///Definition of hit structure
-class Hit: public TObject
+class Hit: public PHObject
 {
 public:
     //Constructor
@@ -37,10 +39,16 @@ public:
     Hit(int uniqueID);
     Hit(int detectorID, int elementID);
 
+    /// PHObject virtual overloads
+    void         identify(std::ostream& os = std::cout) const {print(os);}
+    void         Reset() {*this = Hit();}
+    int          isValid() const {return true;}
+    Hit*         Clone() const {return (new Hit(*this));}
+
     //Decompose the data quality flag
-    bool isInTime() { return (flag & Hit::inTime) != 0; }
-    bool isHodoMask() { return (flag & Hit::hodoMask) != 0; }
-    bool isTriggerMask() { return (flag & Hit::triggerMask) != 0; }
+    bool isInTime() const { return (flag & Hit::inTime) != 0; }
+    bool isHodoMask() const { return (flag & Hit::hodoMask) != 0; }
+    bool isTriggerMask() const { return (flag & Hit::triggerMask) != 0; }
 
     //Set the flag
     void setFlag(UShort_t flag_input) { flag |= flag_input; }
@@ -57,12 +65,13 @@ public:
     Int_t getDetectorID(Int_t uniqueID) { return uniqueID/1000; }
     Int_t getElementID(Int_t uniqueID) { return uniqueID % 1000; }
 
-    //overiden comparison operator for track seeding
+    //overridden comparison operator for track seeding
     bool operator<(const Hit& elem) const;
     bool operator==(const Hit& elem) const;
 
     //Debugging output
-    void print() { std::cout << index << " : " << detectorID << " : " << elementID << " : " << pos << " : " << driftDistance << " : " << isInTime() << " : " << isHodoMask() << " : " << isTriggerMask() << std::endl; }
+    void print(std::ostream& os = std::cout) const
+    { os << index << " : " << detectorID << " : " << elementID << " : " << pos << " : " << driftDistance << " : " << isInTime() << " : " << isHodoMask() << " : " << isTriggerMask() << std::endl; }
 
     //Data members
     Int_t index;             //unique index for identification
@@ -81,14 +90,20 @@ public:
     };
     UShort_t flag;
 
-    ClassDef(Hit, 3)
+    ClassDef(Hit, 4)
 };
 
-class SRawEvent: public TObject
+class SRawEvent: public PHObject
 {
 public:
     SRawEvent();
     ~SRawEvent();
+
+    /// PHObject virtual overloads
+    void         identify(std::ostream& os = std::cout) const { print(os);}
+    void         Reset() {*this = SRawEvent();}
+    int          isValid() const {return true;}
+    SRawEvent*   Clone() const {return (new SRawEvent(*this));}
 
     ///Gets
     //Hit lists
@@ -206,7 +221,7 @@ public:
     void empty() { fAllHits.clear(); fTriggerHits.clear(); }
 
     ///Print for debugging purposes
-    void print();
+    void print (std::ostream& os = std::cout) const;
 
     ///Friend class which handles all kinds of hit list reduction
     friend class EventReducer;
@@ -253,7 +268,7 @@ private:
     std::vector<Hit> fAllHits;
     std::vector<Hit> fTriggerHits;
 
-    ClassDef(SRawEvent, 8)
+    ClassDef(SRawEvent, 9)
 };
 
 class SRawMCEvent: public SRawEvent

--- a/packages/ktracker/SRecEvent.cxx
+++ b/packages/ktracker/SRecEvent.cxx
@@ -16,6 +16,8 @@ Created: 01-21-2013
 #include "KalmanUtil.h"
 #include "KalmanFilter.h"
 
+#include <phool/recoConsts.h>
+
 ClassImp(SRecTrack)
 ClassImp(SRecDimuon)
 ClassImp(SRecEvent)
@@ -306,7 +308,7 @@ void SRecTrack::swimToVertex(TVector3* pos, TVector3* mom)
     double eloss_unit_2 = ELOSS_FMAG_P2/FMAG_LENGTH;
     double eloss_unit_3 = ELOSS_FMAG_P3/FMAG_LENGTH;
     double eloss_unit_4 = ELOSS_FMAG_P4/FMAG_LENGTH;
-    double ptkick_unit = PT_KICK_FMAG/FMAG_LENGTH;
+    double ptkick_unit = 2.909*recoConsts::instance()->get_DoubleFlag("FMAGSTR")/FMAG_LENGTH;
 
     //Step size in FMAG/target area
     double step_fmag = FMAG_LENGTH/NSLICES_FMAG/2.;   //note that in FMag, each step is devided into two slices
@@ -420,7 +422,7 @@ void SRecTrack::swimToVertex(TVector3* pos, TVector3* mom)
     int iStep_y = iStep;                  // both intialized with the most upstream position
     for(int i = 0; i < NSLICES_FMAG+NSTEPS_TARGET+1; ++i)
     {
-        if(FMAGSTR*charge*mom[i].Px() < 0.) continue;    // this is the upstream accidental cross, ignore
+        if(recoConsts::instance()->get_DoubleFlag("FMAGSTR")*charge*mom[i].Px() < 0.) continue;    // this is the upstream accidental cross, ignore
 
         double dca = (pos[i] - TVector3(X_VTX, Y_VTX, pos[i].Z())).Perp();
         if(dca < dca_min)
@@ -520,7 +522,7 @@ int SRecDimuon::isValid() const
     if(chisq_kf > 15. || chisq_kf < 0.) return false;
 
     //Kinematic cuts
-    if(FMAGSTR*(p_pos.Px() - p_neg.Px()) < 0.) return false;
+    if(recoConsts::instance()->get_DoubleFlag("FMAGSTR")*(p_pos.Px() - p_neg.Px()) < 0.) return false;
     if(fabs(xF) > 1.) return false;
     if(x1 < 0. || x1 > 1.) return false;
     if(x2 < 0. || x2 > 1.) return false;

--- a/simulation/g4gdml/CMakeLists.txt
+++ b/simulation/g4gdml/CMakeLists.txt
@@ -48,7 +48,7 @@ add_library(phg4gdml SHARED
   ${PROJECT_SOURCE_DIR}/PHG4GDMLConfig.cc
 )
 
-target_link_libraries(phg4gdml -L./ -L$ENV{OFFLINE_MAIN}/lib -lphool -lSubsysReco -lfun4all -L$ENV{XERCESCROOT} -lxerces-c ${GEANT4_LINK})
+target_link_libraries(phg4gdml -L./ -L$ENV{OFFLINE_MAIN}/lib -lphool -lSubsysReco -lfun4all -L$ENV{XERCESCROOT}/lib -lxerces-c ${GEANT4_LINK})
 
 install(TARGETS phg4gdml 					DESTINATION ${CMAKE_INSTALL_PREFIX}/lib)
 


### PR DESCRIPTION
- new `Fun4AllSRawEventInputManager` to read in E906 decoded data in SRawEvent format
- bug fix for left-right resolving: removed a previous workaround
  -  due to possible geometry in-consistency, L-R resolving was not working for sim data initially
  -  now it works on sim data and the sign of driftDistance removed before tracking
- try to use the `recoConst` to substitute the macros used in 'GlobalConsts.h'
  - now only substituted the `KMAGSTR` var

Now standalone ktracker and the e1039 ktracker yield same results:
![image](https://user-images.githubusercontent.com/10383186/56692137-8056e880-66af-11e9-98b9-e389c7e136e9.png)

Also the e1039 ktracker has a very high reconstruction efficiency with pure simulated muons:
![image](https://user-images.githubusercontent.com/10383186/56692760-e8f29500-66b0-11e9-8c0f-fa147c5705a9.png)

