### PR TITLE
Onlmon client

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -25,25 +25,25 @@ else
     online/chan_map
     online/onlmonserver
     online/decoder_maindaq
-    packages/Half
-    packages/vararray
-    database/pdbcal/base
-    database/PHParameter
-    packages/PHGeometry
-    packages/PHField
-    generators/phhepmc
-    generators/PHPythia8
-    simulation/g4decayer
-    simulation/g4gdml
-    simulation/g4main
-    simulation/g4detectors
-    simulation/g4dst
-    simulation/g4eval
-    packages/db2g4
-    packages/PHGenFitPkg/GenFitExp
-    packages/PHGenFitPkg/PHGenFit
-    packages/ktracker
-    module_example
+#    packages/Half
+#    packages/vararray
+#    database/pdbcal/base
+#    database/PHParameter
+#    packages/PHGeometry
+#    packages/PHField
+#    generators/phhepmc
+#    generators/PHPythia8
+#    simulation/g4decayer
+#    simulation/g4gdml
+#    simulation/g4main
+#    simulation/g4detectors
+#    simulation/g4dst
+#    simulation/g4eval
+#    packages/db2g4
+#    packages/PHGenFitPkg/GenFitExp
+#    packages/PHGenFitPkg/PHGenFit
+#    packages/ktracker
+#    module_example
 	)
 fi
 

--- a/build.sh
+++ b/build.sh
@@ -25,25 +25,25 @@ else
     online/chan_map
     online/onlmonserver
     online/decoder_maindaq
-#    packages/Half
-#    packages/vararray
-#    database/pdbcal/base
-#    database/PHParameter
-#    packages/PHGeometry
-#    packages/PHField
-#    generators/phhepmc
-#    generators/PHPythia8
-#    simulation/g4decayer
-#    simulation/g4gdml
-#    simulation/g4main
-#    simulation/g4detectors
-#    simulation/g4dst
-#    simulation/g4eval
-#    packages/db2g4
-#    packages/PHGenFitPkg/GenFitExp
-#    packages/PHGenFitPkg/PHGenFit
-#    packages/ktracker
-#    module_example
+    packages/Half
+    packages/vararray
+    database/pdbcal/base
+    database/PHParameter
+    packages/PHGeometry
+    packages/PHField
+    generators/phhepmc
+    generators/PHPythia8
+    simulation/g4decayer
+    simulation/g4gdml
+    simulation/g4main
+    simulation/g4detectors
+    simulation/g4dst
+    simulation/g4eval
+    packages/db2g4
+    packages/PHGenFitPkg/GenFitExp
+    packages/PHGenFitPkg/PHGenFit
+    packages/ktracker
+    module_example
 	)
 fi
 

--- a/macros/Fun4MainDaq.C
+++ b/macros/Fun4MainDaq.C
@@ -20,7 +20,7 @@ int Fun4MainDaq(const int nevent = 0, const int run = 28700)
   //const char* dir_in  = "/data/e906",
   const char* dir_in  = "/seaquest/analysis/kenichi/e1039";
   const char* dir_out = ".";
-  const bool is_online = false; // true;
+  const bool is_online = true;//false; // true;
 
   ostringstream oss;
   oss << setfill('0') 
@@ -37,9 +37,8 @@ int Fun4MainDaq(const int nevent = 0, const int run = 28700)
   Fun4AllEVIOInputManager *in = new Fun4AllEVIOInputManager("MainDaq");
   in->Verbosity(1);
   in->EventSamplingFactor(100);
-  if (is_online) {
-    in->PretendSpillInterval(55);
-  }
+  if (is_online) in->PretendSpillInterval(10);
+
   in->DirParam("/seaquest/production/runs");
   //in->DirParam("/data/e906/runs");
   in->fileopen(fn_in);
@@ -53,9 +52,9 @@ int Fun4MainDaq(const int nevent = 0, const int run = 28700)
 
   if (is_online) { // Register the online-monitoring clients
     se->StartServer();
-
-    OnlMonClient* ana = new OnlMonMainDaq();
-    se->registerSubsystem(ana);
+    se->registerSubsystem(new OnlMonSpill());
+    se->registerSubsystem(new OnlMonMainDaq());
+    se->registerSubsystem(new OnlMonCham(OnlMonCham::D3p));
   }
 
   se->run(nevent);

--- a/macros/Fun4MainDaq.C
+++ b/macros/Fun4MainDaq.C
@@ -55,6 +55,7 @@ int Fun4MainDaq(const int nevent = 0, const int run = 28700)
     se->registerSubsystem(new OnlMonSpill());
     se->registerSubsystem(new OnlMonMainDaq());
     se->registerSubsystem(new OnlMonCham(OnlMonCham::D3p));
+    se->registerSubsystem(new OnlMonCham(OnlMonCham::D3m));
   }
 
   se->run(nevent);

--- a/macros/Fun4MainDaq.C
+++ b/macros/Fun4MainDaq.C
@@ -20,7 +20,7 @@ int Fun4MainDaq(const int nevent = 0, const int run = 28700)
   //const char* dir_in  = "/data/e906",
   const char* dir_in  = "/seaquest/analysis/kenichi/e1039";
   const char* dir_out = ".";
-  const bool is_online = true;//false; // true;
+  const bool is_online = true; // false;
 
   ostringstream oss;
   oss << setfill('0') 
@@ -37,7 +37,7 @@ int Fun4MainDaq(const int nevent = 0, const int run = 28700)
   Fun4AllEVIOInputManager *in = new Fun4AllEVIOInputManager("MainDaq");
   in->Verbosity(1);
   in->EventSamplingFactor(100);
-  if (is_online) in->PretendSpillInterval(10);
+  if (is_online) in->PretendSpillInterval(20);
 
   in->DirParam("/seaquest/production/runs");
   //in->DirParam("/data/e906/runs");

--- a/macros/OnlMon4MainDaq.C
+++ b/macros/OnlMon4MainDaq.C
@@ -4,7 +4,8 @@ R__LOAD_LIBRARY(libonlmonserver)
 
 int OnlMon4MainDaq()
 {
-  OnlMonClient* omc = new OnlMonMainDaq();
+  //OnlMonClient* omc = new OnlMonMainDaq();
+  OnlMonClient* omc = new OnlMonCham(OnlMonCham::D3p);
   omc->StartMonitor();
   return 0;
 }

--- a/macros/OnlMon4MainDaq.C
+++ b/macros/OnlMon4MainDaq.C
@@ -1,8 +1,44 @@
 /// OnlMon4MainDaq.C:  Macro to launch an online-monitor client for MainDaq.
