### PR TITLE
Bring back the HepMC input manager

### DIFF
--- a/generators/phhepmc/CMakeLists.txt
+++ b/generators/phhepmc/CMakeLists.txt
@@ -49,8 +49,14 @@ execute_process(COMMAND root-config --evelibs   OUTPUT_VARIABLE ROOT_LINK    OUT
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${ROOT_CFLAGS} -std=c++0x ")
 
 add_library(phhepmc SHARED
+  ${PROJECT_SOURCE_DIR}/Fun4AllHepMCInputManager.cc
+  ${PROJECT_SOURCE_DIR}/Fun4AllHepMCOutputManager.cc
+  #${PROJECT_SOURCE_DIR}/Fun4AllOscarInputManager.cc
   ${PROJECT_SOURCE_DIR}/PHHepMCGenHelper.cc
   ${PROJECT_SOURCE_DIR}/PHHepMCParticleSelectorDecayProductChain.cc
+  Fun4AllHepMCInputManager_Dict.C
+  Fun4AllHepMCOutputManager_Dict.C
+  #Fun4AllOscarInputManager_Dict.C
   PHHepMCGenHelper_Dict.C
   PHHepMCParticleSelectorDecayProductChain_Dict.C
 )
@@ -78,6 +84,9 @@ install(TARGETS phhepmc     DESTINATION ${CMAKE_INSTALL_PREFIX}/lib)
 message(${CMAKE_PROJECT_NAME} " will be installed to " ${CMAKE_INSTALL_PREFIX})
 
 file(GLOB dist_headers
+  Fun4AllHepMCInputManager.h
+  Fun4AllHepMCOutputManager.h
+  #Fun4AllOscarInputManager.h
   PHGenEvent.h
   PHGenEventv1.h
   PHGenEventList.h

--- a/generators/phhepmc/Fun4AllHepMCInputManager.cc
+++ b/generators/phhepmc/Fun4AllHepMCInputManager.cc
@@ -1,4 +1,6 @@
 #include "Fun4AllHepMCInputManager.h"
+#include "PHHepMCGenEvent.h"
+#include "PHHepMCGenEventMap.h"
 
 #include <fun4all/Fun4AllReturnCodes.h>
 #include <fun4all/Fun4AllServer.h>
@@ -6,11 +8,9 @@
 #include <phool/getClass.h>
 #include <phool/recoConsts.h>
 
-#include <PHHepMCGenEvent.h>
-#include <PHHepMCGenEventMap.h>
 #include <ffaobjects/RunHeader.h>
 
-#include <frog/FROG.h>
+//#include <frog/FROG.h>
 #include <phool/PHCompositeNode.h>
 #include <phool/PHDataNode.h>
 
@@ -97,8 +97,9 @@ int Fun4AllHepMCInputManager::fileopen(const string &filenam)
     fileclose();
   }
   filename = filenam;
-  FROG frog;
-  string fname(frog.location(filename.c_str()));
+  //FROG frog;
+  //string fname(frog.location(filename.c_str()));
+  string fname(filename);
   if (verbosity > 0)
   {
     cout << ThisName << ": opening file " << fname << endl;


### PR DESCRIPTION
Removed FROG for now. Full path needed for the input.

[e1039-analysis/SimChainDev/Fun4Sim.C](https://github.com/E1039-Collaboration/e1039-analysis/blob/master/SimChainDev/Fun4Sim.C#L225) updated and tested for the HepMC input/output manager.

An example txt file with 10 DY HepMC events:
/pnfs/e906/persistent/users/yuhw/examples/HepMC_txt/hepmcout.txt