### PR TITLE
More online-monitor clients and related updates

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -25,27 +25,27 @@ else
     online/chan_map
     online/onlmonserver
     online/decoder_maindaq
-    packages/Half
-    packages/vararray
-    database/pdbcal/base
-    database/PHParameter
-    packages/PHGeometry
-    packages/PHField
-    generators/phhepmc
-    generators/PHPythia8
-    simulation/g4decayer
-    simulation/g4gdml
-    simulation/g4main
-    simulation/g4detectors
-    simulation/g4dst
-    simulation/g4eval
-    packages/dptrigger
-    #packages/db2g4
-    packages/PHGenFitPkg/GenFitExp
-    packages/PHGenFitPkg/PHGenFit
-    packages/ktracker
-    packages/embedding
-    module_example
+#    packages/Half
+#    packages/vararray
+#    database/pdbcal/base
+#    database/PHParameter
+#    packages/PHGeometry
+#    packages/PHField
+#    generators/phhepmc
+#    generators/PHPythia8
+#    simulation/g4decayer
+#    simulation/g4gdml
+#    simulation/g4main
+#    simulation/g4detectors
+#    simulation/g4dst
+#    simulation/g4eval
+#    packages/dptrigger
+#    #packages/db2g4
+#    packages/PHGenFitPkg/GenFitExp
+#    packages/PHGenFitPkg/PHGenFit
+#    packages/ktracker
+#    packages/embedding
+#    module_example
 	)
 fi
 

--- a/build.sh
+++ b/build.sh
@@ -25,27 +25,27 @@ else
     online/chan_map
     online/onlmonserver
     online/decoder_maindaq
-#    packages/Half
-#    packages/vararray
-#    database/pdbcal/base
-#    database/PHParameter
-#    packages/PHGeometry
-#    packages/PHField
-#    generators/phhepmc
-#    generators/PHPythia8
-#    simulation/g4decayer
-#    simulation/g4gdml
-#    simulation/g4main
-#    simulation/g4detectors
-#    simulation/g4dst
-#    simulation/g4eval
-#    packages/dptrigger
-#    #packages/db2g4
-#    packages/PHGenFitPkg/GenFitExp
-#    packages/PHGenFitPkg/PHGenFit
-#    packages/ktracker
-#    packages/embedding
-#    module_example
+    packages/Half
+    packages/vararray
+    database/pdbcal/base
+    database/PHParameter
+    packages/PHGeometry
+    packages/PHField
+    generators/phhepmc
+    generators/PHPythia8
+    simulation/g4decayer
+    simulation/g4gdml
+    simulation/g4main
+    simulation/g4detectors
+    simulation/g4dst
+    simulation/g4eval
+    packages/dptrigger
+    #packages/db2g4
+    packages/PHGenFitPkg/GenFitExp
+    packages/PHGenFitPkg/PHGenFit
+    packages/ktracker
+    packages/embedding
+    module_example
 	)
 fi
 

--- a/interface_main/SQHit.h
+++ b/interface_main/SQHit.h
@@ -45,6 +45,9 @@ public:
   virtual short        get_element_id() const                           {return std::numeric_limits<short>::max();}
   virtual void         set_element_id(const short a)                    {}
 
+  virtual short        get_level() const                                {return std::numeric_limits<short>::max();}
+  virtual void         set_level(const short a)                         {}
+
   virtual float        get_tdc_time() const                             {return std::numeric_limits<float>::max();}
   virtual void         set_tdc_time(const float a)                      {}
 

--- a/interface_main/SQHit_v1.cxx
+++ b/interface_main/SQHit_v1.cxx
@@ -17,6 +17,7 @@ SQHit_v1::SQHit_v1()
   : _hit_id(std::numeric_limits<int>::max()),
 	_detector_id(std::numeric_limits<short>::max()),
 	_element_id(std::numeric_limits<short>::max()),
+	_level(std::numeric_limits<short>::max()),
 	_tdc_time(NAN),
 	_drift_distance(NAN),
 	_pos(NAN),