+#include <TGClient.h>
+#include <TGButton.h>
+#include <TGFrame.h>
 R__LOAD_LIBRARY(libinterface_main)
 R__LOAD_LIBRARY(libonlmonserver)
 
 int OnlMon4MainDaq()
+{
+  vector<OnlMonClient*> list_omc;
+  list_omc.push_back(new OnlMonMainDaq());
+  list_omc.push_back(new OnlMonCham(OnlMonCham::D0 ));
+  list_omc.push_back(new OnlMonCham(OnlMonCham::D1 ));
+  list_omc.push_back(new OnlMonCham(OnlMonCham::D2 ));
+  list_omc.push_back(new OnlMonCham(OnlMonCham::D3p));
+  list_omc.push_back(new OnlMonCham(OnlMonCham::D3m));
+  
+  TGMainFrame* frame = new TGMainFrame(gClient->GetRoot(), 400, 800);
+
+  TGTextView* head = new TGTextView(frame, 400, 50, "E1039 OnlMon Selector");
+  frame->AddFrame(head); 
+
+  TGTextButton*  button[99];
+  for (unsigned int ii = 0; ii < list_omc.size(); ii++) {
+    button[ii] = new TGTextButton(frame, list_omc[ii]->Name().c_str());
+    button[ii]->Connect("Clicked()", "OnlMonClient", list_omc[ii], "StartMonitor()");
+    frame->AddFrame(button[ii], new TGLayoutHints(kLHintsNormal | kLHintsExpandX, 10,10,20,20)); // (l, r, t, b) 
+  }
+  
+  TGTextButton* fExit = new TGTextButton(frame, "Exit","gApplication->Terminate(0)");
+  frame->AddFrame(fExit, new TGLayoutHints(kLHintsTop | kLHintsExpandX, 10,10,20,20));
+
+  frame->SetWindowName("E1039 Online Monitor");
+  frame->MapSubwindows();
+  frame->Resize(frame->GetDefaultSize());
+  frame->MapWindow();
+
+  return 0;
+}
+
+int OnlMon4MainDaqSingle()
 {
   //OnlMonClient* omc = new OnlMonMainDaq();
   OnlMonClient* omc = new OnlMonCham(OnlMonCham::D3p);

--- a/online/onlmonserver/CMakeLists.txt
+++ b/online/onlmonserver/CMakeLists.txt
@@ -3,15 +3,14 @@ cmake_minimum_required(VERSION 2.6 FATAL_ERROR)
 project(onlmonserver CXX C)
 
 # ROOT dict generation
-file(GLOB dicts "")
-file(GLOB LinkDefhs ${PROJECT_SOURCE_DIR}/*LinkDef.h)
-foreach(LinkDefh ${LinkDefhs})
-	string(REPLACE "LinkDef.h" ".h" Dicth ${LinkDefh})
-	string(REPLACE "LinkDef.h" "_Dict.C" DictC ${LinkDefh})
-	string(REPLACE "${PROJECT_SOURCE_DIR}/" "" DictC ${DictC})
-	list(APPEND dicts ${DictC})
-	add_custom_command(OUTPUT ${DictC} COMMAND rootcint ARGS -f ${DictC} -c -I$ENV{OFFLINE_MAIN}/include ${Dicth} ${LinkDefh})
-endforeach(LinkDefh)
+add_custom_command (
+  OUTPUT onlmonserver_Dict.cc
+  COMMAND rootcint
+  ARGS -f onlmonserver_Dict.cc -c
+    -I$ENV{OFFLINE_MAIN}/include/ -I${ROOT_PREFIX}/include/
+    ${PROJECT_SOURCE_DIR}/OnlMon*.h
+    ${PROJECT_SOURCE_DIR}/LinkDef.h
+)
 
 # source code
 include_directories("${PROJECT_SOURCE_DIR}/" "$ENV{MY_INSTALL}/include/" "$ENV{OFFLINE_MAIN}/include/")
@@ -34,8 +33,8 @@ execute_process(COMMAND root-config --libs   OUTPUT_VARIABLE ROOT_LINK    OUTPUT
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x -I$ENV{OFFLINE_MAIN}/include/ ${ROOT_CFLAGS}")
 #set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -L$ENV{OFFLINE_MAIN}/lib -lphool -lg4testbench")
 
-add_library(onlmonserver SHARED ${sources} ${dicts})
-target_link_libraries(onlmonserver -L$ENV{OFFLINE_MAIN}/lib -lfun4all)
+add_library(onlmonserver SHARED ${sources} onlmonserver_Dict.cc)
+target_link_libraries(onlmonserver -L$ENV{OFFLINE_MAIN}/lib -lfun4all db_svc chan_map)
 
 message(${CMAKE_PROJECT_NAME} " will be installed to " ${CMAKE_INSTALL_PREFIX})
 

--- a/online/onlmonserver/LinkDef.h
+++ b/online/onlmonserver/LinkDef.h
@@ -1,0 +1,12 @@
+#ifdef __CINT__
+#pragma link off all class;
+#pragma link off all function;
+#pragma link off all global;
+
+#pragma link C++ class OnlMonServer-!;
+#pragma link C++ class OnlMonClient-!;
+#pragma link C++ class OnlMonMainDaq-!;
+#pragma link C++ class OnlMonSpill-!;
+#pragma link C++ class OnlMonCham-!;
+
+#endif

--- a/online/onlmonserver/OnlMonCanvas.cc
+++ b/online/onlmonserver/OnlMonCanvas.cc
@@ -1,0 +1,69 @@
+#include <sstream>
+#include <iomanip>
+#include <TCanvas.h>
+#include <TPaveText.h>
+#include "OnlMonCanvas.h"
+using namespace std;
+
+OnlMonCanvas::OnlMonCanvas(const std::string name, const int num) :
+  m_name(name), m_num(num),
+  m_can("c1", "", 5+600*num, 5, 600, 800), 
+  m_pad_title("title", "", 0.0, 0.9, 1.0, 1.0),
+  m_pad_main ("main" , "", 0.0, 0.1, 1.0, 0.9),
+  m_pad_msg  ("msg"  , "", 0.0, 0.0, 1.0, 0.1),
+  m_pate_msg(.02, .02, .98, .98),
+  m_mon_status(UNDEF)
+{
+  //m_can.SetWindowPosition(5+600*num, 5);
+}
+
+OnlMonCanvas::~OnlMonCanvas()
+{
+  ;
+}
+
+void OnlMonCanvas::AddMessage(const char* msg)
+{
+  m_pate_msg.AddText(msg);
+}
+
+TPad* OnlMonCanvas::GetMainPad()
+{
+  m_pad_main.cd();
+  return &m_pad_main; 
+}
+
+void OnlMonCanvas::PreDraw()
+{
+  ostringstream oss;
+  oss << m_name << " #" << m_num;
+  string title = oss.str();
+  m_can.SetTitle(title.c_str());
+
+  m_can.cd();  m_pad_title.Draw();
+  m_can.cd();  m_pad_main .Draw();
+  m_can.cd();  m_pad_msg  .Draw();
+
+  m_pad_title.cd();
+  TPaveText* pate = new TPaveText(.02, .02, .98, .98);
+  pate->AddText(title.c_str());
+  pate->Draw();
+}
+
+void OnlMonCanvas::PostDraw()
+{
+  int color;
+  switch (m_mon_status) {
+  case OK   :  color = kGreen ;  break;
+  case WARN :  color = kYellow;  break;
+  case ERROR:  color = kRed   ;  break;
+  default   :  color = kGray  ;  break;
+  }
+  m_pate_msg.SetFillColor(color);
+  m_pad_msg .cd();
+  m_pate_msg.Draw();
+
+  ostringstream oss;
+  oss << "/dev/shm/" << m_name << "_" << m_num << ".png";
+  m_can.SaveAs(oss.str().c_str());
+}

--- a/online/onlmonserver/OnlMonCanvas.h
+++ b/online/onlmonserver/OnlMonCanvas.h
@@ -1,0 +1,37 @@
+#ifndef _ONL_MON_CANVAS__H_
+#define _ONL_MON_CANVAS__H_
+#include <TCanvas.h>
+#include <TPaveText.h>
+#include <fun4all/SubsysReco.h>
+class TH1;
+class TH2;
+class TH3;
+class TPaveText;
+
+class OnlMonCanvas {
+ public:
+  typedef enum { OK, WARN, ERROR, UNDEF } MonStatus_t;
+
+ protected:
+  std::string m_name;
+  int         m_num;
+  TCanvas     m_can;
+  TPad        m_pad_title;
+  TPad        m_pad_main;
+  TPad        m_pad_msg;
+  TPaveText   m_pate_msg;
+  MonStatus_t m_mon_status;
+
+ public:
+  OnlMonCanvas(const std::string name, const int num);
+  virtual ~OnlMonCanvas();
+
+  void AddMessage(const char* msg);
+  void SetStatus(const MonStatus_t stat) { m_mon_status = stat; }
+  TPad* GetMainPad();
+
+  void PreDraw();
+  void PostDraw();
+};
+
+#endif /* _ONL_MON_CANVAS__H_ */

--- a/online/onlmonserver/OnlMonCham.cc
+++ b/online/onlmonserver/OnlMonCham.cc
@@ -1,0 +1,134 @@
+/// OnlMonCham.C
+#include <iomanip>
+#include <TH1D.h>
+#include <TSocket.h>
+#include <TClass.h>
+#include <TMessage.h>
+#include <TCanvas.h>
+#include <TPaveText.h>
+#include <interface_main/SQRun.h>
+#include <interface_main/SQStringMap.h>
+#include <interface_main/SQScaler.h>
+#include <interface_main/SQSlowCont.h>
+#include <interface_main/SQEvent.h>
+#include <interface_main/SQHitVector.h>
+#include <fun4all/Fun4AllReturnCodes.h>
+#include <fun4all/Fun4AllHistoManager.h>
+#include <phool/PHNodeIterator.h>
+#include <phool/PHIODataNode.h>
+#include <phool/getClass.h>
+#include <geom_svc/GeomSvc.h>
+#include <chan_map/CalibParamInTimeTaiwan.h>
+#include "OnlMonServer.h"
+#include "OnlMonCham.h"
+using namespace std;
+
+OnlMonCham::OnlMonCham(const ChamType_t type, const std::string& name) : m_type(type), m_pl0(0), OnlMonClient(name)
+{
+  switch (m_type) {
+  case D0 :  m_pl0 =  1;  Name("OnlMonChamD0" );  break;
+  case D1 :  m_pl0 =  7;  Name("OnlMonChamD1" );  break;
+  case D2 :  m_pl0 = 13;  Name("OnlMonChamD2" );  break;
+  case D3p:  m_pl0 = 19;  Name("OnlMonChamD3p");  break;
+  case D3m:  m_pl0 = 25;  Name("OnlMonChamD3m");  break;
+  }
+}
+
+int OnlMonCham::Init(PHCompositeNode* topNode)
+{
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int OnlMonCham::InitRun(PHCompositeNode* topNode)
+{
+  SQRun* run_header = findNode::getClass<SQRun>(topNode, "SQRun");
+  if (!run_header) return Fun4AllReturnCodes::ABORTEVENT;
+  cout << "SQRun: " << run_header->get_run_id() << " " << run_header->get_spill_count() << endl;
+
+  GeomSvc* geom = GeomSvc::instance();
+  CalibParamInTimeTaiwan calib;
+  calib.SetMapIDbyDB(run_header->get_run_id());
+  calib.ReadFromDB();
+
+  Fun4AllHistoManager* hm = new Fun4AllHistoManager(Name());
+  OnlMonServer::instance()->registerHistoManager(hm);
+
+  ostringstream oss;
+  for (int pl = 0; pl < N_PL; pl++) {
+    string name = geom->getDetectorName(m_pl0 + pl);
+    int n_ele = geom->getPlaneNElements(m_pl0 + pl); 
+    oss.str("");
+    oss << "h1_ele_" << pl;
+    h1_ele[pl] = new TH1D(oss.str().c_str(), "", n_ele, 0.5, n_ele+0.5);
+    oss.str("");
+    oss << name << ";Element ID;Hit count";
+    h1_ele[pl]->SetTitle(oss.str().c_str());
+
+    double center, width;
+    calib.Find(m_pl0 + pl, 1, center, width);
+    oss.str("");
+    oss << "h1_time_" << pl;
+    h1_time[pl] = new TH1D(oss.str().c_str(), "", 100, center-width/2, center+width/2);
+    oss.str("");
+    oss << name << ";tdcTime;Hit count";
+    h1_time[pl]->SetTitle(oss.str().c_str());
+
+    hm->registerHisto(h1_ele [pl]);
+    hm->registerHisto(h1_time[pl]);
+  }
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int OnlMonCham::process_event(PHCompositeNode* topNode)
+{
+  SQEvent*     event_header = findNode::getClass<SQEvent    >(topNode, "SQEvent");
+  SQHitVector*      hit_vec = findNode::getClass<SQHitVector>(topNode, "SQHitVector");
+  if (!event_header || !hit_vec) return Fun4AllReturnCodes::ABORTEVENT;
+
+  for (SQHitVector::ConstIter it = hit_vec->begin(); it != hit_vec->end(); it++) {
+    int pl = (*it)->get_detector_id() - m_pl0;
+    if (pl < 0 || pl >= N_PL) continue;
+    h1_ele [pl]->Fill((*it)->get_element_id());
+    h1_time[pl]->Fill((*it)->get_tdc_time  ());
+  }
+  
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int OnlMonCham::End(PHCompositeNode* topNode)
+{
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int OnlMonCham::DrawMonitor()
+{
+  ostringstream oss;
+  for (int pl = 0; pl < N_PL; pl++) {
+    oss.str("");
+    oss << "h1_ele_" << pl;
+    h1_ele[pl] = (TH1*)FindMonObj(oss.str().c_str());
+    oss.str("");
+    oss << "h1_time_" << pl;
+    h1_time[pl] = (TH1*)FindMonObj(oss.str().c_str());
+  }
+
+  pad_main->cd();
+  pad_main->SetGrid();
+  pad_main->Divide(3, 4);
+
+  for (int pl = 0; pl < N_PL; pl++) {
+    pad_main->cd(pl+1);
+    if (h1_ele[pl]->Integral() > 1000) gPad->SetLogy();
+    h1_ele[pl]->Draw();
+
+    pad_main->cd(pl+7);
+    if (h1_time[pl]->Integral() > 1000) gPad->SetLogy();
+    h1_time[pl]->Draw();
+  }
+
+  AddMessage("Always Okay ;^D");
+  SetStatus(OK);
+
+  return 0;
+}

--- a/online/onlmonserver/OnlMonCham.cc
+++ b/online/onlmonserver/OnlMonCham.cc
@@ -1,11 +1,6 @@
 /// OnlMonCham.C
 #include <iomanip>
 #include <TH1D.h>
-#include <TSocket.h>
-#include <TClass.h>
-#include <TMessage.h>
-#include <TCanvas.h>
-#include <TPaveText.h>
 #include <interface_main/SQRun.h>
 #include <interface_main/SQStringMap.h>
 #include <interface_main/SQScaler.h>
@@ -25,6 +20,7 @@ using namespace std;
 
 OnlMonCham::OnlMonCham(const ChamType_t type, const std::string& name) : m_type(type), m_pl0(0), OnlMonClient(name)
 {
+  SetNumCanvases(2);
   switch (m_type) {
   case D0 :  m_pl0 =  1;  Name("OnlMonChamD0" );  break;
   case D1 :  m_pl0 =  7;  Name("OnlMonChamD1" );  break;
@@ -113,22 +109,29 @@ int OnlMonCham::DrawMonitor()
     h1_time[pl] = (TH1*)FindMonObj(oss.str().c_str());
   }
 
-  pad_main->cd();
-  pad_main->SetGrid();
-  pad_main->Divide(3, 4);
-
+  OnlMonCanvas* can0 = GetCanvas(0);
+  TPad* pad0 = can0->GetMainPad();
+  pad0->SetGrid();
+  pad0->Divide(2, 3);
   for (int pl = 0; pl < N_PL; pl++) {
-    pad_main->cd(pl+1);
+    pad0->cd(pl+1);
     if (h1_ele[pl]->Integral() > 1000) gPad->SetLogy();
     h1_ele[pl]->Draw();
+  }
+  can0->AddMessage("Always Okay ;^D");
+  can0->SetStatus(OnlMonCanvas::OK);
 
-    pad_main->cd(pl+7);
+  OnlMonCanvas* can1 = GetCanvas(1);
+  TPad* pad1 = can1->GetMainPad();
+  pad1->SetGrid();
+  pad1->Divide(2, 3);
+  for (int pl = 0; pl < N_PL; pl++) {
+    pad1->cd(pl+1);
     if (h1_time[pl]->Integral() > 1000) gPad->SetLogy();
     h1_time[pl]->Draw();
   }
-
-  AddMessage("Always Okay ;^D");
-  SetStatus(OK);
+  can1->AddMessage("Always Okay ;^D");
+  can1->SetStatus(OnlMonCanvas::OK);
 
   return 0;
 }

--- a/online/onlmonserver/OnlMonCham.h
+++ b/online/onlmonserver/OnlMonCham.h
@@ -1,0 +1,30 @@
+#ifndef _ONL_MON_CHAM__H_
+#define _ONL_MON_CHAM__H_
+#include "OnlMonClient.h"
+class SQSpill;
+class SQEvent;
+class SQHitVector;
+
+class OnlMonCham: public OnlMonClient {
+ public:
+  typedef enum { D0, D1, D2, D3p, D3m } ChamType_t;
+  static const int N_PL = 6;
+
+ private:
+  ChamType_t m_type;
+  int m_pl0;
+  TH1* h1_ele [N_PL];
+  TH1* h1_time[N_PL];
+
+ public:
+  OnlMonCham(const ChamType_t type, const std::string &name = "OnlMonCham");
+  virtual ~OnlMonCham() {}
+  int Init(PHCompositeNode *topNode);
+  int InitRun(PHCompositeNode *topNode);
+  int process_event(PHCompositeNode *topNode);
+  int End(PHCompositeNode *topNode);
+
+  int DrawMonitor();
+};
+
+#endif /* _ONL_MON_CHAM__H_ */

--- a/online/onlmonserver/OnlMonClient.cc
+++ b/online/onlmonserver/OnlMonClient.cc
@@ -4,6 +4,7 @@
 #include <TClass.h>
 #include <TMessage.h>
 #include <TCanvas.h>
+#include <TPaveText.h>
 #include <fun4all/Fun4AllReturnCodes.h>
 #include <fun4all/Fun4AllHistoManager.h>
 #include <phool/PHNodeIterator.h>
@@ -35,6 +36,18 @@ TH1* OnlMonClient::FindMonHist(const std::string name, const bool non_null)
   return 0;
 }
 
+TObject* OnlMonClient::FindMonObj(const std::string name, const bool non_null)
+{
+  for (ObjList_t::iterator it = m_list_obj.begin(); it != m_list_obj.end(); it++) {
+    if (name == (*it)->GetName()) return *it;
+  }
+  if (non_null) {
+    cerr << "!!ERROR!!  OnlMonClient::FindMonObj() cannot find '" << name << "'.  Abort." << endl;
+    exit(1);
+  }
+  return 0;
+}
+
 int OnlMonClient::DrawMonitor()
 {
   cerr << "!!ERROR!!  OnlMonClient::DrawMonitor(): virtual function called.  Abort." << endl;
@@ -49,12 +62,35 @@ int OnlMonClient::StartMonitor()
   pad_title = new TPad("pad_title", "", 0.0, 0.9, 1.0, 1.0);
   pad_main  = new TPad("pad_main" , "", 0.0, 0.1, 1.0, 0.9);
   pad_msg   = new TPad("pad_msg"  , "", 0.0, 0.0, 1.0, 0.1);
+  pate_msg  = new TPaveText(.02, .02, .98, .98);
 
   c1->cd();  pad_title->Draw();
   c1->cd();  pad_main ->Draw();
   c1->cd();  pad_msg  ->Draw();
 
-  return DrawMonitor();
+  pad_title->cd();
+  TPaveText* title = new TPaveText(.02, .02, .98, .98);
+  title->AddText(Name().c_str());
+  title->Draw();
+
+  int ret = DrawMonitor();
+
+  int color;
+  switch (mon_status) {
+  case OK   :  color = kGreen ;  break;
+  case WARN :  color = kYellow;  break;
+  case ERROR:  color = kRed   ;  break;
+  default   :  color = kGray  ;  break;
+  }
+  pate_msg->SetFillColor(color);
+  pad_msg ->cd();
+  pate_msg->Draw();
+
+  ostringstream oss;
+  oss << "/dev/shm/" << Name() << ".png";
+  c1->SaveAs(oss.str().c_str());
+  
+  return ret;
 }
 
 int OnlMonClient::ReceiveHist()
@@ -83,10 +119,14 @@ int OnlMonClient::ReceiveHist()
       mess = 0;
       if (!strcmp(str, "Finished")) break;
     } else if (mess->What() == kMESS_OBJECT) {
-      TClass* cla = mess->GetClass();
-      TH1*    obj = (TH1*)mess->ReadObject(cla);
+      TClass*  cla = mess->GetClass();
+      TObject* obj = mess->ReadObject(cla);
       cout << "  Receive: " << cla->GetName() << " " << obj->GetName() << endl;
-      m_list_h1.push_back( (TH1*)obj->Clone() ); // copy
+      m_list_obj.push_back( obj->Clone() ); // copy
+
+      //TH1*    obj = (TH1*)mess->ReadObject(cla);
+      //cout << "  Receive: " << cla->GetName() << " " << obj->GetName() << endl;
+      //m_list_h1.push_back( (TH1*)obj->Clone() ); // copy
       delete mess;
       mess = 0;
       sock.Send("NEXT"); // Any text is ok for now
@@ -96,10 +136,20 @@ int OnlMonClient::ReceiveHist()
   return 0;
 }
 
+void OnlMonClient::AddMessage(const char* msg)
+{
+  pate_msg->AddText(msg);
+}
+
 void OnlMonClient::ClearHistList()
 {
   for (HistList_t::iterator it = m_list_h1.begin(); it != m_list_h1.end(); it++) {
     delete *it;
   }
   m_list_h1.clear();
+
+  //for (ObjList_t::iterator it = m_list_obj.begin(); it != m_list_obj.end(); it++) {
+  //  delete *it;
+  //}
+  //m_list_obj.clear();
 }

--- a/online/onlmonserver/OnlMonClient.h
+++ b/online/onlmonserver/OnlMonClient.h
@@ -1,30 +1,22 @@
 #ifndef _ONL_MON_CLIENT__H_
 #define _ONL_MON_CLIENT__H_
 #include <TCanvas.h>
+#include <TPaveText.h>
 #include <fun4all/SubsysReco.h>
+#include "OnlMonCanvas.h"
 class TH1;
 class TH2;
 class TH3;
 class TPaveText;
 
 class OnlMonClient: public SubsysReco {
- protected:  
-  typedef enum { OK, WARN, ERROR, UNDEF } MonStatus_t;
-  TCanvas* c1;
-  TPad* pad_title;
-  TPad* pad_main ;
-  TPad* pad_msg  ;
+  int m_n_can;
+  OnlMonCanvas* m_list_can[9];
 
- private:
   typedef std::vector<TH1*> HistList_t;
   HistList_t m_list_h1;
   typedef std::vector<TObject*> ObjList_t;
   ObjList_t m_list_obj;
-  void ClearHistList();
-
-  /// Variables for message and status
-  MonStatus_t mon_status;
-  TPaveText* pate_msg;
 
  public:
   OnlMonClient(const std::string &name = "OnlMonClient");
@@ -38,10 +30,10 @@ class OnlMonClient: public SubsysReco {
 
  protected:  
   int ReceiveHist();
+  void ClearHistList();
 
-  /// Functions for message and status
-  void AddMessage(const char* msg);
-  void SetStatus(const MonStatus_t stat) { mon_status = stat; }
+  void SetNumCanvases(const int num) { m_n_can = num; }
+  OnlMonCanvas* GetCanvas(const int num=0);
 };
 
 #endif /* _ONL_MON_CLIENT__H_ */

--- a/online/onlmonserver/OnlMonClient.h
+++ b/online/onlmonserver/OnlMonClient.h
@@ -5,29 +5,43 @@
 class TH1;
 class TH2;
 class TH3;
+class TPaveText;
 
 class OnlMonClient: public SubsysReco {
+ protected:  
+  typedef enum { OK, WARN, ERROR, UNDEF } MonStatus_t;
+  TCanvas* c1;
+  TPad* pad_title;
+  TPad* pad_main ;
+  TPad* pad_msg  ;
+
+ private:
+  typedef std::vector<TH1*> HistList_t;
+  HistList_t m_list_h1;
+  typedef std::vector<TObject*> ObjList_t;
+  ObjList_t m_list_obj;
+  void ClearHistList();
+
+  /// Variables for message and status
+  MonStatus_t mon_status;
+  TPaveText* pate_msg;
+
  public:
   OnlMonClient(const std::string &name = "OnlMonClient");
   virtual ~OnlMonClient();
 
   int StartMonitor();
   TH1* FindMonHist(const std::string name, const bool non_null=true);
+  TObject* FindMonObj(const std::string name, const bool non_null=true);
 
   virtual int DrawMonitor();
 
  protected:  
-  TCanvas* c1;
-  TPad* pad_title;
-  TPad* pad_main ;
-  TPad* pad_msg  ;
-
   int ReceiveHist();
 
- private:
-  typedef std::vector<TH1*> HistList_t;
-  HistList_t m_list_h1;
-  void ClearHistList();
+  /// Functions for message and status
+  void AddMessage(const char* msg);
+  void SetStatus(const MonStatus_t stat) { mon_status = stat; }
 };
 
 #endif /* _ONL_MON_CLIENT__H_ */

--- a/online/onlmonserver/OnlMonClientLinkDef.h
+++ b/online/onlmonserver/OnlMonClientLinkDef.h
@@ -1,5 +1,0 @@
-#ifdef __CINT__
-
-#pragma link C++ class OnlMonClient-!;
-
-#endif

--- a/online/onlmonserver/OnlMonMainDaq.cc
+++ b/online/onlmonserver/OnlMonMainDaq.cc
@@ -7,8 +7,6 @@
 #include <TCanvas.h>
 #include <TPaveText.h>
 #include <interface_main/SQRun.h>
-#include <interface_main/SQSpillMap.h>
-#include <interface_main/SQSpill.h>
 #include <interface_main/SQStringMap.h>
 #include <interface_main/SQScaler.h>
 #include <interface_main/SQSlowCont.h>
@@ -45,28 +43,16 @@ int OnlMonMainDaq::InitRun(PHCompositeNode* topNode)
 {
   SQRun* run_header = findNode::getClass<SQRun>(topNode, "SQRun");
   if (!run_header) return Fun4AllReturnCodes::ABORTEVENT;
-  cout << "SQRun: \n"
-       << "  " << run_header->get_run_id()
-       << "  " << run_header->get_spill_count()
-       << endl;
+  cout << "SQRun: " << run_header->get_run_id() << " " << run_header->get_spill_count() << endl;
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
 int OnlMonMainDaq::process_event(PHCompositeNode* topNode)
 {
-  SQSpillMap*     spill_map = findNode::getClass<SQSpillMap >(topNode, "SQSpillMap");
   SQEvent*     event_header = findNode::getClass<SQEvent    >(topNode, "SQEvent");
   SQHitVector*      hit_vec = findNode::getClass<SQHitVector>(topNode, "SQHitVector");
   SQHitVector* trig_hit_vec = findNode::getClass<SQHitVector>(topNode, "SQTriggerHitVector");
-  if (!spill_map || !event_header || !hit_vec || !trig_hit_vec) return Fun4AllReturnCodes::ABORTEVENT;
-
-  static int spill_id_pre = -1;
-  if (event_header->get_spill_id() != spill_id_pre) {
-    spill_id_pre = event_header->get_spill_id();
-    SQSpill* spi = spill_map->get(spill_id_pre);
-    //PrintSpill(spi);
-    h1_tgt->Fill(spi->get_target_pos());
-  }
+  if (!event_header || !hit_vec || !trig_hit_vec) return Fun4AllReturnCodes::ABORTEVENT;
 
   //static int n_evt_print = 0;
   //if (n_evt_print++ < 3) PrintEvent(event_header, hit_vec, trig_hit_vec);
@@ -87,13 +73,10 @@ int OnlMonMainDaq::End(PHCompositeNode* topNode)
 
 int OnlMonMainDaq::DrawMonitor()
 {
-  h1_tgt      = FindMonHist("h1_tgt");
-  h1_evt_qual = FindMonHist("h1_evt_qual");
-
-  pad_title->cd();
-  TPaveText* title = new TPaveText(.02, .02, .98, .98);
-  title->AddText(Name().c_str());
-  title->Draw();
+  //h1_tgt      = FindMonHist("h1_tgt");
+  //h1_evt_qual = FindMonHist("h1_evt_qual");
+  h1_tgt      = (TH1*)FindMonObj("h1_tgt");
+  h1_evt_qual = (TH1*)FindMonObj("h1_evt_qual");
 
   pad_main->cd();
   pad_main->SetGrid();
@@ -106,44 +89,10 @@ int OnlMonMainDaq::DrawMonitor()
   pad_main->cd(2);
   h1_tgt->Draw();
 
-  pad_msg->cd();
-  TPaveText* msg = new TPaveText(.02, .02, .98, .98);
-  msg->SetFillColor(kGreen);
-  msg->AddText("Always Okay ;^D");
-  msg->Draw();
-  
+  AddMessage("Always Okay ;^D");
+  SetStatus(OK);
+
   return 0;
-}
-
-
-void OnlMonMainDaq::PrintSpill(SQSpill* spi)
-{
-  cout << "SQSpill:  "
-       << "  " << spi->get_spill_id    ()
-       << "  " << spi->get_run_id      ()
-       << "  " << spi->get_target_pos  ()
-       << "  " << spi->get_bos_coda_id ()
-       << "  " << spi->get_bos_vme_time()
-       << "  " << spi->get_eos_coda_id ()
-       << "  " << spi->get_eos_vme_time()
-       << "  \nBOS Scaler:  " << spi->get_bos_scaler_list()->size() << "\n";
-  for (SQStringMap::ConstIter it = spi->get_bos_scaler_list()->begin(); it != spi->get_bos_scaler_list()->end(); it++) {
-    string name = it->first;
-    SQScaler* sca = dynamic_cast<SQScaler*>(it->second);
-    cout << "    " << setw(20) << name << " " << setw(10) << sca->get_count() << "\n";
-  }
-  cout << "  EOS Scaler:  " << spi->get_eos_scaler_list()->size() << "\n";
-  for (SQStringMap::ConstIter it = spi->get_eos_scaler_list()->begin(); it != spi->get_eos_scaler_list()->end(); it++) {
-    string name = it->first;
-    SQScaler* sca = dynamic_cast<SQScaler*>(it->second);
-    cout << "  " << setw(20) << name << " " << setw(10) << sca->get_count() << "\n";
-  }
-  cout << "  Slow Control  " << spi->get_slow_cont_list()->size() << ":\n";
-  for (SQStringMap::ConstIter it = spi->get_slow_cont_list()->begin(); it != spi->get_slow_cont_list()->end(); it++) {
-    string name = it->first;
-    SQSlowCont* slo = dynamic_cast<SQSlowCont*>(it->second);
-    cout << "  " << setw(20) << name << " " << slo->get_time_stamp() << " " << setw(20) << slo->get_value() << " " << slo->get_type() << "\n";
-  }
 }
 
 void OnlMonMainDaq::PrintEvent(SQEvent* evt, SQHitVector* v_hit, SQHitVector* v_trig_hit)

--- a/online/onlmonserver/OnlMonMainDaq.cc
+++ b/online/onlmonserver/OnlMonMainDaq.cc
@@ -23,7 +23,7 @@ using namespace std;
 
 OnlMonMainDaq::OnlMonMainDaq(const std::string& name) : OnlMonClient(name)
 {
-  ;
+  SetNumCanvases(1);
 }
 
 int OnlMonMainDaq::Init(PHCompositeNode* topNode)
@@ -78,19 +78,20 @@ int OnlMonMainDaq::DrawMonitor()
   h1_tgt      = (TH1*)FindMonObj("h1_tgt");
   h1_evt_qual = (TH1*)FindMonObj("h1_evt_qual");
 
-  pad_main->cd();
-  pad_main->SetGrid();
-  pad_main->Divide(1, 2);
+  OnlMonCanvas* can = GetCanvas();
+  TPad* pad = can->GetMainPad();
+  pad->SetGrid();
+  pad->Divide(1, 2);
 
-  pad_main->cd(1);
+  pad->cd(1);
   if (h1_evt_qual->Integral() > 100) gPad->SetLogy();
   h1_evt_qual->Draw();
 
-  pad_main->cd(2);
+  pad->cd(2);
   h1_tgt->Draw();
 
-  AddMessage("Always Okay ;^D");
-  SetStatus(OK);
+  can->AddMessage("Always Okay ;^D");
+  can->SetStatus(OnlMonCanvas::OK);
 
   return 0;
 }

--- a/online/onlmonserver/OnlMonMainDaq.h
+++ b/online/onlmonserver/OnlMonMainDaq.h
@@ -21,7 +21,6 @@ class OnlMonMainDaq: public OnlMonClient {
   int DrawMonitor();
 
  private:
-  void PrintSpill(SQSpill* spi);
   void PrintEvent(SQEvent* evt, SQHitVector* v_hit, SQHitVector* v_trig_hit);
 };
 

--- a/online/onlmonserver/OnlMonMainDaqLinkDef.h
+++ b/online/onlmonserver/OnlMonMainDaqLinkDef.h
@@ -1,5 +1,0 @@
-#ifdef __CINT__
-
-#pragma link C++ class OnlMonMainDaq-!;
-
-#endif

--- a/online/onlmonserver/OnlMonServerLinkDef.h
+++ b/online/onlmonserver/OnlMonServerLinkDef.h
@@ -1,5 +1,0 @@
-#ifdef __CINT__
-
-#pragma link C++ class OnlMonServer-!;
-
-#endif

--- a/online/onlmonserver/OnlMonSpill.cc
+++ b/online/onlmonserver/OnlMonSpill.cc
@@ -1,0 +1,127 @@
+/// OnlMonSpill.C
+#include <iomanip>
+//#include <TH1D.h>
+//#include <TSocket.h>
+#include <TClass.h>
+#include <interface_main/SQRun.h>
+#include <interface_main/SQSpillMap.h>
+#include <interface_main/SQSpill.h>
+#include <interface_main/SQEvent.h>
+#include <interface_main/SQStringMap.h>
+#include <interface_main/SQScaler.h>
+#include <interface_main/SQSlowCont.h>
+#include <fun4all/Fun4AllReturnCodes.h>
+#include <fun4all/Fun4AllHistoManager.h>
+#include <phool/PHNodeIterator.h>
+#include <phool/PHIODataNode.h>
+#include <phool/getClass.h>
+#include <TSQLServer.h>
+#include <db_svc/DbSvc.h>
+#include "OnlMonServer.h"
+#include "OnlMonSpill.h"
+using namespace std;
+
+OnlMonSpill::OnlMonSpill(const std::string& name) : OnlMonClient(name)
+{
+  ;
+}
+
+int OnlMonSpill::Init(PHCompositeNode* topNode)
+{
+  //Fun4AllHistoManager* hm = new Fun4AllHistoManager(Name());
+  //OnlMonServer::instance()->registerHistoManager(hm);
+  //hm->registerHisto(h1_tgt);
+  //hm->registerHisto(h1_evt_qual);
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int OnlMonSpill::InitRun(PHCompositeNode* topNode)
+{
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int OnlMonSpill::process_event(PHCompositeNode* topNode)
+{
+  SQSpillMap*     spill_map = findNode::getClass<SQSpillMap >(topNode, "SQSpillMap");
+  SQEvent*     event_header = findNode::getClass<SQEvent    >(topNode, "SQEvent");
+  if (!spill_map || !event_header) return Fun4AllReturnCodes::ABORTEVENT;
+
+  static int spill_id_pre = -1;
+  if (event_header->get_spill_id() != spill_id_pre) {
+    spill_id_pre = event_header->get_spill_id();
+    SQSpill* spi = spill_map->get(spill_id_pre);
+    //PrintSpill(spi);
+    UploadToDB(spi);
+  }
+  
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int OnlMonSpill::End(PHCompositeNode* topNode)
+{
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int OnlMonSpill::DrawMonitor()
+{
+  return 0;
+}
+
+void OnlMonSpill::UploadToDB(SQSpill* spi)
+{
+  DbSvc db(DbSvc::DB1);
+  db.UseSchema("user_e1039_maindaq", true);
+  if (! db.HasTable("spill")) {
+    const char* list_var [] = { "run_id", "spill_id", "target_pos", "bos_coda_id", "bos_vme_time", "eos_coda_id", "eos_vme_time" };
+    const char* list_type[] = { "INT"   , "INT"     , "INT"       , "INT"        , "INT"         , "INT"        , "INT"          };
+    const int   n_var       = 7;
+    const char* list_key[] = { "run_id", "spill_id" };
+    const int   n_key      = 2;
+    db.CreateTable("spill", n_var, list_var, list_type, n_key, list_key);
+  }
+  
+  ostringstream oss;
+  oss << "insert into spill (run_id, spill_id, target_pos, bos_coda_id, bos_vme_time, eos_coda_id, eos_vme_time) values ("
+      << spi->get_run_id      () << ", "
+      << spi->get_spill_id    () << ", "
+      << spi->get_target_pos  () << ", "
+      << spi->get_bos_coda_id () << ", "
+      << spi->get_bos_vme_time() << ", "
+      << spi->get_eos_coda_id () << ", "
+      << spi->get_eos_vme_time() << ") on duplicate key update target_pos=values(target_pos), bos_coda_id=values(bos_coda_id), bos_vme_time=values(bos_vme_time), eos_coda_id=values(eos_coda_id), eos_vme_time=values(eos_vme_time)";
+  if (! db.Con()->Exec(oss.str().c_str())) {
+    cerr << "!!ERROR!!  OnlMonSpill::UploadToDB()." << endl;
+    return;
+  }
+}
+
+void OnlMonSpill::PrintSpill(SQSpill* spi)
+{
+  cout << "SQSpill:  "
+       << "  " << spi->get_spill_id    ()
+       << "  " << spi->get_run_id      ()
+       << "  " << spi->get_target_pos  ()
+       << "  " << spi->get_bos_coda_id ()
+       << "  " << spi->get_bos_vme_time()
+       << "  " << spi->get_eos_coda_id ()
+       << "  " << spi->get_eos_vme_time()
+       << "  \nBOS Scaler:  " << spi->get_bos_scaler_list()->size() << "\n";
+  for (SQStringMap::ConstIter it = spi->get_bos_scaler_list()->begin(); it != spi->get_bos_scaler_list()->end(); it++) {
+    string name = it->first;
+    SQScaler* sca = dynamic_cast<SQScaler*>(it->second);
+    cout << "    " << setw(20) << name << " " << setw(10) << sca->get_count() << "\n";
+  }
+  cout << "  EOS Scaler:  " << spi->get_eos_scaler_list()->size() << "\n";
+  for (SQStringMap::ConstIter it = spi->get_eos_scaler_list()->begin(); it != spi->get_eos_scaler_list()->end(); it++) {
+    string name = it->first;
+    SQScaler* sca = dynamic_cast<SQScaler*>(it->second);
+    cout << "  " << setw(20) << name << " " << setw(10) << sca->get_count() << "\n";
+  }
+  cout << "  Slow Control  " << spi->get_slow_cont_list()->size() << ":\n";
+  for (SQStringMap::ConstIter it = spi->get_slow_cont_list()->begin(); it != spi->get_slow_cont_list()->end(); it++) {
+    string name = it->first;
+    SQSlowCont* slo = dynamic_cast<SQSlowCont*>(it->second);
+    cout << "  " << setw(20) << name << " " << slo->get_time_stamp() << " " << setw(20) << slo->get_value() << " " << slo->get_type() << "\n";
+  }
+}

--- a/online/onlmonserver/OnlMonSpill.h
+++ b/online/onlmonserver/OnlMonSpill.h
@@ -1,0 +1,22 @@
+#ifndef _ONL_MON_SPILL__H_
+#define _ONL_MON_SPILL__H_
+#include "OnlMonClient.h"
+class SQSpill;
+
+class OnlMonSpill: public OnlMonClient {
+ public:
+  OnlMonSpill(const std::string &name = "OnlMonSpill");
+  virtual ~OnlMonSpill() {}
+  int Init(PHCompositeNode *topNode);
+  int InitRun(PHCompositeNode *topNode);
+  int process_event(PHCompositeNode *topNode);
+  int End(PHCompositeNode *topNode);
+
+  int DrawMonitor();
+
+ private:
+  void UploadToDB(SQSpill* spi);
+  void PrintSpill(SQSpill* spi);
+};
+
+#endif /* _ONL_MON_SPILL__H_ */

--- a/packages/db_svc/DbSvc.cc
+++ b/packages/db_svc/DbSvc.cc
@@ -78,7 +78,7 @@ bool DbSvc::HasTable(const char* name, const bool exit_on_false)
   return false;
 }
 
-void DbSvc::CreateTable(const std::string name, const std::vector<std::string> list_var, const std::vector<std::string> list_type)
+void DbSvc::CreateTable(const std::string name, const std::vector<std::string> list_var, const std::vector<std::string> list_type, const std::vector<std::string> list_key)
 {
   if (HasTable(name)) {
     cerr << "!!ERROR!!  DbSvc::CreateTable():  Table '" << name << "' already exists.  To avoid an unintended creation, please check and drop the table in your code.  Abort." << endl;
@@ -94,14 +94,24 @@ void DbSvc::CreateTable(const std::string name, const std::vector<std::string> l
   for (unsigned int ii = 0; ii < list_var.size(); ii++) {
     oss << list_var[ii] << " " << list_type[ii] << ", ";
   }
-  oss << "primary_id INT not null auto_increment, PRIMARY KEY (primary_id) )";
+  if (list_key.size() == 0) {
+    oss << "primary_id INT not null auto_increment, PRIMARY KEY (primary_id)";
+  } else {
+    oss << "PRIMARY KEY (";
+    for (unsigned int ii = 0; ii < list_key.size(); ii++) {
+      if (ii != 0) oss << ", ";
+      oss << list_key[ii];
+    }
+    oss << ")";
+  }
+  oss << ")";
   if (! m_con->Exec(oss.str().c_str())) {
     cerr << "!!ERROR!!  DbSvc::CreateTable():  The creation query failed.  Abort." << endl;
     exit(1);
   }
 }
 
-void DbSvc::CreateTable(const std::string name, const int n_var, const char** list_var, const char** list_type)
+void DbSvc::CreateTable(const std::string name, const int n_var, const char** list_var, const char** list_type, const int n_key, const char** list_key)
 {
   vector<string> vec_var;
   vector<string> vec_type;
@@ -109,7 +119,11 @@ void DbSvc::CreateTable(const std::string name, const int n_var, const char** li
     vec_var .push_back(list_var [ii]);
     vec_type.push_back(list_type[ii]);
   }
-  CreateTable(name, vec_var, vec_type);
+  vector<string> vec_key;
+  for (int ii = 0; ii < n_key; ii++) {
+    vec_key.push_back(list_key[ii]);
+  }
+  CreateTable(name, vec_var, vec_type, vec_key);
 }
 
 /** This function runs Statement(), Process() and StoreResult() with error check.

--- a/packages/db_svc/DbSvc.h
+++ b/packages/db_svc/DbSvc.h
@@ -21,8 +21,8 @@ class DbSvc {
   void DropTable  (const std::string name) { DropTable(name.c_str()); }
   bool HasTable(const char* name, const bool exit_on_false=false);
   bool HasTable(const std::string name, const bool exit_on_false=false) { return HasTable(name.c_str(), exit_on_false); }
-  void CreateTable(const std::string name, const std::vector<std::string> list_var, const std::vector<std::string> list_type);
-  void CreateTable(const std::string name, const int n_var, const char** list_var, const char** list_type);
+  void CreateTable(const std::string name, const std::vector<std::string> list_var, const std::vector<std::string> list_type, const std::vector<std::string> list_key);
+  void CreateTable(const std::string name, const int n_var, const char** list_var, const char** list_type, const int n_key=0, const char** list_key=0);
   
   TSQLServer* Con() { return m_con; }
   TSQLStatement* Process(const char*       query);


### PR DESCRIPTION
I added two online-monitor classes (OnlMonSpill and OnlMonCham).  OnlMonCham is a typical example of subsystem basic monitors, which monitors the distributions of element IDs and tdcTimes.
The viewer macro (OnlMon4MainDaq.C) was also updated so as to select the monitor to be drawn, as seen in the attached screenshot.

![onlmon_example_20190503](https://user-images.githubusercontent.com/41366345/57122284-80459f80-6db7-11e9-8005-6b5c3dcb3e60.png)