@@ -26,7 +27,7 @@ SQHit_v1::SQHit_v1()
 void SQHit_v1::identify(ostream& os) const {
   os << "---SQHit_v1--------------------" << endl;
   os << " hitID: " << get_hit_id() << endl;
-  os << " detectorID: " << get_detector_id() << " elementID: "<< get_element_id() << endl;
+  os << " detectorID: " << get_detector_id() << " elementID: "<< get_element_id() << " level: "<< get_level() << endl;
   os
   << " tdcTime: " << get_tdc_time()
   << " driftDistance: " << get_drift_distance()
@@ -46,6 +47,7 @@ int SQHit_v1::isValid() const {
   if (_hit_id == std::numeric_limits<int>::max()) return 0;
   if (_detector_id == std::numeric_limits<short>::max()) return 0;
   if (_element_id == std::numeric_limits<short>::max()) return 0;
+  if (_level      == std::numeric_limits<short>::max()) return 0;
   if (isnan(_tdc_time)) return 0;
   if (isnan(_drift_distance)) return 0;
   //if (isnan(_pos)) return 0;

--- a/interface_main/SQHit_v1.h
+++ b/interface_main/SQHit_v1.h
@@ -39,6 +39,9 @@ public:
   virtual short        get_element_id() const                    {return _element_id;}
   virtual void         set_element_id(const short id)            {_element_id = id;}
 
+  virtual short        get_level() const                         {return _level;}
+  virtual void         set_level(const short level)              {_level = level;}
+
   virtual float        get_tdc_time() const                      {return _tdc_time;}
   virtual void         set_tdc_time(const float a)               {_tdc_time=a;}
 
@@ -62,6 +65,7 @@ private:
   int _hit_id;                   ///< hitID
   short _detector_id;            ///< mapping from detector name to ID
   short _element_id;             ///< elementID
+  short _level;                  ///< level of v1495 (meaningful only for trigger hit)
 
   float _tdc_time;               ///< tdcTime
   float _drift_distance;         ///< driftDistance

--- a/macros/Fun4MainDaq.C
+++ b/macros/Fun4MainDaq.C
@@ -39,7 +39,7 @@ int Fun4MainDaq(const int nevent = 0, const int run = 28700)
   Fun4AllEVIOInputManager *in = new Fun4AllEVIOInputManager("MainDaq");
   in->Verbosity(1);
   in->EventSamplingFactor(100);
-//  if (is_online) in->PretendSpillInterval(20);
+  if (is_online) in->PretendSpillInterval(20);
 
   in->DirParam("/seaquest/production/runs");
   in->fileopen(fn_in);
@@ -61,21 +61,21 @@ int Fun4MainDaq(const int nevent = 0, const int run = 28700)
     se->registerSubsystem(new OnlMonV1495(OnlMonV1495::H2X, 1));
     se->registerSubsystem(new OnlMonV1495(OnlMonV1495::H3X, 1));
     se->registerSubsystem(new OnlMonV1495(OnlMonV1495::H4X, 1));
-    se->registerSubsystem(new OnlMonHodo(OnlMonHodo::H1X));
-    se->registerSubsystem(new OnlMonHodo(OnlMonHodo::H2X));
-    se->registerSubsystem(new OnlMonHodo(OnlMonHodo::H3X));
-    se->registerSubsystem(new OnlMonHodo(OnlMonHodo::H4X));
-    se->registerSubsystem(new OnlMonHodo(OnlMonHodo::H1Y));
-    se->registerSubsystem(new OnlMonHodo(OnlMonHodo::H2Y));
-    se->registerSubsystem(new OnlMonHodo(OnlMonHodo::H4Y1));
-    se->registerSubsystem(new OnlMonHodo(OnlMonHodo::H4Y2));
-    se->registerSubsystem(new OnlMonCham(OnlMonCham::D0));
-    se->registerSubsystem(new OnlMonCham(OnlMonCham::D1));
-    se->registerSubsystem(new OnlMonCham(OnlMonCham::D2));
-    se->registerSubsystem(new OnlMonCham(OnlMonCham::D3p));
-    se->registerSubsystem(new OnlMonCham(OnlMonCham::D3m));
-    se->registerSubsystem(new OnlMonProp(OnlMonProp::P1));
-    se->registerSubsystem(new OnlMonProp(OnlMonProp::P2));
+    se->registerSubsystem(new OnlMonHodo (OnlMonHodo::H1X));
+    se->registerSubsystem(new OnlMonHodo (OnlMonHodo::H2X));
+    se->registerSubsystem(new OnlMonHodo (OnlMonHodo::H3X));
+    se->registerSubsystem(new OnlMonHodo (OnlMonHodo::H4X));
+    se->registerSubsystem(new OnlMonHodo (OnlMonHodo::H1Y));
+    se->registerSubsystem(new OnlMonHodo (OnlMonHodo::H2Y));
+    se->registerSubsystem(new OnlMonHodo (OnlMonHodo::H4Y1));
+    se->registerSubsystem(new OnlMonHodo (OnlMonHodo::H4Y2));
+    se->registerSubsystem(new OnlMonCham (OnlMonCham::D0));
+    se->registerSubsystem(new OnlMonCham (OnlMonCham::D1));
+    se->registerSubsystem(new OnlMonCham (OnlMonCham::D2));
+    se->registerSubsystem(new OnlMonCham (OnlMonCham::D3p));
+    se->registerSubsystem(new OnlMonCham (OnlMonCham::D3m));
+    se->registerSubsystem(new OnlMonProp (OnlMonProp::P1));
+    se->registerSubsystem(new OnlMonProp (OnlMonProp::P2));
   }
 
   se->run(nevent);

--- a/macros/Fun4MainDaq.C
+++ b/macros/Fun4MainDaq.C
@@ -39,7 +39,7 @@ int Fun4MainDaq(const int nevent = 0, const int run = 28700)
   Fun4AllEVIOInputManager *in = new Fun4AllEVIOInputManager("MainDaq");
   in->Verbosity(1);
   in->EventSamplingFactor(100);
-  if (is_online) in->PretendSpillInterval(20);
+//  if (is_online) in->PretendSpillInterval(20);
 
   in->DirParam("/seaquest/production/runs");
   in->fileopen(fn_in);
@@ -56,8 +56,26 @@ int Fun4MainDaq(const int nevent = 0, const int run = 28700)
   if (is_online) { // Register the online-monitoring clients
     se->StartServer();
     se->registerSubsystem(new OnlMonMainDaq());
+    se->registerSubsystem(new OnlMonTrigSig());
+    se->registerSubsystem(new OnlMonV1495(OnlMonV1495::H1X, 1));
+    se->registerSubsystem(new OnlMonV1495(OnlMonV1495::H2X, 1));
+    se->registerSubsystem(new OnlMonV1495(OnlMonV1495::H3X, 1));
+    se->registerSubsystem(new OnlMonV1495(OnlMonV1495::H4X, 1));
+    se->registerSubsystem(new OnlMonHodo(OnlMonHodo::H1X));
+    se->registerSubsystem(new OnlMonHodo(OnlMonHodo::H2X));
+    se->registerSubsystem(new OnlMonHodo(OnlMonHodo::H3X));
+    se->registerSubsystem(new OnlMonHodo(OnlMonHodo::H4X));
+    se->registerSubsystem(new OnlMonHodo(OnlMonHodo::H1Y));
+    se->registerSubsystem(new OnlMonHodo(OnlMonHodo::H2Y));
+    se->registerSubsystem(new OnlMonHodo(OnlMonHodo::H4Y1));
+    se->registerSubsystem(new OnlMonHodo(OnlMonHodo::H4Y2));
+    se->registerSubsystem(new OnlMonCham(OnlMonCham::D0));
+    se->registerSubsystem(new OnlMonCham(OnlMonCham::D1));
+    se->registerSubsystem(new OnlMonCham(OnlMonCham::D2));
     se->registerSubsystem(new OnlMonCham(OnlMonCham::D3p));
     se->registerSubsystem(new OnlMonCham(OnlMonCham::D3m));
+    se->registerSubsystem(new OnlMonProp(OnlMonProp::P1));
+    se->registerSubsystem(new OnlMonProp(OnlMonProp::P2));
   }
 
   se->run(nevent);

--- a/macros/Fun4MainDaq.C
+++ b/macros/Fun4MainDaq.C
@@ -39,7 +39,7 @@ int Fun4MainDaq(const int nevent = 0, const int run = 28700)
   Fun4AllEVIOInputManager *in = new Fun4AllEVIOInputManager("MainDaq");
   in->Verbosity(1);
   in->EventSamplingFactor(100);
-  if (is_online) in->PretendSpillInterval(20);
+//  if (is_online) in->PretendSpillInterval(20);
 
   in->DirParam("/seaquest/production/runs");
   in->fileopen(fn_in);

--- a/macros/OnlMon4MainDaq.C
+++ b/macros/OnlMon4MainDaq.C
@@ -17,14 +17,18 @@ int OnlMon4MainDaq()
   vector<OnlMonClient*> list_omc;
   list_omc.push_back(new OnlMonMainDaq());
   list_omc.push_back(new OnlMonTrigSig());
-  list_omc.push_back(new OnlMonV1495(OnlMonV1495::H1, 1));
-  list_omc.push_back(new OnlMonV1495(OnlMonV1495::H2, 1));
-  list_omc.push_back(new OnlMonV1495(OnlMonV1495::H3, 1));
-  list_omc.push_back(new OnlMonV1495(OnlMonV1495::H4, 1));
-  list_omc.push_back(new OnlMonHodo (OnlMonHodo ::H1 ));
-  list_omc.push_back(new OnlMonHodo (OnlMonHodo ::H2 ));
-  list_omc.push_back(new OnlMonHodo (OnlMonHodo ::H3 ));
-  list_omc.push_back(new OnlMonHodo (OnlMonHodo ::H4 ));
+  list_omc.push_back(new OnlMonV1495(OnlMonV1495::H1X, 1));
+  list_omc.push_back(new OnlMonV1495(OnlMonV1495::H2X, 1));
+  list_omc.push_back(new OnlMonV1495(OnlMonV1495::H3X, 1));
+  list_omc.push_back(new OnlMonV1495(OnlMonV1495::H4X, 1));
+  list_omc.push_back(new OnlMonHodo (OnlMonHodo ::H1X ));
+  list_omc.push_back(new OnlMonHodo (OnlMonHodo ::H2X ));
+  list_omc.push_back(new OnlMonHodo (OnlMonHodo ::H3X ));
+  list_omc.push_back(new OnlMonHodo (OnlMonHodo ::H4X ));
+  list_omc.push_back(new OnlMonHodo (OnlMonHodo ::H1Y ));
+  list_omc.push_back(new OnlMonHodo (OnlMonHodo ::H2Y ));
+  list_omc.push_back(new OnlMonHodo (OnlMonHodo ::H4Y1));
+  list_omc.push_back(new OnlMonHodo (OnlMonHodo ::H4Y2));
   list_omc.push_back(new OnlMonCham (OnlMonCham ::D0 ));
   list_omc.push_back(new OnlMonCham (OnlMonCham ::D1 ));
   list_omc.push_back(new OnlMonCham (OnlMonCham ::D2 ));
@@ -42,11 +46,11 @@ int OnlMon4MainDaq()
   for (unsigned int ii = 0; ii < list_omc.size(); ii++) {
     button[ii] = new TGTextButton(frame, list_omc[ii]->Title().c_str());
     button[ii]->Connect("Clicked()", "OnlMonClient", list_omc[ii], "StartMonitor()");
-    frame->AddFrame(button[ii], new TGLayoutHints(kLHintsNormal | kLHintsExpandX, 10,10,20,20)); // (l, r, t, b) 
+    frame->AddFrame(button[ii], new TGLayoutHints(kLHintsNormal | kLHintsExpandX, 5,5,10,10)); // (l, r, t, b) 
   }
   
   TGTextButton* fExit = new TGTextButton(frame, "Exit","gApplication->Terminate(0)");
-  frame->AddFrame(fExit, new TGLayoutHints(kLHintsTop | kLHintsExpandX, 10,10,20,20));
+  frame->AddFrame(fExit, new TGLayoutHints(kLHintsTop | kLHintsExpandX, 5,5,10,10));
 
   frame->SetWindowName("E1039 Online Monitor");
   frame->MapSubwindows();

--- a/macros/OnlMon4MainDaq.C
+++ b/macros/OnlMon4MainDaq.C
@@ -46,11 +46,17 @@ int OnlMon4MainDaq()
   for (unsigned int ii = 0; ii < list_omc.size(); ii++) {
     button[ii] = new TGTextButton(frame, list_omc[ii]->Title().c_str());
     button[ii]->Connect("Clicked()", "OnlMonClient", list_omc[ii], "StartMonitor()");
-    frame->AddFrame(button[ii], new TGLayoutHints(kLHintsNormal | kLHintsExpandX, 5,5,10,10)); // (l, r, t, b) 
+    frame->AddFrame(button[ii], new TGLayoutHints(kLHintsNormal | kLHintsExpandX, 2,2,5,5)); // (l, r, t, b) 
   }
-  
+
+  TGCheckButton* check = new TGCheckButton(frame, new TGHotString("Auto-close all canvases"), 99);
+  check->SetToolTipText("When checked, all existing canvases are closed by clicking any button above.");
+  check->SetState(OnlMonClient::GetClearUsFlag() ? kButtonDown : kButtonUp);
+  check->Connect("Toggled(Bool_t)", "OnlMonClient", list_omc[0], "SetClearUsFlag(Bool_t)");
+  frame->AddFrame(check, new TGLayoutHints(kLHintsCenterX | kLHintsCenterY, 2,2,5,5));
+ 
   TGTextButton* fExit = new TGTextButton(frame, "Exit","gApplication->Terminate(0)");
-  frame->AddFrame(fExit, new TGLayoutHints(kLHintsTop | kLHintsExpandX, 5,5,10,10));
+  frame->AddFrame(fExit, new TGLayoutHints(kLHintsTop | kLHintsExpandX, 2,2,5,5));
 
   frame->SetWindowName("E1039 Online Monitor");
   frame->MapSubwindows();

--- a/macros/OnlMon4MainDaq.C
+++ b/macros/OnlMon4MainDaq.C
@@ -16,20 +16,31 @@ int OnlMon4MainDaq()
 
   vector<OnlMonClient*> list_omc;
   list_omc.push_back(new OnlMonMainDaq());
-  list_omc.push_back(new OnlMonCham(OnlMonCham::D0 ));
-  list_omc.push_back(new OnlMonCham(OnlMonCham::D1 ));
-  list_omc.push_back(new OnlMonCham(OnlMonCham::D2 ));
-  list_omc.push_back(new OnlMonCham(OnlMonCham::D3p));
-  list_omc.push_back(new OnlMonCham(OnlMonCham::D3m));
+  list_omc.push_back(new OnlMonTrigSig());
+  list_omc.push_back(new OnlMonV1495(OnlMonV1495::H1, 1));
+  list_omc.push_back(new OnlMonV1495(OnlMonV1495::H2, 1));
+  list_omc.push_back(new OnlMonV1495(OnlMonV1495::H3, 1));
+  list_omc.push_back(new OnlMonV1495(OnlMonV1495::H4, 1));
+  list_omc.push_back(new OnlMonHodo (OnlMonHodo ::H1 ));
+  list_omc.push_back(new OnlMonHodo (OnlMonHodo ::H2 ));
+  list_omc.push_back(new OnlMonHodo (OnlMonHodo ::H3 ));
+  list_omc.push_back(new OnlMonHodo (OnlMonHodo ::H4 ));
+  list_omc.push_back(new OnlMonCham (OnlMonCham ::D0 ));
+  list_omc.push_back(new OnlMonCham (OnlMonCham ::D1 ));
+  list_omc.push_back(new OnlMonCham (OnlMonCham ::D2 ));
+  list_omc.push_back(new OnlMonCham (OnlMonCham ::D3p));
+  list_omc.push_back(new OnlMonCham (OnlMonCham ::D3m));
+  list_omc.push_back(new OnlMonProp (OnlMonProp ::P1 ));
+  list_omc.push_back(new OnlMonProp (OnlMonProp ::P2 ));
   
-  TGMainFrame* frame = new TGMainFrame(gClient->GetRoot(), 400, 800);
+  TGMainFrame* frame = new TGMainFrame(gClient->GetRoot(), 200, 800);
 
-  TGTextView* head = new TGTextView(frame, 400, 50, "E1039 OnlMon Selector");
+  TGTextView* head = new TGTextView(frame, 200, 50, "E1039 OnlMon Selector");
   frame->AddFrame(head); 
 
   TGTextButton*  button[99];
   for (unsigned int ii = 0; ii < list_omc.size(); ii++) {
-    button[ii] = new TGTextButton(frame, list_omc[ii]->Name().c_str());
+    button[ii] = new TGTextButton(frame, list_omc[ii]->Title().c_str());
     button[ii]->Connect("Clicked()", "OnlMonClient", list_omc[ii], "StartMonitor()");
     frame->AddFrame(button[ii], new TGLayoutHints(kLHintsNormal | kLHintsExpandX, 10,10,20,20)); // (l, r, t, b) 
   }

--- a/online/chan_map/CalibParamXT.cc
+++ b/online/chan_map/CalibParamXT.cc
@@ -93,7 +93,17 @@ void CalibParamXT::Add(
   const std::string det,
   const double t, const double x, const double dx)
 {
-  const int ele = 1; // any element is OK??
+  /// The X-T curve of the prop tubes is given per plane pair in the TSV file (at present), 
+  /// namely P1H, P1V, P2V and P2H.  Since CalibParamXT needs one X-T curve per plane,
+  /// two X-T curves are being made from one input (ex. P1H1f & P1H1b from P1H).
+  /// In the future, the X-T curve is expected to be given per plane, like the drift chamber.
+  if (det[0] == 'P' && det.length() == 3) {
+    Add(det + "1f", t, x, dx);
+    Add(det + "1b", t, x, dx);
+    return;
+  }
+
+  const int ele = 1; // Any element is OK since the X-T curve is single per plane.
   GeomSvc* geom = GeomSvc::instance();
   string det_new = det;
   int    ele_new = ele;
@@ -101,12 +111,12 @@ void CalibParamXT::Add(
   int det_id = geom->getDetectorID(det_new);
   Add(det, det_id, t, x, dx);
 
-  if (ele_new != ele) { // I know the current version cannot handle "P4" properly!!
-    cout << "!WARNING!  CalibParamXT::Add():  The GeomSvc conversion changed element ID unexpectedly:\n"
-         << "  From det = " << det << ", ele = " << ele << "\n"
-         << "  To   det = " << det_new << " (id=" << det_id << "), ele = " << ele_new << "\n"
-         << "  The mapping result will be incorrect!!" << endl;
-  }
+  //if (ele_new != ele) {
+  //  cout << "!WARNING!  CalibParamXT::Add():  The GeomSvc conversion changed element ID unexpectedly:\n"
+  //       << "  From det = " << det << ", ele = " << ele << "\n"
+  //       << "  To   det = " << det_new << " (id=" << det_id << "), ele = " << ele_new << "\n"
+  //       << "  The mapping result will be incorrect!!" << endl;
+  //}
 }
 
 void CalibParamXT::Add(

--- a/online/decoder_maindaq/CalibInTime.cc
+++ b/online/decoder_maindaq/CalibInTime.cc
@@ -53,10 +53,14 @@ int CalibInTime::process_event(PHCompositeNode* topNode)
     SQHit* hit = *it;
     int det = hit->get_detector_id();
     int ele = hit->get_element_id();
+    if (det == 0) continue; /// Just skip here.  Must be warned by the channel mapper instead.
+
     double center, width;
     if (! m_cal_taiwan->Find(det, ele, center, width)) {
       cerr << "  WARNING:  Cannot find the in-time parameter for det=" << det << " ele=" << ele << ".\n";
-      return Fun4AllReturnCodes::ABORTEVENT;
+      hit->set_in_time(false);
+      continue;
+      //return Fun4AllReturnCodes::ABORTEVENT;
     }
     hit->set_in_time( fabs(hit->get_tdc_time() - center) <= width / 2 );
   }
@@ -65,13 +69,15 @@ int CalibInTime::process_event(PHCompositeNode* topNode)
     SQHit* hit = *it;
     int det = hit->get_detector_id();
     int ele = hit->get_element_id();
-    int lvl = 0; // not available in SQHit yet.
-    if (det == 0) continue; // known that the mapping is not complete yet.
+    int lvl = hit->get_level();
+    if (det == 0) continue; /// Just skip here.  Must be warned by the channel mapper instead.
 
     double center, width;
     if (! m_cal_v1495->Find(det, ele, lvl, center, width)) {
-      cerr << "  WARNING:  Cannot find the in-time parameter for trigger det=" << det << " ele=" << ele << ".\n";
-      return Fun4AllReturnCodes::ABORTEVENT;
+      cerr << "  WARNING:  Cannot find the in-time parameter for trigger det=" << det << " ele=" << ele << " lvl=" << lvl << ".\n";
+      hit->set_in_time(false);
+      continue;
+      //return Fun4AllReturnCodes::ABORTEVENT;
     }
     hit->set_in_time( fabs(hit->get_tdc_time() - center) <= width / 2 );
   }

--- a/online/decoder_maindaq/CalibXT.cc
+++ b/online/decoder_maindaq/CalibXT.cc
@@ -57,8 +57,9 @@ int CalibXT::process_event(PHCompositeNode* topNode)
       int ele = hit->get_element_id();
       double center, width;
       if (! m_cal_int->Find(det, ele, center, width)) {
-        cerr << "  WARNING:  Cannot find the in-time parameter for det=" << det << " ele=" << ele << ".\n";
-        return Fun4AllReturnCodes::ABORTEVENT;
+        cerr << "  WARNING:  Cannot find the in-time parameter for det=" << det << " ele=" << ele << " in CalibXT.\n";
+        continue;
+        //return Fun4AllReturnCodes::ABORTEVENT;
       }
       float t0 = center + width / 2;
       float drift_time = t0 - hit->get_tdc_time();

--- a/online/decoder_maindaq/DecoData.cc
+++ b/online/decoder_maindaq/DecoData.cc
@@ -68,7 +68,7 @@ SpillData::SpillData() :
 //
 
 HitData::HitData() :
-  event(0), id(0), roc(0), board(0), chan(0), det(0), ele(0), time(0)
+  event(0), id(0), roc(0), board(0), chan(0), det(0), ele(0), lvl(0), time(0)
 {
   ;
 }

--- a/online/decoder_maindaq/DecoData.h
+++ b/online/decoder_maindaq/DecoData.h
@@ -172,6 +172,7 @@ struct HitData {
   short chan;
   short det;
   short ele;
+  short lvl;
   double         time;
   HitData();
   virtual ~HitData() {;}

--- a/online/decoder_maindaq/Fun4AllEVIOInputManager.cc
+++ b/online/decoder_maindaq/Fun4AllEVIOInputManager.cc
@@ -322,6 +322,7 @@ int Fun4AllEVIOInputManager::run(const int nevents)
     hit->set_hit_id     (hd->id  );
     hit->set_detector_id(hd->det );
     hit->set_element_id (hd->ele );
+    hit->set_level      (hd->lvl );
     hit->set_tdc_time   (hd->time);
     hit_vec->push_back(hit);
     delete hit;
@@ -333,6 +334,7 @@ int Fun4AllEVIOInputManager::run(const int nevents)
     hit->set_hit_id     (hd->id  );
     hit->set_detector_id(hd->det );
     hit->set_element_id (hd->ele );
+    hit->set_level      (hd->lvl );
     hit->set_tdc_time   (hd->time);
     trig_hit_vec->push_back(hit);
     delete hit;

--- a/online/decoder_maindaq/Fun4AllEVIOInputManager.cc
+++ b/online/decoder_maindaq/Fun4AllEVIOInputManager.cc
@@ -299,7 +299,16 @@ int Fun4AllEVIOInputManager::run(const int nevents)
   event_header->set_coda_event_id(ed->event.codaEventID);
   event_header->set_data_quality (ed->event.dataQuality);
   event_header->set_vme_time     (ed->event.vmeTime);
-  event_header->set_trigger      (ed->event.trigger_bits);
+  event_header->set_trigger      (SQEvent::MATRIX1, ed->event.MATRIX[0]);
+  event_header->set_trigger      (SQEvent::MATRIX2, ed->event.MATRIX[1]);
+  event_header->set_trigger      (SQEvent::MATRIX3, ed->event.MATRIX[2]);
+  event_header->set_trigger      (SQEvent::MATRIX4, ed->event.MATRIX[3]);
+  event_header->set_trigger      (SQEvent::MATRIX5, ed->event.MATRIX[4]);
+  event_header->set_trigger      (SQEvent::NIM1   , ed->event.NIM   [0]);
+  event_header->set_trigger      (SQEvent::NIM2   , ed->event.NIM   [1]);
+  event_header->set_trigger      (SQEvent::NIM3   , ed->event.NIM   [2]);
+  event_header->set_trigger      (SQEvent::NIM4   , ed->event.NIM   [3]);
+  event_header->set_trigger      (SQEvent::NIM5   , ed->event.NIM   [4]);
   for (int ii=0; ii<5; ii++) {
     event_header->set_raw_matrix      (ii, ed->event.RawMATRIX     [ii]);
     event_header->set_after_inh_matrix(ii, ed->event.AfterInhMATRIX[ii]);

--- a/online/decoder_maindaq/MainDaqParser.cc
+++ b/online/decoder_maindaq/MainDaqParser.cc
@@ -1095,8 +1095,7 @@ int MainDaqParser::PackOneSpillData()
     }
     for (unsigned int ih = 0; ih < n_v1495; ih++) {
       HitData* hd = &ed->list_hit_trig[ih];
-      short level; // not stored for now
-      if (! dec_par.chan_map_v1495.Find(hd->roc, hd->board, hd->chan, hd->det, hd->ele, level)) {
+      if (! dec_par.chan_map_v1495.Find(hd->roc, hd->board, hd->chan, hd->det, hd->ele, hd->lvl)) {
         if (dec_par.verbose > 1) cout << "  Unmapped v1495: " << hd->roc << " " << hd->board << " " << hd->chan << "\n";
       }
     }

--- a/online/onlmonserver/LinkDef.h
+++ b/online/onlmonserver/LinkDef.h
@@ -6,6 +6,10 @@
 #pragma link C++ class OnlMonServer-!;
 #pragma link C++ class OnlMonClient-!;
 #pragma link C++ class OnlMonMainDaq-!;
+#pragma link C++ class OnlMonTrigSig-!;
+#pragma link C++ class OnlMonV1495-!;
+#pragma link C++ class OnlMonHodo-!;
 #pragma link C++ class OnlMonCham-!;
+#pragma link C++ class OnlMonProp-!;
 
 #endif

--- a/online/onlmonserver/OnlMonCanvas.cc
+++ b/online/onlmonserver/OnlMonCanvas.cc
@@ -56,17 +56,19 @@ void OnlMonCanvas::PreDraw()
   pate->AddText(oss.str().c_str());
   pate->Draw();
 
+  TPaveText* pate2 = new TPaveText(.02, .02, .98, .48, "NB");
+  pate2->SetFillColor(kWhite);
+
+  oss.str("");  oss << "Run " << m_run;
+  pate2->AddText(oss.str().c_str());
+
   time_t utime = time(0);
   char stime[64];
   strftime(stime, sizeof(stime),"%Y-%m-%d %H:%M:%S", localtime(&utime));
-  oss.str("");
-  oss << "Run " << m_run << " : Drawn at " << stime;
-
-  TPaveText* pate2 = new TPaveText(.02, .02, .98, .48, "NB");
-  pate2->SetFillColor(kWhite);
+  oss.str("");  oss << "Drawn at " << stime;
   pate2->AddText(oss.str().c_str());
-  pate2->Draw();
 
+  pate2->Draw();
   gStyle->SetOptStat(0000);
   gStyle->SetHistMinimumZero(true);
 }

--- a/online/onlmonserver/OnlMonCanvas.cc
+++ b/online/onlmonserver/OnlMonCanvas.cc
@@ -1,10 +1,15 @@
+#include <iostream>
 #include <sstream>
 #include <iomanip>
+#include <TROOT.h>
 #include <TSystem.h>
+#include <TStyle.h>
 #include <TCanvas.h>
 #include <TPaveText.h>
 #include "OnlMonCanvas.h"
 using namespace std;
+
+//bool OnlMonCanvas::m_clear_all_can = true;
 
 OnlMonCanvas::OnlMonCanvas(const std::string name, const std::string title, const int num, const int run) :
   m_name(name), m_title(title), m_num(num), m_run(run),
@@ -61,6 +66,9 @@ void OnlMonCanvas::PreDraw()
   pate2->SetFillColor(kWhite);
   pate2->AddText(oss.str().c_str());
   pate2->Draw();
+
+  gStyle->SetOptStat(0000);
+  gStyle->SetHistMinimumZero(true);
 }
 
 void OnlMonCanvas::PostDraw(const bool at_end)
@@ -88,3 +96,14 @@ void OnlMonCanvas::PostDraw(const bool at_end)
     gErrorIgnoreLevel = lvl;
   }
 }
+
+//void OnlMonCanvas::ClearAllCanvases()
+//{
+//  TIter next(gROOT->GetListOfCanvases());
+//  TObject* obj;
+//  while ((obj = next())) {
+//    string name = obj->ClassName();
+//    cout << "OBJ " << name << " " << obj->GetName() << endl;
+//    if (name == "TCanvas") dynamic_cast<TCanvas*>(obj)->Close();
+//  }
+//}

--- a/online/onlmonserver/OnlMonCanvas.cc
+++ b/online/onlmonserver/OnlMonCanvas.cc
@@ -9,16 +9,15 @@
 #include "OnlMonCanvas.h"
 using namespace std;
 
-//bool OnlMonCanvas::m_clear_all_can = true;
-
-OnlMonCanvas::OnlMonCanvas(const std::string name, const std::string title, const int num, const int run) :
-  m_name(name), m_title(title), m_num(num), m_run(run),
+OnlMonCanvas::OnlMonCanvas(const std::string name, const std::string title, const int num) :
+  m_name(name), m_title(title), m_num(num), 
   m_can("c1", "", 5+600*num, 5, 600, 800), 
   m_pad_title("title", "", 0.0, 0.9, 1.0, 1.0),
   m_pad_main ("main" , "", 0.0, 0.1, 1.0, 0.9),
   m_pad_msg  ("msg"  , "", 0.0, 0.0, 1.0, 0.1),
   m_pate_msg(.02, .02, .98, .98),
-  m_mon_status(UNDEF)
+  m_mon_status(UNDEF),
+  m_run(0), m_spill(0), m_event(0), m_n_evt(0)
 {
   //m_can.SetWindowPosition(5+600*num, 5);
 }
@@ -26,6 +25,14 @@ OnlMonCanvas::OnlMonCanvas(const std::string name, const std::string title, cons
 OnlMonCanvas::~OnlMonCanvas()
 {
   ;
+}
+
+void OnlMonCanvas::SetBasicInfo(const int run_id, const int spill_id, const int event_id, const int n_evt)
+{
+  m_run   = run_id;
+  m_spill = spill_id;
+  m_event = event_id;
+  m_n_evt = n_evt;
 }
 
 void OnlMonCanvas::AddMessage(const char* msg)
@@ -39,7 +46,7 @@ TPad* OnlMonCanvas::GetMainPad()
   return &m_pad_main; 
 }
 
-void OnlMonCanvas::PreDraw()
+void OnlMonCanvas::PreDraw(const bool at_end)
 {
   ostringstream oss;
   oss << m_name << " Canvas #" << m_num;
@@ -59,7 +66,9 @@ void OnlMonCanvas::PreDraw()
   TPaveText* pate2 = new TPaveText(.02, .02, .98, .48, "NB");
   pate2->SetFillColor(kWhite);
 
-  oss.str("");  oss << "Run " << m_run;
+  oss.str("");
+  oss << "Run #" << m_run;
+  if (! at_end) oss << ", Spill #" << m_spill << ", Event #" << m_event << ", " << m_n_evt << " events";
   pate2->AddText(oss.str().c_str());
 
   time_t utime = time(0);
@@ -98,14 +107,3 @@ void OnlMonCanvas::PostDraw(const bool at_end)
     gErrorIgnoreLevel = lvl;
   }
 }
-
-//void OnlMonCanvas::ClearAllCanvases()
-//{
-//  TIter next(gROOT->GetListOfCanvases());
-//  TObject* obj;
-//  while ((obj = next())) {
-//    string name = obj->ClassName();
-//    cout << "OBJ " << name << " " << obj->GetName() << endl;
-//    if (name == "TCanvas") dynamic_cast<TCanvas*>(obj)->Close();
-//  }
-//}

--- a/online/onlmonserver/OnlMonCanvas.cc
+++ b/online/onlmonserver/OnlMonCanvas.cc
@@ -1,12 +1,13 @@
 #include <sstream>
 #include <iomanip>
+#include <TSystem.h>
 #include <TCanvas.h>
 #include <TPaveText.h>
 #include "OnlMonCanvas.h"
 using namespace std;
 
-OnlMonCanvas::OnlMonCanvas(const std::string name, const int num) :
-  m_name(name), m_num(num),
+OnlMonCanvas::OnlMonCanvas(const std::string name, const std::string title, const int num, const int run) :
+  m_name(name), m_title(title), m_num(num), m_run(run),
   m_can("c1", "", 5+600*num, 5, 600, 800), 
   m_pad_title("title", "", 0.0, 0.9, 1.0, 1.0),
   m_pad_main ("main" , "", 0.0, 0.1, 1.0, 0.9),
@@ -36,21 +37,33 @@ TPad* OnlMonCanvas::GetMainPad()
 void OnlMonCanvas::PreDraw()
 {
   ostringstream oss;
-  oss << m_name << " #" << m_num;
-  string title = oss.str();
-  m_can.SetTitle(title.c_str());
+  oss << m_name << " Canvas #" << m_num;
+  m_can.SetTitle(oss.str().c_str());
 
   m_can.cd();  m_pad_title.Draw();
   m_can.cd();  m_pad_main .Draw();
   m_can.cd();  m_pad_msg  .Draw();
 
   m_pad_title.cd();
-  TPaveText* pate = new TPaveText(.02, .02, .98, .98);
-  pate->AddText(title.c_str());
+  TPaveText* pate = new TPaveText(.02, .52, .98, .98);
+  oss.str("");
+  oss << m_title << " #" << m_num;
+  pate->AddText(oss.str().c_str());
   pate->Draw();
+
+  time_t utime = time(0);
+  char stime[64];
+  strftime(stime, sizeof(stime),"%Y-%m-%d %H:%M:%S", localtime(&utime));
+  oss.str("");
+  oss << "Run " << m_run << " : Drawn at " << stime;
+
+  TPaveText* pate2 = new TPaveText(.02, .02, .98, .48, "NB");
+  pate2->SetFillColor(kWhite);
+  pate2->AddText(oss.str().c_str());
+  pate2->Draw();
 }
 
-void OnlMonCanvas::PostDraw()
+void OnlMonCanvas::PostDraw(const bool at_end)
 {
   int color;
   switch (m_mon_status) {
@@ -63,7 +76,15 @@ void OnlMonCanvas::PostDraw()
   m_pad_msg .cd();
   m_pate_msg.Draw();
 
-  ostringstream oss;
-  oss << "/dev/shm/" << m_name << "_" << m_num << ".png";
-  m_can.SaveAs(oss.str().c_str());
+  if (at_end) {
+    ostringstream oss;
+    oss << "/dev/shm/onlmon/" << setfill('0') << setw(6) << m_run;
+    gSystem->mkdir(oss.str().c_str(), true);
+
+    int lvl = gErrorIgnoreLevel;
+    gErrorIgnoreLevel = 1111; // Suppress the message by TCanvas::SaveAs().
+    oss << "/" << m_name << "_can" << m_num << ".png";
+    m_can.SaveAs(oss.str().c_str());
+    gErrorIgnoreLevel = lvl;
+  }
 }

--- a/online/onlmonserver/OnlMonCanvas.h
+++ b/online/onlmonserver/OnlMonCanvas.h
@@ -13,6 +13,8 @@ class OnlMonCanvas {
   typedef enum { OK, WARN, ERROR, UNDEF } MonStatus_t;
 
  protected:
+  //static bool m_clear_all_can;
+
   std::string m_name;
   std::string m_title;
   int         m_num;
@@ -34,6 +36,10 @@ class OnlMonCanvas {
 
   void PreDraw();
   void PostDraw(const bool at_end=false);
+
+  //static void WillClearAllCanvases(const bool val) { m_clear_all_can = val; }
+  //static bool WillClearAllCanvases() { return m_clear_all_can; }
+  //static void ClearAllCanvases();
 };
 
 #endif /* _ONL_MON_CANVAS__H_ */

--- a/online/onlmonserver/OnlMonCanvas.h
+++ b/online/onlmonserver/OnlMonCanvas.h
@@ -14,7 +14,9 @@ class OnlMonCanvas {
 
  protected:
   std::string m_name;
+  std::string m_title;
   int         m_num;
+  int         m_run;
   TCanvas     m_can;
   TPad        m_pad_title;
   TPad        m_pad_main;
@@ -23,7 +25,7 @@ class OnlMonCanvas {
   MonStatus_t m_mon_status;
 
  public:
-  OnlMonCanvas(const std::string name, const int num);
+  OnlMonCanvas(const std::string name, const std::string title, const int num, const int run);
   virtual ~OnlMonCanvas();
 
   void AddMessage(const char* msg);
@@ -31,7 +33,7 @@ class OnlMonCanvas {
   TPad* GetMainPad();
 
   void PreDraw();
-  void PostDraw();
+  void PostDraw(const bool at_end=false);
 };
 
 #endif /* _ONL_MON_CANVAS__H_ */

--- a/online/onlmonserver/OnlMonCanvas.h
+++ b/online/onlmonserver/OnlMonCanvas.h
@@ -13,12 +13,9 @@ class OnlMonCanvas {
   typedef enum { OK, WARN, ERROR, UNDEF } MonStatus_t;
 
  protected:
-  //static bool m_clear_all_can;
-
   std::string m_name;
   std::string m_title;
   int         m_num;
-  int         m_run;
   TCanvas     m_can;
   TPad        m_pad_title;
   TPad        m_pad_main;
@@ -26,20 +23,22 @@ class OnlMonCanvas {
   TPaveText   m_pate_msg;
   MonStatus_t m_mon_status;
 
+  int         m_run;
+  int         m_spill;
+  int         m_event;
+  int         m_n_evt;
+
  public:
-  OnlMonCanvas(const std::string name, const std::string title, const int num, const int run);
+  OnlMonCanvas(const std::string name, const std::string title, const int num);
   virtual ~OnlMonCanvas();
 
+  void SetBasicInfo(const int run_id, const int spill_id=0, const int event_id=0, const int n_evt=0);
   void AddMessage(const char* msg);
   void SetStatus(const MonStatus_t stat) { m_mon_status = stat; }
   TPad* GetMainPad();
 
-  void PreDraw();
+  void  PreDraw(const bool at_end=false);
   void PostDraw(const bool at_end=false);
-
-  //static void WillClearAllCanvases(const bool val) { m_clear_all_can = val; }
-  //static bool WillClearAllCanvases() { return m_clear_all_can; }
-  //static void ClearAllCanvases();
 };
 
 #endif /* _ONL_MON_CANVAS__H_ */

--- a/online/onlmonserver/OnlMonCham.cc
+++ b/online/onlmonserver/OnlMonCham.cc
@@ -2,13 +2,9 @@
 #include <iomanip>
 #include <TH1D.h>
 #include <interface_main/SQRun.h>
-#include <interface_main/SQStringMap.h>
-#include <interface_main/SQScaler.h>
-#include <interface_main/SQSlowCont.h>
 #include <interface_main/SQEvent.h>
 #include <interface_main/SQHitVector.h>
 #include <fun4all/Fun4AllReturnCodes.h>
-#include <fun4all/Fun4AllHistoManager.h>
 #include <phool/PHNodeIterator.h>
 #include <phool/PHIODataNode.h>
 #include <phool/getClass.h>
@@ -38,16 +34,13 @@ int OnlMonCham::InitOnlMon(PHCompositeNode* topNode)
 
 int OnlMonCham::InitRunOnlMon(PHCompositeNode* topNode)
 {
-  SQRun* run_header = findNode::getClass<SQRun>(topNode, "SQRun");
-  if (!run_header) return Fun4AllReturnCodes::ABORTEVENT;
+  //SQRun* run_header = findNode::getClass<SQRun>(topNode, "SQRun");
+  //if (!run_header) return Fun4AllReturnCodes::ABORTEVENT;
 
   GeomSvc* geom = GeomSvc::instance();
   //CalibParamInTimeTaiwan calib;
   //calib.SetMapIDbyDB(run_header->get_run_id());
   //calib.ReadFromDB();
-
-  Fun4AllHistoManager* hm = new Fun4AllHistoManager(Name());
-  OnlMonServer::instance()->registerHistoManager(hm);
 
   ostringstream oss;
   for (int pl = 0; pl < N_PL; pl++) {
@@ -76,8 +69,8 @@ int OnlMonCham::InitRunOnlMon(PHCompositeNode* topNode)
     oss << name << ";tdcTime;Hit count";
     h1_time[pl]->SetTitle(oss.str().c_str());
 
-    hm->registerHisto(h1_ele [pl]);
-    hm->registerHisto(h1_time[pl]);
+    RegisterHist(h1_ele [pl]);
+    RegisterHist(h1_time[pl]);
   }
 
   return Fun4AllReturnCodes::EVENT_OK;

--- a/online/onlmonserver/OnlMonCham.cc
+++ b/online/onlmonserver/OnlMonCham.cc
@@ -128,10 +128,9 @@ int OnlMonCham::DrawMonitor()
   pad0->Divide(2, 3);
   for (int pl = 0; pl < N_PL; pl++) {
     pad0->cd(pl+1);
-    //if (h1_ele[pl]->Integral() > 1000) gPad->SetLogy();
     h1_ele[pl]->Draw();
   }
-  can0->AddMessage("Always Okay ;^D");
+  can0->AddMessage("OK");
   can0->SetStatus(OnlMonCanvas::OK);
 
   OnlMonCanvas* can1 = GetCanvas(1);
@@ -140,11 +139,10 @@ int OnlMonCham::DrawMonitor()
   pad1->Divide(2, 3);
   for (int pl = 0; pl < N_PL; pl++) {
     pad1->cd(pl+1);
-    //if (h1_time[pl]->Integral() > 1000) gPad->SetLogy();
     UtilHist::AutoSetRange(h1_time[pl]);
     h1_time[pl]->Draw();
   }
-  can1->AddMessage("Always Okay ;^D");
+  can1->AddMessage("OK");
   can1->SetStatus(OnlMonCanvas::OK);
 
   return 0;

--- a/online/onlmonserver/OnlMonClient.cc
+++ b/online/onlmonserver/OnlMonClient.cc
@@ -1,4 +1,5 @@
 #include <iomanip>
+#include <TStyle.h>
 #include <TH1D.h>
 #include <TSocket.h>
 #include <TClass.h>
@@ -40,6 +41,17 @@ int OnlMonClient::Init(PHCompositeNode* topNode)
 
 int OnlMonClient::InitRun(PHCompositeNode* topNode)
 {
+  /// These settings will be applied to histograms created in InitRunOnlMon().
+  /// Fine tunes should be necessary in the future.
+  /// Note: the label/title size is a percent of the pad _height_, and
+  ///       the offset is a relative scale to the default distance from axis.
+  gStyle->SetLabelSize  (0.05, "X");
+  gStyle->SetTitleSize  (0.05, "X");
+  gStyle->SetLabelSize  (0.06, "YZ");
+  gStyle->SetTitleSize  (0.06, "YZ");
+  gStyle->SetTitleOffset(0.90, "XY");
+  gStyle->SetTitleSize  (0.10, "");
+
   m_hm = new Fun4AllHistoManager(Name());
   OnlMonServer::instance()->registerHistoManager(m_hm);
   m_h1_basic_info = new TH1D("h1_basic_info", "", 10, 0.5, 10.5);

--- a/online/onlmonserver/OnlMonClient.cc
+++ b/online/onlmonserver/OnlMonClient.cc
@@ -1,4 +1,5 @@
 #include <iomanip>
+#include <algorithm>
 #include <TStyle.h>
 #include <TH1D.h>
 #include <TSocket.h>
@@ -14,9 +15,6 @@
 #include "OnlMonServer.h"
 #include "OnlMonCanvas.h"
 #include "OnlMonClient.h"
-
-#include <algorithm>
-
 using namespace std;
 
 std::vector<OnlMonClient*> OnlMonClient::m_list_us;

--- a/online/onlmonserver/OnlMonClient.h
+++ b/online/onlmonserver/OnlMonClient.h
@@ -1,24 +1,24 @@
 #ifndef _ONL_MON_CLIENT__H_
 #define _ONL_MON_CLIENT__H_
-#include <TCanvas.h>
-#include <TPaveText.h>
 #include <fun4all/SubsysReco.h>
 #include "OnlMonCanvas.h"
+class Fun4AllHistoManager;
 class TH1;
 class TH2;
 class TH3;
-class TPaveText;
 
 class OnlMonClient: public SubsysReco {
   std::string m_title;
+  Fun4AllHistoManager* m_hm;
   int m_n_can;
   OnlMonCanvas* m_list_can[9];
 
-  int m_run_id;
+  typedef enum { BIN_RUN = 1, BIN_SPILL = 2, BIN_EVENT = 3 } BasicInfoBin_t;
+  TH1* m_h1_basic_info;
   typedef std::vector<TH1*> HistList_t;
   HistList_t m_list_h1;
   typedef std::vector<TObject*> ObjList_t;
-  ObjList_t m_list_obj;
+  ObjList_t m_list_obj; ///< Need this or m_list_h1 at end...
 
   /// List of OnlMonClient objects created.  Used to clear all canvases opened by all objects.
   typedef std::vector<OnlMonClient*> SelfList_t;
@@ -37,6 +37,7 @@ class OnlMonClient: public SubsysReco {
   int process_event(PHCompositeNode *topNode);
   int End(PHCompositeNode *topNode);
 
+  void GetBasicInfo(int* run_id=0, int* spill_id=0, int* event_id=0);
   int StartMonitor();
   TH1* FindMonHist(const std::string name, const bool non_null=true);
   TObject* FindMonObj(const std::string name, const bool non_null=true);
@@ -52,6 +53,8 @@ class OnlMonClient: public SubsysReco {
   static bool GetClearUsFlag() { return m_bl_clear_us; }
 
  protected:  
+  void RegisterHist(TH1* h1);
+
   int ReceiveHist();
   void ClearHistList();
 

--- a/online/onlmonserver/OnlMonClient.h
+++ b/online/onlmonserver/OnlMonClient.h
@@ -13,7 +13,7 @@ class OnlMonClient: public SubsysReco {
   int m_n_can;
   OnlMonCanvas* m_list_can[9];
 
-  typedef enum { BIN_RUN = 1, BIN_SPILL = 2, BIN_EVENT = 3 } BasicInfoBin_t;
+  typedef enum { BIN_RUN = 1, BIN_SPILL = 2, BIN_EVENT = 3, BIN_N_EVT = 4 } BasicInfoBin_t;
   TH1* m_h1_basic_info;
   typedef std::vector<TH1*> HistList_t;
   HistList_t m_list_h1;
@@ -37,7 +37,7 @@ class OnlMonClient: public SubsysReco {
   int process_event(PHCompositeNode *topNode);
   int End(PHCompositeNode *topNode);
 
-  void GetBasicInfo(int* run_id=0, int* spill_id=0, int* event_id=0);
+  void GetBasicInfo(int* run_id=0, int* spill_id=0, int* event_id=0, int* n_evt=0);
   int StartMonitor();
   TH1* FindMonHist(const std::string name, const bool non_null=true);
   TObject* FindMonObj(const std::string name, const bool non_null=true);

--- a/online/onlmonserver/OnlMonClient.h
+++ b/online/onlmonserver/OnlMonClient.h
@@ -10,29 +10,45 @@ class TH3;
 class TPaveText;
 
 class OnlMonClient: public SubsysReco {
+  std::string m_title;
   int m_n_can;
   OnlMonCanvas* m_list_can[9];
 
+  int m_run_id;
   typedef std::vector<TH1*> HistList_t;
   HistList_t m_list_h1;
   typedef std::vector<TObject*> ObjList_t;
   ObjList_t m_list_obj;
 
  public:
-  OnlMonClient(const std::string &name = "OnlMonClient");
+  OnlMonClient();
   virtual ~OnlMonClient();
+
+  void Title(const std::string &title) { m_title = title; }
+  std::string Title() { return m_title; }
+
+  int Init(PHCompositeNode *topNode);
+  int InitRun(PHCompositeNode *topNode);
+  int process_event(PHCompositeNode *topNode);
+  int End(PHCompositeNode *topNode);
 
   int StartMonitor();
   TH1* FindMonHist(const std::string name, const bool non_null=true);
   TObject* FindMonObj(const std::string name, const bool non_null=true);
 
+  virtual int InitOnlMon(PHCompositeNode *topNode);
+  virtual int InitRunOnlMon(PHCompositeNode *topNode);
+  virtual int ProcessEventOnlMon(PHCompositeNode *topNode);
+  virtual int EndOnlMon(PHCompositeNode *topNode);
+  virtual int FindAllMonHist();
   virtual int DrawMonitor();
 
  protected:  
   int ReceiveHist();
   void ClearHistList();
 
-  void SetNumCanvases(const int num) { m_n_can = num; }
+  void NumCanvases(const int num) { m_n_can = num; }
+  int  NumCanvases() { return m_n_can; }
   OnlMonCanvas* GetCanvas(const int num=0);
 };
 

--- a/online/onlmonserver/OnlMonClient.h
+++ b/online/onlmonserver/OnlMonClient.h
@@ -20,6 +20,11 @@ class OnlMonClient: public SubsysReco {
   typedef std::vector<TObject*> ObjList_t;
   ObjList_t m_list_obj;
 
+  /// List of OnlMonClient objects created.  Used to clear all canvases opened by all objects.
+  typedef std::vector<OnlMonClient*> SelfList_t;
+  static SelfList_t m_list_us;
+  static bool m_bl_clear_us;
+
  public:
   OnlMonClient();
   virtual ~OnlMonClient();
@@ -43,6 +48,9 @@ class OnlMonClient: public SubsysReco {
   virtual int FindAllMonHist();
   virtual int DrawMonitor();
 
+  static void SetClearUsFlag(const bool val) { m_bl_clear_us = val; }
+  static bool GetClearUsFlag() { return m_bl_clear_us; }
+
  protected:  
   int ReceiveHist();
   void ClearHistList();
@@ -50,6 +58,7 @@ class OnlMonClient: public SubsysReco {
   void NumCanvases(const int num) { m_n_can = num; }
   int  NumCanvases() { return m_n_can; }
   OnlMonCanvas* GetCanvas(const int num=0);
+  void ClearCanvasList();
 };
 
 #endif /* _ONL_MON_CLIENT__H_ */

--- a/online/onlmonserver/OnlMonHodo.cc
+++ b/online/onlmonserver/OnlMonHodo.cc
@@ -153,7 +153,6 @@ int OnlMonHodo::DrawMonitor()
   pad0->Divide(1, 2);
   for (int pl = 0; pl < m_n_pl; pl++) {
     pad0->cd(pl+1);
-    //h1_ele[pl]->SetMinimum(0);
     h1_ele[pl]->SetLineColor(kBlack);
     h1_ele[pl]->Draw();
     h1_ele_in[pl]->SetLineColor(kBlue);

--- a/online/onlmonserver/OnlMonHodo.cc
+++ b/online/onlmonserver/OnlMonHodo.cc
@@ -1,4 +1,4 @@
-/// OnlMonCham.C
+/// OnlMonHodo.C
 #include <iomanip>
 #include <TH1D.h>
 #include <interface_main/SQRun.h>
@@ -15,28 +15,32 @@
 #include <geom_svc/GeomSvc.h>
 //#include <chan_map/CalibParamInTimeTaiwan.h>
 #include "OnlMonServer.h"
-#include "OnlMonCham.h"
+#include "OnlMonHodo.h"
 #include "UtilHist.h"
 using namespace std;
 
-OnlMonCham::OnlMonCham(const ChamType_t type) : m_type(type)
+OnlMonHodo::OnlMonHodo(const HodoType_t type) : m_type(type)
 {
   NumCanvases(2);
+  m_n_pl = 2;
   switch (m_type) {
-  case D0 :  m_pl0 =  1;  Name("OnlMonChamD0" );  Title( "D0 Chamber");  break;
-  case D1 :  m_pl0 =  7;  Name("OnlMonChamD1" );  Title( "D1 Chamber");  break;
-  case D2 :  m_pl0 = 13;  Name("OnlMonChamD2" );  Title( "D2 Chamber");  break;
-  case D3p:  m_pl0 = 19;  Name("OnlMonChamD3p");  Title("D3p Chamber");  break;
-  case D3m:  m_pl0 = 25;  Name("OnlMonChamD3m");  Title("D3m Chamber");  break;
+  case H1X:  m_pl0 = 31;  Name("OnlMonHodoH1X" );  Title("H1X Hodo" );  break;
+  case H2X:  m_pl0 = 37;  Name("OnlMonHodoH2X" );  Title("H2X Hodo" );  break;
+  case H3X:  m_pl0 = 39;  Name("OnlMonHodoH3X" );  Title("H3X Hodo" );  break;
+  case H4X:  m_pl0 = 45;  Name("OnlMonHodoH4X" );  Title("H4X Hodo" );  break;
+  case H1Y:  m_pl0 = 33;  Name("OnlMonHodoH1Y" );  Title("H1Y Hodo" );  break;
+  case H2Y:  m_pl0 = 35;  Name("OnlMonHodoH2Y" );  Title("H2Y Hodo" );  break;
+  case H4Y1: m_pl0 = 41;  Name("OnlMonHodoH4Y1");  Title("H4Y1 Hodo");  break;
+  case H4Y2: m_pl0 = 43;  Name("OnlMonHodoH4Y2");  Title("H4Y2 Hodo");  break;
   }
 }
 
-int OnlMonCham::InitOnlMon(PHCompositeNode* topNode)
+int OnlMonHodo::InitOnlMon(PHCompositeNode* topNode)
 {
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-int OnlMonCham::InitRunOnlMon(PHCompositeNode* topNode)
+int OnlMonHodo::InitRunOnlMon(PHCompositeNode* topNode)
 {
   SQRun* run_header = findNode::getClass<SQRun>(topNode, "SQRun");
   if (!run_header) return Fun4AllReturnCodes::ABORTEVENT;
@@ -50,7 +54,7 @@ int OnlMonCham::InitRunOnlMon(PHCompositeNode* topNode)
   OnlMonServer::instance()->registerHistoManager(hm);
 
   ostringstream oss;
-  for (int pl = 0; pl < N_PL; pl++) {
+  for (int pl = 0; pl < m_n_pl; pl++) {
     string name = geom->getDetectorName(m_pl0 + pl);
     int n_ele = geom->getPlaneNElements(m_pl0 + pl); 
     oss.str("");
@@ -60,8 +64,8 @@ int OnlMonCham::InitRunOnlMon(PHCompositeNode* topNode)
     oss << name << ";Element ID;Hit count";
     h1_ele[pl]->SetTitle(oss.str().c_str());
 
-    const double DT = 20/9.0; // 4/9 ns per single count of Taiwan TDC
-    const int NT = 1000;
+    const double DT = 4/9.0; // 4/9 ns per single count of Taiwan TDC
+    const int NT = 4000;
     const double T0 = 0.5*DT;
     const double T1 = (NT+0.5)*DT;
 
@@ -70,20 +74,28 @@ int OnlMonCham::InitRunOnlMon(PHCompositeNode* topNode)
     oss.str("");
     oss << "h1_time_" << pl;
     h1_time[pl] = new TH1D(oss.str().c_str(), "", NT, T0, T1);
-    //h1_time[pl] = new TH1D(oss.str().c_str(), "", 100, center-width/2, center+width/2);
+    //h1_time[pl] = new TH1D(oss.str().c_str(), "", 100, center-2.5*width, center+2.5*width);
 
     oss.str("");
     oss << name << ";tdcTime;Hit count";
     h1_time[pl]->SetTitle(oss.str().c_str());
 
-    hm->registerHisto(h1_ele [pl]);
-    hm->registerHisto(h1_time[pl]);
+    oss.str("");
+    oss << "h1_time_in_" << pl;
+    h1_time_in[pl] = new TH1D(oss.str().c_str(), "", NT, T0, T1);
+    oss.str("");
+    oss << name << ";tdcTime;In-time hit count";
+    h1_time_in[pl]->SetTitle(oss.str().c_str());
+
+    hm->registerHisto(h1_ele    [pl]);
+    hm->registerHisto(h1_time   [pl]);
+    hm->registerHisto(h1_time_in[pl]);
   }
 
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-int OnlMonCham::ProcessEventOnlMon(PHCompositeNode* topNode)
+int OnlMonHodo::ProcessEventOnlMon(PHCompositeNode* topNode)
 {
   SQEvent*     event_header = findNode::getClass<SQEvent    >(topNode, "SQEvent");
   SQHitVector*      hit_vec = findNode::getClass<SQHitVector>(topNode, "SQHitVector");
@@ -91,23 +103,24 @@ int OnlMonCham::ProcessEventOnlMon(PHCompositeNode* topNode)
 
   for (SQHitVector::ConstIter it = hit_vec->begin(); it != hit_vec->end(); it++) {
     int pl = (*it)->get_detector_id() - m_pl0;
-    if (pl < 0 || pl >= N_PL) continue;
+    if (pl < 0 || pl >= m_n_pl) continue;
     h1_ele [pl]->Fill((*it)->get_element_id());
     h1_time[pl]->Fill((*it)->get_tdc_time  ());
+    if ((*it)->is_in_time()) h1_time_in[pl]->Fill((*it)->get_tdc_time());
   }
   
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-int OnlMonCham::EndOnlMon(PHCompositeNode* topNode)
+int OnlMonHodo::EndOnlMon(PHCompositeNode* topNode)
 {
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-int OnlMonCham::FindAllMonHist()
+int OnlMonHodo::FindAllMonHist()
 {
   ostringstream oss;
-  for (int pl = 0; pl < N_PL; pl++) {
+  for (int pl = 0; pl < m_n_pl; pl++) {
     oss.str("");
     oss << "h1_ele_" << pl;
     h1_ele[pl] = (TH1*)FindMonObj(oss.str().c_str());
@@ -116,17 +129,21 @@ int OnlMonCham::FindAllMonHist()
     oss << "h1_time_" << pl;
     h1_time[pl] = (TH1*)FindMonObj(oss.str().c_str());
     if (! h1_time[pl]) return 1;
+    oss.str("");
+    oss << "h1_time_in_" << pl;
+    h1_time_in[pl] = (TH1*)FindMonObj(oss.str().c_str());
+    if (! h1_time_in[pl]) return 1;
   }
   return 0;
 }
 
-int OnlMonCham::DrawMonitor()
+int OnlMonHodo::DrawMonitor()
 {
   OnlMonCanvas* can0 = GetCanvas(0);
   TPad* pad0 = can0->GetMainPad();
   pad0->SetGrid();
-  pad0->Divide(2, 3);
-  for (int pl = 0; pl < N_PL; pl++) {
+  pad0->Divide(1, 2);
+  for (int pl = 0; pl < m_n_pl; pl++) {
     pad0->cd(pl+1);
     //if (h1_ele[pl]->Integral() > 1000) gPad->SetLogy();
     h1_ele[pl]->Draw();
@@ -137,12 +154,15 @@ int OnlMonCham::DrawMonitor()
   OnlMonCanvas* can1 = GetCanvas(1);
   TPad* pad1 = can1->GetMainPad();
   pad1->SetGrid();
-  pad1->Divide(2, 3);
-  for (int pl = 0; pl < N_PL; pl++) {
+  pad1->Divide(1, 2);
+  for (int pl = 0; pl < m_n_pl; pl++) {
     pad1->cd(pl+1);
     //if (h1_time[pl]->Integral() > 1000) gPad->SetLogy();
     UtilHist::AutoSetRange(h1_time[pl]);
     h1_time[pl]->Draw();
+    h1_time_in[pl]->SetLineColor(kRed);
+    h1_time_in[pl]->SetFillColor(kRed-7);
+    h1_time_in[pl]->Draw("same");
   }
   can1->AddMessage("Always Okay ;^D");
   can1->SetStatus(OnlMonCanvas::OK);

--- a/online/onlmonserver/OnlMonHodo.cc
+++ b/online/onlmonserver/OnlMonHodo.cc
@@ -2,13 +2,9 @@
 #include <iomanip>
 #include <TH1D.h>
 #include <interface_main/SQRun.h>
-#include <interface_main/SQStringMap.h>
-#include <interface_main/SQScaler.h>
-#include <interface_main/SQSlowCont.h>
 #include <interface_main/SQEvent.h>
 #include <interface_main/SQHitVector.h>
 #include <fun4all/Fun4AllReturnCodes.h>
-#include <fun4all/Fun4AllHistoManager.h>
 #include <phool/PHNodeIterator.h>
 #include <phool/PHIODataNode.h>
 #include <phool/getClass.h>
@@ -42,16 +38,13 @@ int OnlMonHodo::InitOnlMon(PHCompositeNode* topNode)
 
 int OnlMonHodo::InitRunOnlMon(PHCompositeNode* topNode)
 {
-  SQRun* run_header = findNode::getClass<SQRun>(topNode, "SQRun");
-  if (!run_header) return Fun4AllReturnCodes::ABORTEVENT;
+  //SQRun* run_header = findNode::getClass<SQRun>(topNode, "SQRun");
+  //if (!run_header) return Fun4AllReturnCodes::ABORTEVENT;
 
   GeomSvc* geom = GeomSvc::instance();
   //CalibParamInTimeTaiwan calib;
   //calib.SetMapIDbyDB(run_header->get_run_id());
   //calib.ReadFromDB();
-
-  Fun4AllHistoManager* hm = new Fun4AllHistoManager(Name());
-  OnlMonServer::instance()->registerHistoManager(hm);
 
   ostringstream oss;
   for (int pl = 0; pl < m_n_pl; pl++) {
@@ -94,10 +87,10 @@ int OnlMonHodo::InitRunOnlMon(PHCompositeNode* topNode)
     oss << name << ";tdcTime;In-time hit count";
     h1_time_in[pl]->SetTitle(oss.str().c_str());
 
-    hm->registerHisto(h1_ele    [pl]);
-    hm->registerHisto(h1_ele_in [pl]);
-    hm->registerHisto(h1_time   [pl]);
-    hm->registerHisto(h1_time_in[pl]);
+    RegisterHist(h1_ele    [pl]);
+    RegisterHist(h1_ele_in [pl]);
+    RegisterHist(h1_time   [pl]);
+    RegisterHist(h1_time_in[pl]);
   }
 
   return Fun4AllReturnCodes::EVENT_OK;

--- a/online/onlmonserver/OnlMonHodo.h
+++ b/online/onlmonserver/OnlMonHodo.h
@@ -14,6 +14,7 @@ class OnlMonHodo: public OnlMonClient {
   int m_pl0;
   int m_n_pl;
   TH1* h1_ele    [99];
+  TH1* h1_ele_in [99];
   TH1* h1_time   [99];
   TH1* h1_time_in[99];
 

--- a/online/onlmonserver/OnlMonHodo.h
+++ b/online/onlmonserver/OnlMonHodo.h
@@ -1,0 +1,32 @@
+#ifndef _ONL_MON_HODO__H_
+#define _ONL_MON_HODO__H_
+#include "OnlMonClient.h"
+class SQSpill;
+class SQEvent;
+class SQHitVector;
+
+class OnlMonHodo: public OnlMonClient {
+ public:
+  typedef enum { H1X, H2X, H3X, H4X, H1Y, H2Y, H4Y1, H4Y2 } HodoType_t;
+
+ private:
+  HodoType_t m_type;
+  int m_pl0;
+  int m_n_pl;
+  TH1* h1_ele    [99];
+  TH1* h1_time   [99];
+  TH1* h1_time_in[99];
+
+ public:
+  OnlMonHodo(const HodoType_t type);
+  virtual ~OnlMonHodo() {}
+
+  int InitOnlMon(PHCompositeNode *topNode);
+  int InitRunOnlMon(PHCompositeNode *topNode);
+  int ProcessEventOnlMon(PHCompositeNode *topNode);
+  int EndOnlMon(PHCompositeNode *topNode);
+  int FindAllMonHist();
+  int DrawMonitor();
+};
+
+#endif /* _ONL_MON_HODO__H_ */

--- a/online/onlmonserver/OnlMonHodo.h
+++ b/online/onlmonserver/OnlMonHodo.h
@@ -1,9 +1,6 @@
 #ifndef _ONL_MON_HODO__H_
 #define _ONL_MON_HODO__H_
 #include "OnlMonClient.h"
-class SQSpill;
-class SQEvent;
-class SQHitVector;
 
 class OnlMonHodo: public OnlMonClient {
  public:

--- a/online/onlmonserver/OnlMonMainDaq.cc
+++ b/online/onlmonserver/OnlMonMainDaq.cc
@@ -122,17 +122,9 @@ int OnlMonMainDaq::DrawMonitor()
   pad->SetGrid();
   pad->Divide(1, 4);
 
-  pad->cd(1);
-  //if (h1_trig->Integral() > 100) gPad->SetLogy();
-  h1_trig->Draw();
-
-  pad->cd(2);
-  //if (h1_evt_qual->Integral() > 100) gPad->SetLogy();
-  h1_evt_qual->Draw();
-
-  pad->cd(3);
-  //if (h1_flag_v1495->Integral() > 100) gPad->SetLogy();
-  h1_flag_v1495->Draw();
+  pad->cd(1);  h1_trig->Draw();
+  pad->cd(2);  h1_evt_qual->Draw();
+  pad->cd(3);  h1_flag_v1495->Draw();
 
   pad->cd(4);
   TPaveText* pate = new TPaveText(.02, .02, .98, .98);
@@ -159,7 +151,7 @@ int OnlMonMainDaq::DrawMonitor()
   pate->AddText(oss.str().c_str());
   pate->Draw();
 
-  can->AddMessage("Always Okay ;^D");
+  can->AddMessage("OK");
   can->SetStatus(OnlMonCanvas::OK);
 
   return 0;

--- a/online/onlmonserver/OnlMonMainDaq.cc
+++ b/online/onlmonserver/OnlMonMainDaq.cc
@@ -1,15 +1,11 @@
 /// OnlMonMainDaq.C
 #include <iomanip>
 #include <TH1D.h>
-#include <TSocket.h>
-#include <TClass.h>
-#include <TMessage.h>
 #include <TCanvas.h>
 #include <TPaveText.h>
 #include <interface_main/SQRun.h>
 #include <interface_main/SQEvent.h>
 #include <fun4all/Fun4AllReturnCodes.h>
-#include <fun4all/Fun4AllHistoManager.h>
 #include <phool/PHNodeIterator.h>
 #include <phool/PHIODataNode.h>
 #include <phool/getClass.h>
@@ -45,12 +41,10 @@ int OnlMonMainDaq::InitRunOnlMon(PHCompositeNode* topNode)
   h1_trig->GetXaxis()->SetBinLabel(7, "NIM2");
   h1_trig->GetXaxis()->SetBinLabel(8, "NIM3");
 
-  Fun4AllHistoManager* hm = new Fun4AllHistoManager(Name());
-  OnlMonServer::instance()->registerHistoManager(hm);
-  hm->registerHisto(h1_trig);
-  hm->registerHisto(h1_evt_qual);
-  hm->registerHisto(h1_flag_v1495);
-  hm->registerHisto(h1_cnt);
+  RegisterHist(h1_trig);
+  RegisterHist(h1_evt_qual);
+  RegisterHist(h1_flag_v1495);
+  RegisterHist(h1_cnt);
 
   return Fun4AllReturnCodes::EVENT_OK;
 }
@@ -120,13 +114,20 @@ int OnlMonMainDaq::DrawMonitor()
   OnlMonCanvas* can = GetCanvas();
   TPad* pad = can->GetMainPad();
   pad->SetGrid();
-  pad->Divide(1, 4);
+  pad->Divide(1, 3);
 
-  pad->cd(1);  h1_trig->Draw();
-  pad->cd(2);  h1_evt_qual->Draw();
-  pad->cd(3);  h1_flag_v1495->Draw();
+  pad->cd(1);
+  TPad* pad11 = new TPad("pad11", "", 0.0, 0.0, 0.6, 1.0);
+  TPad* pad12 = new TPad("pad12", "", 0.6, 0.0, 1.0, 1.0);
+  pad11->Draw();
+  pad12->Draw();
+  pad11->cd();  h1_trig->Draw();
+  pad12->cd();  h1_flag_v1495->Draw();
 
-  pad->cd(4);
+  pad->cd(2);
+  h1_evt_qual->Draw();
+
+  pad->cd(3);
   TPaveText* pate = new TPaveText(.02, .02, .98, .98);
   ostringstream oss;
   oss << "N of spills = " << h1_cnt->GetBinContent(1);

--- a/online/onlmonserver/OnlMonMainDaq.cc
+++ b/online/onlmonserver/OnlMonMainDaq.cc
@@ -27,19 +27,34 @@ int OnlMonMainDaq::InitOnlMon(PHCompositeNode* topNode)
 
 int OnlMonMainDaq::InitRunOnlMon(PHCompositeNode* topNode)
 {
-  h1_trig = new TH1D("h1_trig", ";Trigger;N of events", 8, 0.5, 8.5);
-  h1_evt_qual = new TH1D("h1_evt_qual", ";Event-quality bit;N of events", 33, -0.5, 32.5);
-  h1_flag_v1495 = new TH1D("h1_flag_v1495", ";v1495 status flag; N of v1495 events", 4, -0.5, 3.5);
+  h1_trig = new TH1D("h1_trig", "Trigger Status;Trigger;N of events", 10, 0.5, 10.5);
+  h1_evt_qual = new TH1D("h1_evt_qual", "Event Status;Event-quality bit;N of events", 33, -0.5, 32.5);
+  h1_flag_v1495 = new TH1D("h1_flag_v1495", "V1495 Status;v1495 status bit; N of v1495 events", 5, -0.5, 4.5);
   h1_cnt = new TH1D("h1_cnt", ";Type;Count", 15, 0.5, 15.5);
 
-  h1_trig->GetXaxis()->SetBinLabel(1, "FPGA1");
-  h1_trig->GetXaxis()->SetBinLabel(2, "FPGA2");
-  h1_trig->GetXaxis()->SetBinLabel(3, "FPGA3");
-  h1_trig->GetXaxis()->SetBinLabel(4, "FPGA4");
-  h1_trig->GetXaxis()->SetBinLabel(5, "FPGA5");
-  h1_trig->GetXaxis()->SetBinLabel(6, "NIM1");
-  h1_trig->GetXaxis()->SetBinLabel(7, "NIM2");
-  h1_trig->GetXaxis()->SetBinLabel(8, "NIM3");
+  h1_trig->GetXaxis()->SetBinLabel( 1, "FPGA1");
+  h1_trig->GetXaxis()->SetBinLabel( 2, "FPGA2");
+  h1_trig->GetXaxis()->SetBinLabel( 3, "FPGA3");
+  h1_trig->GetXaxis()->SetBinLabel( 4, "FPGA4");
+  h1_trig->GetXaxis()->SetBinLabel( 5, "FPGA5");
+  h1_trig->GetXaxis()->SetBinLabel( 6, "NIM1");
+  h1_trig->GetXaxis()->SetBinLabel( 7, "NIM2");
+  h1_trig->GetXaxis()->SetBinLabel( 8, "NIM3");
+  h1_trig->GetXaxis()->SetBinLabel( 9, "NIM4");
+  h1_trig->GetXaxis()->SetBinLabel(10, "NIM5");
+
+  ostringstream oss;
+  h1_evt_qual->GetXaxis()->SetBinLabel(1, "OK");
+  for (int ii = 1; ii <= 32; ii++) {
+    oss.str("");  oss << ii;
+    h1_evt_qual->GetXaxis()->SetBinLabel(ii+1, oss.str().c_str());
+  }
+
+  h1_flag_v1495->GetXaxis()->SetBinLabel(1, "OK");
+  h1_flag_v1495->GetXaxis()->SetBinLabel(2, "d1ad");
+  h1_flag_v1495->GetXaxis()->SetBinLabel(3, "d2ad");
+  h1_flag_v1495->GetXaxis()->SetBinLabel(4, "d3ad");
+  h1_flag_v1495->GetXaxis()->SetBinLabel(5, "Other");
 
   RegisterHist(h1_trig);
   RegisterHist(h1_evt_qual);
@@ -55,14 +70,16 @@ int OnlMonMainDaq::ProcessEventOnlMon(PHCompositeNode* topNode)
   SQEvent* event = findNode::getClass<SQEvent>(topNode, "SQEvent");
   if (! run || ! event) return Fun4AllReturnCodes::ABORTEVENT;
 
-  if (event->get_trigger(SQEvent::MATRIX1)) h1_trig->Fill(1);
-  if (event->get_trigger(SQEvent::MATRIX2)) h1_trig->Fill(2);
-  if (event->get_trigger(SQEvent::MATRIX3)) h1_trig->Fill(3);
-  if (event->get_trigger(SQEvent::MATRIX4)) h1_trig->Fill(4);
-  if (event->get_trigger(SQEvent::MATRIX5)) h1_trig->Fill(5);
-  if (event->get_trigger(SQEvent::NIM1   )) h1_trig->Fill(6);
-  if (event->get_trigger(SQEvent::NIM2   )) h1_trig->Fill(7);
-  if (event->get_trigger(SQEvent::NIM3   )) h1_trig->Fill(8);
+  if (event->get_trigger(SQEvent::MATRIX1)) h1_trig->Fill( 1);
+  if (event->get_trigger(SQEvent::MATRIX2)) h1_trig->Fill( 2);
+  if (event->get_trigger(SQEvent::MATRIX3)) h1_trig->Fill( 3);
+  if (event->get_trigger(SQEvent::MATRIX4)) h1_trig->Fill( 4);
+  if (event->get_trigger(SQEvent::MATRIX5)) h1_trig->Fill( 5);
+  if (event->get_trigger(SQEvent::NIM1   )) h1_trig->Fill( 6);
+  if (event->get_trigger(SQEvent::NIM2   )) h1_trig->Fill( 7);
+  if (event->get_trigger(SQEvent::NIM3   )) h1_trig->Fill( 8);
+  if (event->get_trigger(SQEvent::NIM4   )) h1_trig->Fill( 9);
+  if (event->get_trigger(SQEvent::NIM5   )) h1_trig->Fill(10);
 
   h1_cnt->SetBinContent( 1, run->get_n_spill        ());
   h1_cnt->SetBinContent( 2, run->get_n_evt_all      ());
@@ -88,7 +105,7 @@ int OnlMonMainDaq::ProcessEventOnlMon(PHCompositeNode* topNode)
 
   int v1495 = event->get_flag_v1495();
   if (v1495 == 0) h1_flag_v1495->Fill(0);
-  for (int bit = 0; bit < 3; bit++) {
+  for (int bit = 0; bit < 4; bit++) {
     if ((v1495 >> bit) & 0x1) h1_flag_v1495->Fill(bit + 1);
   }
 

--- a/online/onlmonserver/OnlMonMainDaq.h
+++ b/online/onlmonserver/OnlMonMainDaq.h
@@ -2,8 +2,6 @@
 #ifndef _ONL_MON_MAIN_DAQ__H_
 #define _ONL_MON_MAIN_DAQ__H_
 #include "OnlMonClient.h"
-class SQEvent;
-class TArrayI;
 
 class OnlMonMainDaq: public OnlMonClient {
   TH1* h1_trig;
@@ -21,9 +19,6 @@ class OnlMonMainDaq: public OnlMonClient {
   int EndOnlMon(PHCompositeNode *topNode);
   int FindAllMonHist();
   int DrawMonitor();
-
- private:
-  //void PrintEvent(SQEvent* evt, SQHitVector* v_hit, SQHitVector* v_trig_hit);
 };
 
 #endif /* _ONL_MON_MAIN_DAQ__H_ */

--- a/online/onlmonserver/OnlMonMainDaq.h
+++ b/online/onlmonserver/OnlMonMainDaq.h
@@ -6,18 +6,20 @@ class SQEvent;
 class TArrayI;
 
 class OnlMonMainDaq: public OnlMonClient {
+  TH1* h1_trig;
   TH1* h1_evt_qual;
   TH1* h1_flag_v1495;
   TH1* h1_cnt;
 
  public:
-  OnlMonMainDaq(const std::string &name = "OnlMonMainDaq");
+  OnlMonMainDaq();
   virtual ~OnlMonMainDaq() {}
-  int Init(PHCompositeNode *topNode);
-  int InitRun(PHCompositeNode *topNode);
-  int process_event(PHCompositeNode *topNode);
-  int End(PHCompositeNode *topNode);
 
+  int InitOnlMon(PHCompositeNode *topNode);
+  int InitRunOnlMon(PHCompositeNode *topNode);
+  int ProcessEventOnlMon(PHCompositeNode *topNode);
+  int EndOnlMon(PHCompositeNode *topNode);
+  int FindAllMonHist();
   int DrawMonitor();
 
  private:

--- a/online/onlmonserver/OnlMonProp.cc
+++ b/online/onlmonserver/OnlMonProp.cc
@@ -2,13 +2,9 @@
 #include <iomanip>
 #include <TH1D.h>
 #include <interface_main/SQRun.h>
-#include <interface_main/SQStringMap.h>
-#include <interface_main/SQScaler.h>
-#include <interface_main/SQSlowCont.h>
 #include <interface_main/SQEvent.h>
 #include <interface_main/SQHitVector.h>
 #include <fun4all/Fun4AllReturnCodes.h>
-#include <fun4all/Fun4AllHistoManager.h>
 #include <phool/PHNodeIterator.h>
 #include <phool/PHIODataNode.h>
 #include <phool/getClass.h>
@@ -35,16 +31,13 @@ int OnlMonProp::InitOnlMon(PHCompositeNode* topNode)
 
 int OnlMonProp::InitRunOnlMon(PHCompositeNode* topNode)
 {
-  SQRun* run_header = findNode::getClass<SQRun>(topNode, "SQRun");
-  if (!run_header) return Fun4AllReturnCodes::ABORTEVENT;
+  //SQRun* run_header = findNode::getClass<SQRun>(topNode, "SQRun");
+  //if (!run_header) return Fun4AllReturnCodes::ABORTEVENT;
 
   GeomSvc* geom = GeomSvc::instance();
   //CalibParamInTimeTaiwan calib;
   //calib.SetMapIDbyDB(run_header->get_run_id());
   //calib.ReadFromDB();
-
-  Fun4AllHistoManager* hm = new Fun4AllHistoManager(Name());
-  OnlMonServer::instance()->registerHistoManager(hm);
 
   ostringstream oss;
   for (int pl = 0; pl < N_PL; pl++) {
@@ -73,8 +66,8 @@ int OnlMonProp::InitRunOnlMon(PHCompositeNode* topNode)
     oss << name << ";tdcTime;Hit count";
     h1_time[pl]->SetTitle(oss.str().c_str());
 
-    hm->registerHisto(h1_ele [pl]);
-    hm->registerHisto(h1_time[pl]);
+    RegisterHist(h1_ele [pl]);
+    RegisterHist(h1_time[pl]);
   }
 
   return Fun4AllReturnCodes::EVENT_OK;

--- a/online/onlmonserver/OnlMonProp.cc
+++ b/online/onlmonserver/OnlMonProp.cc
@@ -1,4 +1,4 @@
-/// OnlMonCham.C
+/// OnlMonProp.C
 #include <iomanip>
 #include <TH1D.h>
 #include <interface_main/SQRun.h>
@@ -15,28 +15,25 @@
 #include <geom_svc/GeomSvc.h>
 //#include <chan_map/CalibParamInTimeTaiwan.h>
 #include "OnlMonServer.h"
-#include "OnlMonCham.h"
+#include "OnlMonProp.h"
 #include "UtilHist.h"
 using namespace std;
 
-OnlMonCham::OnlMonCham(const ChamType_t type) : m_type(type)
+OnlMonProp::OnlMonProp(const PropType_t type) : m_type(type)
 {
   NumCanvases(2);
   switch (m_type) {
-  case D0 :  m_pl0 =  1;  Name("OnlMonChamD0" );  Title( "D0 Chamber");  break;
-  case D1 :  m_pl0 =  7;  Name("OnlMonChamD1" );  Title( "D1 Chamber");  break;
-  case D2 :  m_pl0 = 13;  Name("OnlMonChamD2" );  Title( "D2 Chamber");  break;
-  case D3p:  m_pl0 = 19;  Name("OnlMonChamD3p");  Title("D3p Chamber");  break;
-  case D3m:  m_pl0 = 25;  Name("OnlMonChamD3m");  Title("D3m Chamber");  break;
+  case P1 :  m_pl0 = 47;  Name("OnlMonPropP1" );  Title( "P1 Prop Tube");  break;
+  case P2 :  m_pl0 = 51;  Name("OnlMonPropP2" );  Title( "P2 Prop Tube");  break;
   }
 }
 
-int OnlMonCham::InitOnlMon(PHCompositeNode* topNode)
+int OnlMonProp::InitOnlMon(PHCompositeNode* topNode)
 {
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-int OnlMonCham::InitRunOnlMon(PHCompositeNode* topNode)
+int OnlMonProp::InitRunOnlMon(PHCompositeNode* topNode)
 {
   SQRun* run_header = findNode::getClass<SQRun>(topNode, "SQRun");
   if (!run_header) return Fun4AllReturnCodes::ABORTEVENT;
@@ -60,8 +57,8 @@ int OnlMonCham::InitRunOnlMon(PHCompositeNode* topNode)
     oss << name << ";Element ID;Hit count";
     h1_ele[pl]->SetTitle(oss.str().c_str());
 
-    const double DT = 20/9.0; // 4/9 ns per single count of Taiwan TDC
-    const int NT = 1000;
+    const double DT = 40/9.0; // 4/9 ns per single count of Taiwan TDC
+    const int NT = 500;
     const double T0 = 0.5*DT;
     const double T1 = (NT+0.5)*DT;
 
@@ -83,7 +80,7 @@ int OnlMonCham::InitRunOnlMon(PHCompositeNode* topNode)
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-int OnlMonCham::ProcessEventOnlMon(PHCompositeNode* topNode)
+int OnlMonProp::ProcessEventOnlMon(PHCompositeNode* topNode)
 {
   SQEvent*     event_header = findNode::getClass<SQEvent    >(topNode, "SQEvent");
   SQHitVector*      hit_vec = findNode::getClass<SQHitVector>(topNode, "SQHitVector");
@@ -99,12 +96,12 @@ int OnlMonCham::ProcessEventOnlMon(PHCompositeNode* topNode)
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-int OnlMonCham::EndOnlMon(PHCompositeNode* topNode)
+int OnlMonProp::EndOnlMon(PHCompositeNode* topNode)
 {
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-int OnlMonCham::FindAllMonHist()
+int OnlMonProp::FindAllMonHist()
 {
   ostringstream oss;
   for (int pl = 0; pl < N_PL; pl++) {
@@ -120,12 +117,12 @@ int OnlMonCham::FindAllMonHist()
   return 0;
 }
 
-int OnlMonCham::DrawMonitor()
+int OnlMonProp::DrawMonitor()
 {
   OnlMonCanvas* can0 = GetCanvas(0);
   TPad* pad0 = can0->GetMainPad();
   pad0->SetGrid();
-  pad0->Divide(2, 3);
+  pad0->Divide(2, 2);
   for (int pl = 0; pl < N_PL; pl++) {
     pad0->cd(pl+1);
     //if (h1_ele[pl]->Integral() > 1000) gPad->SetLogy();
@@ -137,7 +134,7 @@ int OnlMonCham::DrawMonitor()
   OnlMonCanvas* can1 = GetCanvas(1);
   TPad* pad1 = can1->GetMainPad();
   pad1->SetGrid();
-  pad1->Divide(2, 3);
+  pad1->Divide(2, 2);
   for (int pl = 0; pl < N_PL; pl++) {
     pad1->cd(pl+1);
     //if (h1_time[pl]->Integral() > 1000) gPad->SetLogy();

--- a/online/onlmonserver/OnlMonProp.cc
+++ b/online/onlmonserver/OnlMonProp.cc
@@ -125,10 +125,9 @@ int OnlMonProp::DrawMonitor()
   pad0->Divide(2, 2);
   for (int pl = 0; pl < N_PL; pl++) {
     pad0->cd(pl+1);
-    //if (h1_ele[pl]->Integral() > 1000) gPad->SetLogy();
     h1_ele[pl]->Draw();
   }
-  can0->AddMessage("Always Okay ;^D");
+  can0->AddMessage("OK");
   can0->SetStatus(OnlMonCanvas::OK);
 
   OnlMonCanvas* can1 = GetCanvas(1);
@@ -137,11 +136,10 @@ int OnlMonProp::DrawMonitor()
   pad1->Divide(2, 2);
   for (int pl = 0; pl < N_PL; pl++) {
     pad1->cd(pl+1);
-    //if (h1_time[pl]->Integral() > 1000) gPad->SetLogy();
     UtilHist::AutoSetRange(h1_time[pl]);
     h1_time[pl]->Draw();
   }
-  can1->AddMessage("Always Okay ;^D");
+  can1->AddMessage("OK");
   can1->SetStatus(OnlMonCanvas::OK);
 
   return 0;

--- a/online/onlmonserver/OnlMonProp.h
+++ b/online/onlmonserver/OnlMonProp.h
@@ -1,21 +1,21 @@
-#ifndef _ONL_MON_CHAM__H_
-#define _ONL_MON_CHAM__H_
+#ifndef _ONL_MON_PROP__H_
+#define _ONL_MON_PROP__H_
 #include "OnlMonClient.h"
 
-class OnlMonCham: public OnlMonClient {
+class OnlMonProp: public OnlMonClient {
  public:
-  typedef enum { D0, D1, D2, D3p, D3m } ChamType_t;
-  static const int N_PL = 6;
+  typedef enum { P1, P2 } PropType_t;
+  static const int N_PL = 4;
 
  private:
-  ChamType_t m_type;
+  PropType_t m_type;
   int m_pl0;
   TH1* h1_ele [N_PL];
   TH1* h1_time[N_PL];
 
  public:
-  OnlMonCham(const ChamType_t type);
-  virtual ~OnlMonCham() {}
+  OnlMonProp(const PropType_t type);
+  virtual ~OnlMonProp() {}
 
   int InitOnlMon(PHCompositeNode *topNode);
   int InitRunOnlMon(PHCompositeNode *topNode);
@@ -25,4 +25,4 @@ class OnlMonCham: public OnlMonClient {
   int DrawMonitor();
 };
 
-#endif /* _ONL_MON_CHAM__H_ */
+#endif /* _ONL_MON_PROP__H_ */

--- a/online/onlmonserver/OnlMonTrigSig.cc
+++ b/online/onlmonserver/OnlMonTrigSig.cc
@@ -1,0 +1,152 @@
+/// OnlMonTrigSig.C
+#include <iomanip>
+#include <TH2D.h>
+#include <interface_main/SQRun.h>
+#include <interface_main/SQStringMap.h>
+#include <interface_main/SQScaler.h>
+#include <interface_main/SQSlowCont.h>
+#include <interface_main/SQEvent.h>
+#include <interface_main/SQHitVector.h>
+#include <fun4all/Fun4AllReturnCodes.h>
+#include <fun4all/Fun4AllHistoManager.h>
+#include <phool/PHNodeIterator.h>
+#include <phool/PHIODataNode.h>
+#include <phool/getClass.h>
+#include <geom_svc/GeomSvc.h>
+#include <chan_map/CalibParamInTimeTaiwan.h>
+#include "OnlMonServer.h"
+#include "OnlMonTrigSig.h"
+#include "UtilHist.h"
+using namespace std;
+
+// BeforeInhNIM = 55
+// BeforeInhMatrix
+// AfterInhNIM
+// AfterInhMatrix 
+// BOS ???
+// EOS ???
+// L1  ???
+// RF   (ch = 0-8 on v1495)
+// STOP (ch = 0-8 on v1495)
+// L1PXtp         
+// L1PXtn         
+// L1PXbp         
+// L1PXbn         
+// L1NIMxt        
+// L1NIMxb        
+// L1NIMyt        
+// L1NIMyb        
+
+OnlMonTrigSig::OnlMonTrigSig()
+{
+  NumCanvases(2);
+  Name("OnlMonTrigSig");
+  Title("Trigger Signal");
+}
+
+int OnlMonTrigSig::InitOnlMon(PHCompositeNode* topNode)
+{
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int OnlMonTrigSig::InitRunOnlMon(PHCompositeNode* topNode)
+{
+  const double DT = 4/9.0; // 4/9 ns per single count of Taiwan TDC
+  const int NT = 4000;
+  const double T0 = 0.5*DT;
+  const double T1 = (NT+0.5)*DT;
+  h2_bi_fpga = new TH2D("h2_bi_fpga", "FPGA Before Inhibit;tdcTime;", NT, T0, T1,  5, 0.5, 5.5);
+  h2_ai_fpga = new TH2D("h2_ai_fpga",  "FPGA After Inhibit;tdcTime;", NT, T0, T1,  5, 0.5, 5.5);
+  h2_bi_nim  = new TH2D("h2_bi_nim" ,  "NIM Before Inhibit;tdcTime;", NT, T0, T1,  5, 0.5, 5.5);
+  h2_ai_nim  = new TH2D("h2_ai_nim" ,   "NIM After Inhibit;tdcTime;", NT, T0, T1,  5, 0.5, 5.5);
+  for (int ii = 1; ii <= 5; ii++) {
+    ostringstream oss;
+    oss << "FPGA " << ii;
+    h2_bi_fpga->GetYaxis()->SetBinLabel(ii, oss.str().c_str());
+    h2_ai_fpga->GetYaxis()->SetBinLabel(ii, oss.str().c_str());
+    oss.str("");
+    oss << "NIM " << ii;
+    h2_bi_nim->GetYaxis()->SetBinLabel(ii, oss.str().c_str());
+    h2_ai_nim->GetYaxis()->SetBinLabel(ii, oss.str().c_str());
+  }
+
+  Fun4AllHistoManager* hm = new Fun4AllHistoManager(Name());
+  OnlMonServer::instance()->registerHistoManager(hm);
+  hm->registerHisto(h2_bi_fpga);
+  hm->registerHisto(h2_ai_fpga);
+  hm->registerHisto(h2_bi_nim );
+  hm->registerHisto(h2_ai_nim );
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int OnlMonTrigSig::ProcessEventOnlMon(PHCompositeNode* topNode)
+{
+  SQEvent*     event_header = findNode::getClass<SQEvent    >(topNode, "SQEvent");
+  SQHitVector*      hit_vec = findNode::getClass<SQHitVector>(topNode, "SQHitVector");
+  if (!event_header || !hit_vec) return Fun4AllReturnCodes::ABORTEVENT;
+
+  for (SQHitVector::ConstIter it = hit_vec->begin(); it != hit_vec->end(); it++) {
+    int det_id  = (*it)->get_detector_id();
+    int ele_id  = (*it)->get_element_id ();
+    double time = (*it)->get_tdc_time   ();
+    /// Lazy ID search.  Temporary...
+    if      (det_id == 55) h2_bi_nim ->Fill(time, ele_id);
+    else if (det_id == 56) h2_bi_fpga->Fill(time, ele_id);
+    else if (det_id == 57) h2_ai_nim ->Fill(time, ele_id);
+    else if (det_id == 58) h2_ai_fpga->Fill(time, ele_id);
+  }
+  
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int OnlMonTrigSig::EndOnlMon(PHCompositeNode* topNode)
+{
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int OnlMonTrigSig::FindAllMonHist()
+{
+  h2_bi_fpga = (TH2*)FindMonObj("h2_bi_fpga");
+  h2_ai_fpga = (TH2*)FindMonObj("h2_ai_fpga");
+  h2_bi_nim  = (TH2*)FindMonObj("h2_bi_nim" );
+  h2_ai_nim  = (TH2*)FindMonObj("h2_ai_nim" );
+  return (h2_bi_fpga && h2_ai_fpga && h2_bi_nim && h2_ai_nim  ?  0  :  1);
+}
+
+int OnlMonTrigSig::DrawMonitor()
+{
+  UtilHist::AutoSetRangeX(h2_bi_fpga);
+  UtilHist::AutoSetRangeX(h2_ai_fpga);
+  UtilHist::AutoSetRangeX(h2_bi_nim );
+  UtilHist::AutoSetRangeX(h2_ai_nim );
+
+  //TH1* h1_tmp = h2_bi_fpga->ProjectionX("h1_tmp");
+  //int i_lo = 1;
+  //while (h1_tmp->GetBinContent(i_lo) == 0) i_lo++;
+  //int i_hi = h1_tmp->GetNbinsX();
+  //while (h1_tmp->GetBinContent(i_hi) == 0) i_hi--;
+  //delete h1_tmp;
+  //cout << "L " << i_lo << " " << i_hi << endl;
+  //h2_bi_fpga->GetXaxis()->SetRange(i_lo-5, i_hi+5);
+
+  OnlMonCanvas* can0 = GetCanvas(0);
+  TPad* pad0 = can0->GetMainPad();
+  pad0->SetGrid();
+  pad0->Divide(1, 2);
+  pad0->cd(1);  h2_bi_fpga->Draw("colz");
+  pad0->cd(2);  h2_ai_fpga->Draw("colz");
+  can0->AddMessage("Always Okay ;^D");
+  can0->SetStatus(OnlMonCanvas::OK);
+
+  OnlMonCanvas* can1 = GetCanvas(1);
+  TPad* pad1 = can1->GetMainPad();
+  pad1->SetGrid();
+  pad1->Divide(1, 2);
+  pad1->cd(1);  h2_bi_nim ->Draw("colz");
+  pad1->cd(2);  h2_ai_nim ->Draw("colz");
+  can1->AddMessage("Always Okay ;^D");
+  can1->SetStatus(OnlMonCanvas::OK);
+
+  return 0;
+}

--- a/online/onlmonserver/OnlMonTrigSig.cc
+++ b/online/onlmonserver/OnlMonTrigSig.cc
@@ -39,7 +39,7 @@ using namespace std;
 
 OnlMonTrigSig::OnlMonTrigSig()
 {
-  NumCanvases(2);
+  NumCanvases(3);
   Name("OnlMonTrigSig");
   Title("Trigger Signal");
 }
@@ -70,12 +70,27 @@ int OnlMonTrigSig::InitRunOnlMon(PHCompositeNode* topNode)
     h2_ai_nim->GetYaxis()->SetBinLabel(ii, oss.str().c_str());
   }
 
+  const double DT2 = 1.0; // 1 ns per single count of v1495 TDC
+  const int NT2 = 2000;
+  const double T02 = 0.5*DT2;
+  const double T12 = (NT2+0.5)*DT2;
+  h2_rf      = new TH2D("h2_rf"     ,   "RF on v1495;tdcTime;", NT2, T02, T12,  9, 0.5, 9.5);
+  h2_stop    = new TH2D("h2_stop"   , "STOP on v1495;tdcTime;", NT2, T02, T12,  9, 0.5, 9.5);
+  for (int ii = 1; ii <= 9; ii++) {
+    ostringstream oss;
+    oss << "Board " << ii;
+    h2_rf  ->GetYaxis()->SetBinLabel(ii, oss.str().c_str());
+    h2_stop->GetYaxis()->SetBinLabel(ii, oss.str().c_str());
+  }
+
   Fun4AllHistoManager* hm = new Fun4AllHistoManager(Name());
   OnlMonServer::instance()->registerHistoManager(hm);
   hm->registerHisto(h2_bi_fpga);
   hm->registerHisto(h2_ai_fpga);
   hm->registerHisto(h2_bi_nim );
   hm->registerHisto(h2_ai_nim );
+  hm->registerHisto(h2_rf     );
+  hm->registerHisto(h2_stop   );
 
   return Fun4AllReturnCodes::EVENT_OK;
 }
@@ -84,17 +99,27 @@ int OnlMonTrigSig::ProcessEventOnlMon(PHCompositeNode* topNode)
 {
   SQEvent*     event_header = findNode::getClass<SQEvent    >(topNode, "SQEvent");
   SQHitVector*      hit_vec = findNode::getClass<SQHitVector>(topNode, "SQHitVector");
-  if (!event_header || !hit_vec) return Fun4AllReturnCodes::ABORTEVENT;
+  SQHitVector* trig_hit_vec = findNode::getClass<SQHitVector>(topNode, "SQTriggerHitVector");
+  if (!event_header || !hit_vec || !trig_hit_vec) return Fun4AllReturnCodes::ABORTEVENT;
+
+  GeomSvc* geom = GeomSvc::instance();
 
   for (SQHitVector::ConstIter it = hit_vec->begin(); it != hit_vec->end(); it++) {
     int det_id  = (*it)->get_detector_id();
     int ele_id  = (*it)->get_element_id ();
     double time = (*it)->get_tdc_time   ();
-    /// Lazy ID search.  Temporary...
-    if      (det_id == 55) h2_bi_nim ->Fill(time, ele_id);
-    else if (det_id == 56) h2_bi_fpga->Fill(time, ele_id);
-    else if (det_id == 57) h2_ai_nim ->Fill(time, ele_id);
-    else if (det_id == 58) h2_ai_fpga->Fill(time, ele_id);
+    if      (det_id == geom->getDetectorID("BeforeInhNIM"   )) h2_bi_nim ->Fill(time, ele_id);
+    else if (det_id == geom->getDetectorID("BeforeInhMatrix")) h2_bi_fpga->Fill(time, ele_id);
+    else if (det_id == geom->getDetectorID("AfterInhNIM"    )) h2_ai_nim ->Fill(time, ele_id);
+    else if (det_id == geom->getDetectorID("AfterInhMatrix" )) h2_ai_fpga->Fill(time, ele_id);
+  }
+
+  for (SQHitVector::ConstIter it = trig_hit_vec->begin(); it != trig_hit_vec->end(); it++) {
+    int det_id  = (*it)->get_detector_id();
+    int ele_id  = (*it)->get_element_id ();
+    double time = (*it)->get_tdc_time   ();
+    if      (det_id == geom->getDetectorID("RF"  )) h2_rf  ->Fill(time, ele_id);
+    else if (det_id == geom->getDetectorID("STOP")) h2_stop->Fill(time, ele_id);
   }
   
   return Fun4AllReturnCodes::EVENT_OK;
@@ -111,7 +136,9 @@ int OnlMonTrigSig::FindAllMonHist()
   h2_ai_fpga = (TH2*)FindMonObj("h2_ai_fpga");
   h2_bi_nim  = (TH2*)FindMonObj("h2_bi_nim" );
   h2_ai_nim  = (TH2*)FindMonObj("h2_ai_nim" );
-  return (h2_bi_fpga && h2_ai_fpga && h2_bi_nim && h2_ai_nim  ?  0  :  1);
+  h2_rf      = (TH2*)FindMonObj("h2_rf"     );
+  h2_stop    = (TH2*)FindMonObj("h2_stop"   );
+  return (h2_bi_fpga && h2_ai_fpga && h2_bi_nim && h2_ai_nim && h2_rf && h2_stop  ?  0  :  1);
 }
 
 int OnlMonTrigSig::DrawMonitor()
@@ -120,33 +147,55 @@ int OnlMonTrigSig::DrawMonitor()
   UtilHist::AutoSetRangeX(h2_ai_fpga);
   UtilHist::AutoSetRangeX(h2_bi_nim );
   UtilHist::AutoSetRangeX(h2_ai_nim );
-
-  //TH1* h1_tmp = h2_bi_fpga->ProjectionX("h1_tmp");
-  //int i_lo = 1;
-  //while (h1_tmp->GetBinContent(i_lo) == 0) i_lo++;
-  //int i_hi = h1_tmp->GetNbinsX();
-  //while (h1_tmp->GetBinContent(i_hi) == 0) i_hi--;
-  //delete h1_tmp;
-  //cout << "L " << i_lo << " " << i_hi << endl;
-  //h2_bi_fpga->GetXaxis()->SetRange(i_lo-5, i_hi+5);
+  UtilHist::AutoSetRangeX(h2_rf     );
+  UtilHist::AutoSetRangeX(h2_stop   );
 
   OnlMonCanvas* can0 = GetCanvas(0);
   TPad* pad0 = can0->GetMainPad();
   pad0->SetGrid();
   pad0->Divide(1, 2);
-  pad0->cd(1);  h2_bi_fpga->Draw("colz");
-  pad0->cd(2);  h2_ai_fpga->Draw("colz");
-  can0->AddMessage("Always Okay ;^D");
+  pad0->cd(1);  DrawTH2WithPeakPos(h2_bi_fpga);
+  pad0->cd(2);  DrawTH2WithPeakPos(h2_ai_fpga);
+  can0->AddMessage("OK");
   can0->SetStatus(OnlMonCanvas::OK);
 
   OnlMonCanvas* can1 = GetCanvas(1);
   TPad* pad1 = can1->GetMainPad();
   pad1->SetGrid();
   pad1->Divide(1, 2);
-  pad1->cd(1);  h2_bi_nim ->Draw("colz");
-  pad1->cd(2);  h2_ai_nim ->Draw("colz");
-  can1->AddMessage("Always Okay ;^D");
+  pad1->cd(1);  DrawTH2WithPeakPos(h2_bi_nim);
+  pad1->cd(2);  DrawTH2WithPeakPos(h2_ai_nim);
+  can1->AddMessage("OK");
   can1->SetStatus(OnlMonCanvas::OK);
 
+  OnlMonCanvas* can2 = GetCanvas(2);
+  TPad* pad2 = can2->GetMainPad();
+  pad2->SetGrid();
+  pad2->Divide(1, 2);
+  pad2->cd(1);  DrawTH2WithPeakPos(h2_rf  );
+  pad2->cd(2);  DrawTH2WithPeakPos(h2_stop);
+  can2->AddMessage("OK");
+  can2->SetStatus(OnlMonCanvas::OK);
+
   return 0;
+}
+
+void OnlMonTrigSig::DrawTH2WithPeakPos(TH2* h2, const double cont_min)
+{
+  h2->Draw("colz");
+  int ny = h2->GetNbinsY();
+  for (int iy = 1; iy <= ny; iy++) {
+    TH1* h1 = h2->ProjectionX("h1_draw_th2", iy, iy);
+    ostringstream oss;
+    if (h1->GetMaximum() >= cont_min) {
+      oss << "Peak @ " << h1->GetXaxis()->GetBinCenter(h1->GetMaximumBin());
+    } else {
+      oss << "No sizable peak";
+    }
+    TText* text = new TText();
+    text->SetNDC(true);
+    text->SetTextAlign(22);
+    text->DrawText(0.3, 0.1+(iy-0.5)*0.8/ny, oss.str().c_str());
+    // The y-position above assumes that the top & bottom margins are 0.1 each.
+  }
 }

--- a/online/onlmonserver/OnlMonTrigSig.cc
+++ b/online/onlmonserver/OnlMonTrigSig.cc
@@ -1,41 +1,35 @@
 /// OnlMonTrigSig.C
 #include <iomanip>
 #include <TH2D.h>
-#include <interface_main/SQRun.h>
-#include <interface_main/SQStringMap.h>
-#include <interface_main/SQScaler.h>
-#include <interface_main/SQSlowCont.h>
 #include <interface_main/SQEvent.h>
 #include <interface_main/SQHitVector.h>
 #include <fun4all/Fun4AllReturnCodes.h>
-#include <fun4all/Fun4AllHistoManager.h>
 #include <phool/PHNodeIterator.h>
 #include <phool/PHIODataNode.h>
 #include <phool/getClass.h>
 #include <geom_svc/GeomSvc.h>
-#include <chan_map/CalibParamInTimeTaiwan.h>
 #include "OnlMonServer.h"
 #include "OnlMonTrigSig.h"
 #include "UtilHist.h"
 using namespace std;
 
-// BeforeInhNIM = 55
+// BeforeInhNIM
 // BeforeInhMatrix
 // AfterInhNIM
 // AfterInhMatrix 
-// BOS ???
-// EOS ???
-// L1  ???
+// BOS  (ch = ?)
+// EOS  (ch = ?)
+// L1   (ch = ?)
 // RF   (ch = 0-8 on v1495)
 // STOP (ch = 0-8 on v1495)
-// L1PXtp         
-// L1PXtn         
-// L1PXbp         
-// L1PXbn         
-// L1NIMxt        
-// L1NIMxb        
-// L1NIMyt        
-// L1NIMyb        
+// L1PXtp
+// L1PXtn
+// L1PXbp
+// L1PXbn
+// L1NIMxt
+// L1NIMxb
+// L1NIMyt
+// L1NIMyb
 
 OnlMonTrigSig::OnlMonTrigSig()
 {
@@ -83,14 +77,12 @@ int OnlMonTrigSig::InitRunOnlMon(PHCompositeNode* topNode)
     h2_stop->GetYaxis()->SetBinLabel(ii, oss.str().c_str());
   }
 
-  Fun4AllHistoManager* hm = new Fun4AllHistoManager(Name());
-  OnlMonServer::instance()->registerHistoManager(hm);
-  hm->registerHisto(h2_bi_fpga);
-  hm->registerHisto(h2_ai_fpga);
-  hm->registerHisto(h2_bi_nim );
-  hm->registerHisto(h2_ai_nim );
-  hm->registerHisto(h2_rf     );
-  hm->registerHisto(h2_stop   );
+  RegisterHist(h2_bi_fpga);
+  RegisterHist(h2_ai_fpga);
+  RegisterHist(h2_bi_nim );
+  RegisterHist(h2_ai_nim );
+  RegisterHist(h2_rf     );
+  RegisterHist(h2_stop   );
 
   return Fun4AllReturnCodes::EVENT_OK;
 }

--- a/online/onlmonserver/OnlMonTrigSig.h
+++ b/online/onlmonserver/OnlMonTrigSig.h
@@ -1,0 +1,26 @@
+#ifndef _ONL_MON_TRIG_SIG__H_
+#define _ONL_MON_TRIG_SIG__H_
+#include "OnlMonClient.h"
+class SQSpill;
+class SQEvent;
+class SQHitVector;
+
+class OnlMonTrigSig: public OnlMonClient {
+  TH2* h2_bi_fpga;
+  TH2* h2_ai_fpga;
+  TH2* h2_bi_nim;
+  TH2* h2_ai_nim;
+
+ public:
+  OnlMonTrigSig();
+  virtual ~OnlMonTrigSig() {}
+
+  int InitOnlMon(PHCompositeNode *topNode);
+  int InitRunOnlMon(PHCompositeNode *topNode);
+  int ProcessEventOnlMon(PHCompositeNode *topNode);
+  int EndOnlMon(PHCompositeNode *topNode);
+  int FindAllMonHist();
+  int DrawMonitor();
+};
+
+#endif /* _ONL_MON_TRIG_SIG__H_ */

--- a/online/onlmonserver/OnlMonTrigSig.h
+++ b/online/onlmonserver/OnlMonTrigSig.h
@@ -10,6 +10,8 @@ class OnlMonTrigSig: public OnlMonClient {
   TH2* h2_ai_fpga;
   TH2* h2_bi_nim;
   TH2* h2_ai_nim;
+  TH2* h2_rf;
+  TH2* h2_stop;
 
  public:
   OnlMonTrigSig();
@@ -21,6 +23,9 @@ class OnlMonTrigSig: public OnlMonClient {
   int EndOnlMon(PHCompositeNode *topNode);
   int FindAllMonHist();
   int DrawMonitor();
+
+ private:
+  void DrawTH2WithPeakPos(TH2* h2, const double cont_min=100);
 };
 
 #endif /* _ONL_MON_TRIG_SIG__H_ */

--- a/online/onlmonserver/OnlMonTrigSig.h
+++ b/online/onlmonserver/OnlMonTrigSig.h
@@ -1,9 +1,6 @@
 #ifndef _ONL_MON_TRIG_SIG__H_
 #define _ONL_MON_TRIG_SIG__H_
 #include "OnlMonClient.h"
-class SQSpill;
-class SQEvent;
-class SQHitVector;
 
 class OnlMonTrigSig: public OnlMonClient {
   TH2* h2_bi_fpga;

--- a/online/onlmonserver/OnlMonV1495.cc
+++ b/online/onlmonserver/OnlMonV1495.cc
@@ -1,4 +1,4 @@
-/// OnlMonCham.C
+/// OnlMonV1495.C
 #include <iomanip>
 #include <TH1D.h>
 #include <interface_main/SQRun.h>
@@ -13,36 +13,40 @@
 #include <phool/PHIODataNode.h>
 #include <phool/getClass.h>
 #include <geom_svc/GeomSvc.h>
-//#include <chan_map/CalibParamInTimeTaiwan.h>
+//#include <chan_map/CalibParamInTimeV1495.h>
 #include "OnlMonServer.h"
-#include "OnlMonCham.h"
+#include "OnlMonV1495.h"
 #include "UtilHist.h"
 using namespace std;
 
-OnlMonCham::OnlMonCham(const ChamType_t type) : m_type(type)
+OnlMonV1495::OnlMonV1495(const HodoType_t type, const int lvl) : m_type(type), m_lvl(lvl)
 {
   NumCanvases(2);
+  m_n_pl = 2;
   switch (m_type) {
-  case D0 :  m_pl0 =  1;  Name("OnlMonChamD0" );  Title( "D0 Chamber");  break;
-  case D1 :  m_pl0 =  7;  Name("OnlMonChamD1" );  Title( "D1 Chamber");  break;
-  case D2 :  m_pl0 = 13;  Name("OnlMonChamD2" );  Title( "D2 Chamber");  break;
-  case D3p:  m_pl0 = 19;  Name("OnlMonChamD3p");  Title("D3p Chamber");  break;
-  case D3m:  m_pl0 = 25;  Name("OnlMonChamD3m");  Title("D3m Chamber");  break;
+  case H1X:  m_pl0 = 31;  Name("OnlMonV1495H1X" );  Title("H1X v1495" );  break;
+  case H2X:  m_pl0 = 37;  Name("OnlMonV1495H2X" );  Title("H2X v1495" );  break;
+  case H3X:  m_pl0 = 39;  Name("OnlMonV1495H3X" );  Title("H3X v1495" );  break;
+  case H4X:  m_pl0 = 45;  Name("OnlMonV1495H4X" );  Title("H4X v1495" );  break;
+  case H1Y:  m_pl0 = 33;  Name("OnlMonV1495H1Y" );  Title("H1Y v1495" );  break;
+  case H2Y:  m_pl0 = 35;  Name("OnlMonV1495H2Y" );  Title("H2Y v1495" );  break;
+  case H4Y1: m_pl0 = 41;  Name("OnlMonV1495H4Y1");  Title("H4Y1 v1495");  break;
+  case H4Y2: m_pl0 = 43;  Name("OnlMonV1495H4Y2");  Title("H4Y2 v1495");  break;
   }
 }
 
-int OnlMonCham::InitOnlMon(PHCompositeNode* topNode)
+int OnlMonV1495::InitOnlMon(PHCompositeNode* topNode)
 {
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-int OnlMonCham::InitRunOnlMon(PHCompositeNode* topNode)
+int OnlMonV1495::InitRunOnlMon(PHCompositeNode* topNode)
 {
   SQRun* run_header = findNode::getClass<SQRun>(topNode, "SQRun");
   if (!run_header) return Fun4AllReturnCodes::ABORTEVENT;
 
   GeomSvc* geom = GeomSvc::instance();
-  //CalibParamInTimeTaiwan calib;
+  //CalibParamInTimeV1495 calib;
   //calib.SetMapIDbyDB(run_header->get_run_id());
   //calib.ReadFromDB();
 
@@ -50,7 +54,7 @@ int OnlMonCham::InitRunOnlMon(PHCompositeNode* topNode)
   OnlMonServer::instance()->registerHistoManager(hm);
 
   ostringstream oss;
-  for (int pl = 0; pl < N_PL; pl++) {
+  for (int pl = 0; pl < m_n_pl; pl++) {
     string name = geom->getDetectorName(m_pl0 + pl);
     int n_ele = geom->getPlaneNElements(m_pl0 + pl); 
     oss.str("");
@@ -60,54 +64,63 @@ int OnlMonCham::InitRunOnlMon(PHCompositeNode* topNode)
     oss << name << ";Element ID;Hit count";
     h1_ele[pl]->SetTitle(oss.str().c_str());
 
-    const double DT = 20/9.0; // 4/9 ns per single count of Taiwan TDC
-    const int NT = 1000;
+    const double DT = 1.0; // 1 ns per single count of v1495 TDC
+    const int NT = 2000;
     const double T0 = 0.5*DT;
     const double T1 = (NT+0.5)*DT;
 
     //double center, width;
-    //calib.Find(m_pl0 + pl, 1, center, width);
+    //calib.Find(m_pl0 + pl, 1, m_lvl, center, width);
     oss.str("");
     oss << "h1_time_" << pl;
     h1_time[pl] = new TH1D(oss.str().c_str(), "", NT, T0, T1);
-    //h1_time[pl] = new TH1D(oss.str().c_str(), "", 100, center-width/2, center+width/2);
+    //h1_time[pl] = new TH1D(oss.str().c_str(), "", 100, center-2.5*width, center+2.5*width);
 
     oss.str("");
     oss << name << ";tdcTime;Hit count";
     h1_time[pl]->SetTitle(oss.str().c_str());
 
-    hm->registerHisto(h1_ele [pl]);
-    hm->registerHisto(h1_time[pl]);
+    oss.str("");
+    oss << "h1_time_in_" << pl;
+    h1_time_in[pl] = new TH1D(oss.str().c_str(), "", NT, T0, T1);
+    oss.str("");
+    oss << name << ";tdcTime;In-time hit count";
+    h1_time_in[pl]->SetTitle(oss.str().c_str());
+
+    hm->registerHisto(h1_ele    [pl]);
+    hm->registerHisto(h1_time   [pl]);
+    hm->registerHisto(h1_time_in[pl]);
   }
 
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-int OnlMonCham::ProcessEventOnlMon(PHCompositeNode* topNode)
+int OnlMonV1495::ProcessEventOnlMon(PHCompositeNode* topNode)
 {
   SQEvent*     event_header = findNode::getClass<SQEvent    >(topNode, "SQEvent");
-  SQHitVector*      hit_vec = findNode::getClass<SQHitVector>(topNode, "SQHitVector");
+  SQHitVector*      hit_vec = findNode::getClass<SQHitVector>(topNode, "SQTriggerHitVector");
   if (!event_header || !hit_vec) return Fun4AllReturnCodes::ABORTEVENT;
 
   for (SQHitVector::ConstIter it = hit_vec->begin(); it != hit_vec->end(); it++) {
     int pl = (*it)->get_detector_id() - m_pl0;
-    if (pl < 0 || pl >= N_PL) continue;
+    if (pl < 0 || pl >= m_n_pl || (*it)->get_level() != m_lvl) continue;
     h1_ele [pl]->Fill((*it)->get_element_id());
     h1_time[pl]->Fill((*it)->get_tdc_time  ());
+    if ((*it)->is_in_time()) h1_time_in[pl]->Fill((*it)->get_tdc_time());
   }
   
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-int OnlMonCham::EndOnlMon(PHCompositeNode* topNode)
+int OnlMonV1495::EndOnlMon(PHCompositeNode* topNode)
 {
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-int OnlMonCham::FindAllMonHist()
+int OnlMonV1495::FindAllMonHist()
 {
   ostringstream oss;
-  for (int pl = 0; pl < N_PL; pl++) {
+  for (int pl = 0; pl < m_n_pl; pl++) {
     oss.str("");
     oss << "h1_ele_" << pl;
     h1_ele[pl] = (TH1*)FindMonObj(oss.str().c_str());
@@ -116,17 +129,21 @@ int OnlMonCham::FindAllMonHist()
     oss << "h1_time_" << pl;
     h1_time[pl] = (TH1*)FindMonObj(oss.str().c_str());
     if (! h1_time[pl]) return 1;
+    oss.str("");
+    oss << "h1_time_in_" << pl;
+    h1_time_in[pl] = (TH1*)FindMonObj(oss.str().c_str());
+    if (! h1_time_in[pl]) return 1;
   }
   return 0;
 }
 
-int OnlMonCham::DrawMonitor()
+int OnlMonV1495::DrawMonitor()
 {
   OnlMonCanvas* can0 = GetCanvas(0);
   TPad* pad0 = can0->GetMainPad();
   pad0->SetGrid();
-  pad0->Divide(2, 3);
-  for (int pl = 0; pl < N_PL; pl++) {
+  pad0->Divide(1, 2);
+  for (int pl = 0; pl < m_n_pl; pl++) {
     pad0->cd(pl+1);
     //if (h1_ele[pl]->Integral() > 1000) gPad->SetLogy();
     h1_ele[pl]->Draw();
@@ -137,12 +154,15 @@ int OnlMonCham::DrawMonitor()
   OnlMonCanvas* can1 = GetCanvas(1);
   TPad* pad1 = can1->GetMainPad();
   pad1->SetGrid();
-  pad1->Divide(2, 3);
-  for (int pl = 0; pl < N_PL; pl++) {
+  pad1->Divide(1, 2);
+  for (int pl = 0; pl < m_n_pl; pl++) {
     pad1->cd(pl+1);
     //if (h1_time[pl]->Integral() > 1000) gPad->SetLogy();
     UtilHist::AutoSetRange(h1_time[pl]);
     h1_time[pl]->Draw();
+    h1_time_in[pl]->SetLineColor(kRed);
+    h1_time_in[pl]->SetFillColor(kRed-7);
+    h1_time_in[pl]->Draw("same");
   }
   can1->AddMessage("Always Okay ;^D");
   can1->SetStatus(OnlMonCanvas::OK);

--- a/online/onlmonserver/OnlMonV1495.cc
+++ b/online/onlmonserver/OnlMonV1495.cc
@@ -2,13 +2,9 @@
 #include <iomanip>
 #include <TH1D.h>
 #include <interface_main/SQRun.h>
-#include <interface_main/SQStringMap.h>
-#include <interface_main/SQScaler.h>
-#include <interface_main/SQSlowCont.h>
 #include <interface_main/SQEvent.h>
 #include <interface_main/SQHitVector.h>
 #include <fun4all/Fun4AllReturnCodes.h>
-#include <fun4all/Fun4AllHistoManager.h>
 #include <phool/PHNodeIterator.h>
 #include <phool/PHIODataNode.h>
 #include <phool/getClass.h>
@@ -49,9 +45,6 @@ int OnlMonV1495::InitRunOnlMon(PHCompositeNode* topNode)
   //CalibParamInTimeV1495 calib;
   //calib.SetMapIDbyDB(run_header->get_run_id());
   //calib.ReadFromDB();
-
-  Fun4AllHistoManager* hm = new Fun4AllHistoManager(Name());
-  OnlMonServer::instance()->registerHistoManager(hm);
 
   ostringstream oss;
   for (int pl = 0; pl < m_n_pl; pl++) {
@@ -94,10 +87,10 @@ int OnlMonV1495::InitRunOnlMon(PHCompositeNode* topNode)
     oss << name << ";tdcTime;In-time hit count";
     h1_time_in[pl]->SetTitle(oss.str().c_str());
 
-    hm->registerHisto(h1_ele    [pl]);
-    hm->registerHisto(h1_ele_in [pl]);
-    hm->registerHisto(h1_time   [pl]);
-    hm->registerHisto(h1_time_in[pl]);
+    RegisterHist(h1_ele    [pl]);
+    RegisterHist(h1_ele_in [pl]);
+    RegisterHist(h1_time   [pl]);
+    RegisterHist(h1_time_in[pl]);
   }
 
   return Fun4AllReturnCodes::EVENT_OK;

--- a/online/onlmonserver/OnlMonV1495.cc
+++ b/online/onlmonserver/OnlMonV1495.cc
@@ -64,6 +64,13 @@ int OnlMonV1495::InitRunOnlMon(PHCompositeNode* topNode)
     oss << name << ";Element ID;Hit count";
     h1_ele[pl]->SetTitle(oss.str().c_str());
 
+    oss.str("");
+    oss << "h1_ele_in_" << pl;
+    h1_ele_in[pl] = new TH1D(oss.str().c_str(), "", n_ele, 0.5, n_ele+0.5);
+    oss.str("");
+    oss << name << ";Element ID;In-time hit count";
+    h1_ele_in[pl]->SetTitle(oss.str().c_str());
+
     const double DT = 1.0; // 1 ns per single count of v1495 TDC
     const int NT = 2000;
     const double T0 = 0.5*DT;
@@ -88,6 +95,7 @@ int OnlMonV1495::InitRunOnlMon(PHCompositeNode* topNode)
     h1_time_in[pl]->SetTitle(oss.str().c_str());
 
     hm->registerHisto(h1_ele    [pl]);
+    hm->registerHisto(h1_ele_in [pl]);
     hm->registerHisto(h1_time   [pl]);
     hm->registerHisto(h1_time_in[pl]);
   }
@@ -106,7 +114,10 @@ int OnlMonV1495::ProcessEventOnlMon(PHCompositeNode* topNode)
     if (pl < 0 || pl >= m_n_pl || (*it)->get_level() != m_lvl) continue;
     h1_ele [pl]->Fill((*it)->get_element_id());
     h1_time[pl]->Fill((*it)->get_tdc_time  ());
-    if ((*it)->is_in_time()) h1_time_in[pl]->Fill((*it)->get_tdc_time());
+    if ((*it)->is_in_time()) {
+      h1_ele_in [pl]->Fill((*it)->get_element_id());
+      h1_time_in[pl]->Fill((*it)->get_tdc_time());
+    }
   }
   
   return Fun4AllReturnCodes::EVENT_OK;
@@ -125,6 +136,10 @@ int OnlMonV1495::FindAllMonHist()
     oss << "h1_ele_" << pl;
     h1_ele[pl] = (TH1*)FindMonObj(oss.str().c_str());
     if (! h1_ele[pl]) return 1;
+    oss.str("");
+    oss << "h1_ele_in_" << pl;
+    h1_ele_in[pl] = (TH1*)FindMonObj(oss.str().c_str());
+    if (! h1_ele_in[pl]) return 1;
     oss.str("");
     oss << "h1_time_" << pl;
     h1_time[pl] = (TH1*)FindMonObj(oss.str().c_str());
@@ -145,10 +160,13 @@ int OnlMonV1495::DrawMonitor()
   pad0->Divide(1, 2);
   for (int pl = 0; pl < m_n_pl; pl++) {
     pad0->cd(pl+1);
-    //if (h1_ele[pl]->Integral() > 1000) gPad->SetLogy();
+    h1_ele[pl]->SetLineColor(kBlack);
     h1_ele[pl]->Draw();
+    h1_ele_in[pl]->SetLineColor(kBlue);
+    h1_ele_in[pl]->SetFillColor(kBlue-7);
+    h1_ele_in[pl]->Draw("same");
   }
-  can0->AddMessage("Always Okay ;^D");
+  can0->AddMessage("OK");
   can0->SetStatus(OnlMonCanvas::OK);
 
   OnlMonCanvas* can1 = GetCanvas(1);
@@ -157,14 +175,14 @@ int OnlMonV1495::DrawMonitor()
   pad1->Divide(1, 2);
   for (int pl = 0; pl < m_n_pl; pl++) {
     pad1->cd(pl+1);
-    //if (h1_time[pl]->Integral() > 1000) gPad->SetLogy();
     UtilHist::AutoSetRange(h1_time[pl]);
+    h1_time[pl]->SetLineColor(kBlack);
     h1_time[pl]->Draw();
-    h1_time_in[pl]->SetLineColor(kRed);
-    h1_time_in[pl]->SetFillColor(kRed-7);
+    h1_time_in[pl]->SetLineColor(kBlue);
+    h1_time_in[pl]->SetFillColor(kBlue-7);
     h1_time_in[pl]->Draw("same");
   }
-  can1->AddMessage("Always Okay ;^D");
+  can1->AddMessage("OK");
   can1->SetStatus(OnlMonCanvas::OK);
 
   return 0;

--- a/online/onlmonserver/OnlMonV1495.h
+++ b/online/onlmonserver/OnlMonV1495.h
@@ -1,9 +1,6 @@
 #ifndef _ONL_MON_V1495__H_
 #define _ONL_MON_V1495__H_
 #include "OnlMonClient.h"
-class SQSpill;
-class SQEvent;
-class SQHitVector;
 
 class OnlMonV1495: public OnlMonClient {
  public:

--- a/online/onlmonserver/OnlMonV1495.h
+++ b/online/onlmonserver/OnlMonV1495.h
@@ -1,0 +1,33 @@
+#ifndef _ONL_MON_V1495__H_
+#define _ONL_MON_V1495__H_
+#include "OnlMonClient.h"
+class SQSpill;
+class SQEvent;
+class SQHitVector;
+
+class OnlMonV1495: public OnlMonClient {
+ public:
+  typedef enum { H1X, H2X, H3X, H4X, H1Y, H2Y, H4Y1, H4Y2 } HodoType_t;
+
+ private:
+  HodoType_t m_type;
+  int m_lvl;
+  int m_pl0;
+  int m_n_pl;
+  TH1* h1_ele    [99];
+  TH1* h1_time   [99];
+  TH1* h1_time_in[99];
+
+ public:
+  OnlMonV1495(const HodoType_t type, const int lvl);
+  virtual ~OnlMonV1495() {}
+
+  int InitOnlMon(PHCompositeNode *topNode);
+  int InitRunOnlMon(PHCompositeNode *topNode);
+  int ProcessEventOnlMon(PHCompositeNode *topNode);
+  int EndOnlMon(PHCompositeNode *topNode);
+  int FindAllMonHist();
+  int DrawMonitor();
+};
+
+#endif /* _ONL_MON_V1495__H_ */

--- a/online/onlmonserver/OnlMonV1495.h
+++ b/online/onlmonserver/OnlMonV1495.h
@@ -15,6 +15,7 @@ class OnlMonV1495: public OnlMonClient {
   int m_pl0;
   int m_n_pl;
   TH1* h1_ele    [99];
+  TH1* h1_ele_in [99];
   TH1* h1_time   [99];
   TH1* h1_time_in[99];
 

--- a/online/onlmonserver/UtilHist.cc
+++ b/online/onlmonserver/UtilHist.cc
@@ -1,0 +1,55 @@
+#include <iomanip>
+#include <TH1D.h>
+#include <TH2D.h>
+#include "UtilHist.h"
+using namespace std;
+
+void UtilHist::FindFilledRange(TH1* h1, int& bin_lo, int& bin_hi)
+{
+  if (h1->Integral() == 0) return;
+  int nn = h1->GetNbinsX();
+  bin_lo = 1;
+  while (h1->GetBinContent(bin_lo) == 0) bin_lo++;
+  bin_hi = nn;
+  while (h1->GetBinContent(bin_hi) == 0) bin_hi--;
+}
+
+void UtilHist::AutoSetRange(TH1* h1, const int margin_lo, const int margin_hi)
+{
+  int nn = h1->GetNbinsX();
+  int bin_lo, bin_hi;
+  FindFilledRange(h1, bin_lo, bin_hi);
+  bin_lo -= margin_lo;
+  bin_hi += margin_hi;
+  if (bin_lo <  1) bin_lo =  1;
+  if (bin_hi > nn) bin_hi = nn;
+  h1->GetXaxis()->SetRange(bin_lo, bin_hi);
+}
+
+void UtilHist::AutoSetRangeX(TH2* h2, const int margin_lo, const int margin_hi)
+{
+  TH1* h1 = h2->ProjectionX("h1_auto_set_range_x");
+  int nn = h1->GetNbinsX();
+  int bin_lo, bin_hi;
+  FindFilledRange(h1, bin_lo, bin_hi);
+  delete h1;
+  bin_lo -= margin_lo;
+  bin_hi += margin_hi;
+  if (bin_lo <  1) bin_lo =  1;
+  if (bin_hi > nn) bin_hi = nn;
+  h2->GetXaxis()->SetRange(bin_lo, bin_hi);
+}
+
+void UtilHist::AutoSetRangeY(TH2* h2, const int margin_lo, const int margin_hi)
+{
+  TH1* h1 = h2->ProjectionY("h1_auto_set_range_y");
+  int nn = h1->GetNbinsX();
+  int bin_lo, bin_hi;
+  FindFilledRange(h1, bin_lo, bin_hi);
+  delete h1;
+  bin_lo -= margin_lo;
+  bin_hi += margin_hi;
+  if (bin_lo <  1) bin_lo =  1;
+  if (bin_hi > nn) bin_hi = nn;
+  h2->GetYaxis()->SetRange(bin_lo, bin_hi);
+}

--- a/online/onlmonserver/UtilHist.h
+++ b/online/onlmonserver/UtilHist.h
@@ -1,0 +1,14 @@
+#ifndef _UTIL_HIST__H_
+#define _UTIL_HIST__H_
+class TH1;
+class TH2;
+class TH3;
+
+namespace UtilHist {
+  void FindFilledRange(TH1* h1, int& bin_lo, int& bin_hi);
+  void AutoSetRange (TH1* h1, const int margin_lo=5, const int margin_hi=5);
+  void AutoSetRangeX(TH2* h2, const int margin_lo=5, const int margin_hi=5);
+  void AutoSetRangeY(TH2* h2, const int margin_lo=5, const int margin_hi=5);
+};
+
+#endif /* _UTIL_HIST__H_ */

--- a/packages/jobopts_svc/JobOptsSvc.cxx
+++ b/packages/jobopts_svc/JobOptsSvc.cxx
@@ -96,7 +96,7 @@ JobOptsSvc::JobOptsSvc()
     m_fMagFile = "$GEOMETRY_ROOT/magnetic_fields/tab.Fmag";
     m_kMagFile = "$GEOMETRY_ROOT/magnetic_fields/tab.Kmag";
 
-    m_geomVersion = "geometry_G18_run3";
+    m_geomVersion = "geometry_G10_run5";
     m_mySQLInputServer  = "e906-db1.fnal.gov";
     m_mySQLOutputServer = "e906-db1.fnal.gov";
 }

--- a/setup-e1039-core.sh
+++ b/setup-e1039-core.sh
@@ -9,6 +9,15 @@ if [ $HOSTNAME = 'seaquestdaq01.fnal.gov' ] ; then
     export           CPATH=$MY_INSTALL/include:$CPATH
     export    LIBRARY_PATH=$MY_INSTALL/lib:$LIBRARY_PATH
     export LD_LIBRARY_PATH=$MY_INSTALL/lib:$LD_LIBRARY_PATH
+elif [ ${HOSTNAME:0:12} = 'seaquestgpvm' ] ; then
+    source /e906/app/users/yuhw/setup.sh
+    export OFFLINE_MAIN=$(dirname $DIR_E1039_CORE)/e1039-core-build/inst
+    export MY_INSTALL=$OFFLINE_MAIN
+
+    export            PATH=$MY_INSTALL/bin:$PATH
+    export           CPATH=$MY_INSTALL/include:$CPATH
+    export    LIBRARY_PATH=$MY_INSTALL/lib:$LIBRARY_PATH
+    export LD_LIBRARY_PATH=$MY_INSTALL/lib:$LD_LIBRARY_PATH
 else
     echo "Using the non-host-specific setting.  This might not work on your environment."
     export  CC=gcc-4.9


### PR DESCRIPTION
I added more OnlMonClient classes (for hodoscope, prop tube, v1495 TDC and trigger signal). While I checked the outputs of these new classes with run 27400, I updated many other files as well.  The front end of the online monitor is nearly ready for use now, although the back end should be improved further in terms of stable server-client connection and error handling.

The SQHit class was updated to hold the level info.

The default geometry schema in JobOptsSvc.cxx was changed to "geometry_G10_run5" so that D0 was taken into the mapping.

The CalibParamXT class, which stores the parameters for the X-T curve, was updated.  It now handles all parameters correctly (as far as I checked) including the detector name for the prop-tube X-T curve.

The looks of the plot viewer were improved.  A snapshot is attached.
![onlmon_example](https://user-images.githubusercontent.com/41366345/57916353-a39b3f00-78cd-11e9-93f6-2b41a94845ce.png)
