### PR TITLE
Init PatternDBGen; Sim. compatible with run6 config

### DIFF
--- a/module_example/TrkEval.cxx
+++ b/module_example/TrkEval.cxx
@@ -123,11 +123,14 @@ int TrkEval::RecoEval(PHCompositeNode* topNode)
     run_id      = _event_header->get_run_id();
   }
 
-  PHG4HitContainer *C1X_hits = findNode::getClass<PHG4HitContainer>(topNode, "G4HIT_D1X");
-  if (!C1X_hits)
+  PHG4HitContainer *D1X_hits = findNode::getClass<PHG4HitContainer>(topNode, "G4HIT_D0X");
+  if (!D1X_hits)
+    D1X_hits = findNode::getClass<PHG4HitContainer>(topNode, "G4HIT_D1X");
+
+  if (!D1X_hits)
   {
-    cout << Name() << " Could not locate g4 hit node " << "G4HIT_D1X" << endl;
-    return Fun4AllReturnCodes::ABORTRUN;
+    if(Verbosity() >= Fun4AllBase::VERBOSITY_A_LOT)
+        cout << Name() << " Could not locate g4 hit node " << "G4HIT_D0X or G4HIT_D1X" << endl;
   }
 
 	std::map<int, int> parID_nhits_dc;
@@ -346,8 +349,8 @@ int TrkEval::RecoEval(PHCompositeNode* topNode)
 					if(verbosity >= Fun4AllBase::VERBOSITY_A_LOT) {
 						hit->identify();
 					}
-					if(hit) {
-						PHG4Hit* g4hit =  C1X_hits->findHit(hit->get_g4hit_id());
+					if(hit and D1X_hits) {
+						PHG4Hit* g4hit =  D1X_hits->findHit(hit->get_g4hit_id());
 						if (g4hit) {
 							if(verbosity >= 2) {
 								g4hit->identify();
@@ -411,11 +414,14 @@ int TrkEval::TruthEval(PHCompositeNode* topNode)
     run_id      = _event_header->get_run_id();
   }
 
-  PHG4HitContainer *C1X_hits = findNode::getClass<PHG4HitContainer>(topNode, "G4HIT_D1X");
-  if (!C1X_hits)
+  PHG4HitContainer *D1X_hits = findNode::getClass<PHG4HitContainer>(topNode, "G4HIT_D0X");
+  if (!D1X_hits)
+    D1X_hits = findNode::getClass<PHG4HitContainer>(topNode, "G4HIT_D1X");
+
+  if (!D1X_hits)
   {
-    cout << Name() << " Could not locate g4 hit node " << "G4HIT_D1X" << endl;
-    return Fun4AllReturnCodes::ABORTRUN;
+    if(Verbosity() >= Fun4AllBase::VERBOSITY_A_LOT)
+        cout << Name() << " Could not locate g4 hit node " << "G4HIT_D0X or G4HIT_D1X" << endl;
   }
 
 	std::map<int, int> parID_nhits_dc;
@@ -643,8 +649,8 @@ int TrkEval::TruthEval(PHCompositeNode* topNode)
 					if(verbosity >= 2) {
 						hit->identify();
 					}
-  				if(hit) {
-  					PHG4Hit* g4hit =  C1X_hits->findHit(hit->get_g4hit_id());
+					if(hit and D1X_hits) {
+  					PHG4Hit* g4hit =  D1X_hits->findHit(hit->get_g4hit_id());
   					if (g4hit) {
   						if(verbosity >= 2) {
   							g4hit->identify();

--- a/packages/ktracker/KalmanDSTrk.cxx
+++ b/packages/ktracker/KalmanDSTrk.cxx
@@ -103,7 +103,7 @@ KalmanDSTrk::KalmanDSTrk(
 				std::cout <<"KalmanDSTrk::KalmanDSTrk: DB NOT loaded. Try to build. " << std::endl;
 				_timers["build_db"]->restart();
         _pattern_db = new PatternDB();
-				PatternDBUtil::BuildPatternDB("pattern_db.root", "PatternDB_bad.root", *_pattern_db);
+				PatternDBUtil::BuildPatternDB("pattern_db.root", "PatternDB_tmp.root", *_pattern_db);
 				_timers["build_db"]->stop();
 				_timers["load_db"]->restart();
 				//_pattern_db = PatternDBUtil::LoadPatternDB("PatternDB.root");

--- a/packages/ktracker/KalmanFastTrackingWrapper.cxx
+++ b/packages/ktracker/KalmanFastTrackingWrapper.cxx
@@ -238,7 +238,7 @@ SRawEvent* KalmanFastTrackingWrapper::BuildSRawEvent() {
       h.detectorID = sq_hit->get_detector_id();
       h.elementID = sq_hit->get_element_id();
       h.tdcTime = sq_hit->get_tdc_time();
-      h.driftDistance = 0;
+      h.driftDistance = fabs(sq_hit->get_drift_distance()); //MC L-R info removed here
       h.pos = sq_hit->get_pos();
 
       if(sq_hit->is_in_time()) h.setInTime();

--- a/packages/ktracker/PatternDBGen.cxx
+++ b/packages/ktracker/PatternDBGen.cxx
@@ -1,0 +1,372 @@
+/**
+ * \class PatternDBGen
+ * \brief General purposed evaluation module
+ * \author Haiwang Yu, yuhw@nmsu.edu
+ *
+ * Created: 08-27-2018
+ */
+
+
+#include "PatternDBGen.h"
+
+#include <interface_main/SQHit.h>
+#include <interface_main/SQHit_v1.h>
+#include <interface_main/SQMCHit_v1.h>
+#include <interface_main/SQHitMap_v1.h>
+#include <interface_main/SQHitVector_v1.h>
+#include <interface_main/SQEvent_v1.h>
+#include <interface_main/SQRun_v1.h>
+#include <interface_main/SQSpill_v1.h>
+#include <interface_main/SQSpillMap_v1.h>
+
+#include <ktracker/SRecEvent.h>
+
+#include <geom_svc/GeomSvc.h>
+
+#include <fun4all/Fun4AllReturnCodes.h>
+#include <fun4all/PHTFileServer.h>
+#include <phool/PHNodeIterator.h>
+#include <phool/PHIODataNode.h>
+#include <phool/getClass.h>
+
+#include <g4main/PHG4TruthInfoContainer.h>
+#include <g4main/PHG4HitContainer.h>
+#include <g4main/PHG4Hit.h>
+#include <g4main/PHG4Particle.h>
+#include <g4main/PHG4HitDefs.h>
+#include <g4main/PHG4VtxPoint.h>
+
+#include <TFile.h>
+#include <TTree.h>
+
+#include <cstring>
+#include <cmath>
+#include <cfloat>
+#include <stdexcept>
+#include <limits>
+#include <tuple>
+
+#include <boost/lexical_cast.hpp>
+
+#define LogDebug(exp)   std::cout<<"DEBUG: "  <<__FILE__<<": "<<__LINE__<<": "<< exp << std::endl
+#define LogError(exp)   std::cout<<"ERROR: "  <<__FILE__<<": "<<__LINE__<<": "<< exp << std::endl
+#define LogWarning(exp)     std::cout<<"WARNING: "<<__FILE__<<": "<<__LINE__<<": "<< exp << std::endl
+
+using namespace std;
+
+PatternDBGen::PatternDBGen(const std::string& name) :
+SubsysReco(name),
+_hit_container_type("Vector"),
+_event(0),
+_event_header(nullptr),
+_hit_map(nullptr),
+_hit_vector(nullptr),
+_out_name("pattern_db.root")
+{
+}
+
+int PatternDBGen::Init(PHCompositeNode* topNode) {
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int PatternDBGen::InitRun(PHCompositeNode* topNode) {
+
+  ResetEvalVars();
+  InitEvalTree();
+
+  p_geomSvc = GeomSvc::instance();
+
+  int ret = GetNodes(topNode);
+  if(ret != Fun4AllReturnCodes::EVENT_OK) return ret;
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int PatternDBGen::process_event(PHCompositeNode* topNode) {
+  int ret = Fun4AllReturnCodes::ABORTRUN;
+
+  ret = TruthEval(topNode);
+  if (ret != Fun4AllReturnCodes::EVENT_OK) return ret;
+
+  ++_event;
+
+  return ret;
+}
+
+int PatternDBGen::TruthEval(PHCompositeNode* topNode)
+{
+  if(Verbosity() >= Fun4AllBase::VERBOSITY_A_LOT)
+    std::cout << "Entering PatternDBGen::TruthEval: " << _event << std::endl;
+
+  PHG4HitContainer *D1X_hits = findNode::getClass<PHG4HitContainer>(topNode, "G4HIT_D1X");
+  if (!D1X_hits)
+  {
+    cout << Name() << " Could not locate g4 hit node " << "G4HIT_D1X" << endl;
+    return Fun4AllReturnCodes::ABORTRUN;
+  }
+
+  ResetEvalVars();
+
+  std::map<int, int> parID_nhits_dc;
+  std::map<int, int> parID_nhits_hodo;
+  std::map<int, int> parID_nhits_prop;
+
+  std::map<int, std::map<int, int> > parID_detid_elmid;
+
+  typedef std::tuple<int, int> ParDetPair;
+  std::map<ParDetPair, int> parID_detID_ihit;
+
+  std::map<int, int> hitID_ihit;
+
+  if(_hit_vector) {
+    for(int ihit=0; ihit<_hit_vector->size(); ++ihit) {
+      SQHit *hit = _hit_vector->at(ihit);
+
+      if(Verbosity() >= Fun4AllBase::VERBOSITY_A_LOT) {
+        LogInfo(hit->get_detector_id());
+        hit->identify();
+      }
+
+      if(_truth) {
+        int track_id = hit->get_track_id();
+        int det_id = hit->get_detector_id();
+        parID_detID_ihit[std::make_tuple(track_id, det_id)] = ihit;
+
+        auto detid_elmid_iter = parID_detid_elmid.find(track_id);
+        if(detid_elmid_iter != parID_detid_elmid.end()) {
+          detid_elmid_iter->second.insert(std::pair<int, int>(det_id, hit->get_element_id()));
+        } else {
+          std::map<int, int> detid_elmid;
+          detid_elmid.insert(std::pair<int, int>(det_id, hit->get_element_id()));
+          parID_detid_elmid[track_id] = detid_elmid;
+        }
+
+        if(hit->get_detector_id() >= 1 and hit->get_detector_id() <=30) {
+          if(parID_nhits_dc.find(track_id)!=parID_nhits_dc.end())
+            parID_nhits_dc[track_id] = parID_nhits_dc[track_id]+1;
+          else
+            parID_nhits_dc[track_id] = 1;
+        }
+        if(hit->get_detector_id() >= 31 and hit->get_detector_id() <=46) {
+          if(parID_nhits_hodo.find(track_id)!=parID_nhits_hodo.end())
+            parID_nhits_hodo[track_id] = parID_nhits_hodo[track_id]+1;
+          else
+            parID_nhits_hodo[track_id] = 1;
+        }
+        if(hit->get_detector_id() >= 47 and hit->get_detector_id() <=54) {
+          if(parID_nhits_prop.find(track_id)!=parID_nhits_prop.end())
+            parID_nhits_prop[track_id] = parID_nhits_prop[track_id]+1;
+          else
+            parID_nhits_prop[track_id] = 1;
+        }
+      }
+    }
+  }
+
+  if(Verbosity() >= Fun4AllBase::VERBOSITY_A_LOT) LogInfo("ghit eval finished");
+
+  n_tracks = 0;
+  if(_truth) {
+    for(auto iter=_truth->GetPrimaryParticleRange().first;
+        iter!=_truth->GetPrimaryParticleRange().second;
+        ++iter) {
+      PHG4Particle * par = iter->second;
+
+      pid[n_tracks] = par->get_pid();
+
+      int vtx_id =  par->get_vtx_id();
+      PHG4VtxPoint* vtx = _truth->GetVtx(vtx_id);
+      gvx[n_tracks] = vtx->get_x();
+      gvy[n_tracks] = vtx->get_y();
+      gvz[n_tracks] = vtx->get_z();
+
+      TVector3 mom(par->get_px(), par->get_py(), par->get_pz());
+      gpx[n_tracks] = par->get_px();
+      gpy[n_tracks] = par->get_py();
+      gpz[n_tracks] = par->get_pz();
+      gpt[n_tracks] = mom.Pt();
+      geta[n_tracks] = mom.Eta();
+      gphi[n_tracks] = mom.Phi();
+
+      int parID = par->get_track_id();
+
+      // Get truth track par at station 1
+      // trackID + detID -> SQHit -> PHG4Hit -> momentum
+      for(int det_id=7; det_id<=12; ++det_id) {
+        auto iter = parID_detID_ihit.find(std::make_tuple(parID, det_id));
+        if(iter != parID_detID_ihit.end()) {
+          if(verbosity >= 2) {
+            LogDebug("ihit: " << iter->second);
+          }
+          SQHit *hit = _hit_vector->at(iter->second);
+          if(verbosity >= 2) {
+            hit->identify();
+          }
+          if(hit) {
+            PHG4Hit* g4hit =  D1X_hits->findHit(hit->get_g4hit_id());
+            if (g4hit) {
+              if(verbosity >= 2) {
+                g4hit->identify();
+              }
+              gx_st1[n_tracks]  = g4hit->get_x(0);
+              gy_st1[n_tracks]  = g4hit->get_y(0);
+              gz_st1[n_tracks]  = g4hit->get_z(0);
+
+              gpx_st1[n_tracks] = g4hit->get_px(0)/1000.;
+              gpy_st1[n_tracks] = g4hit->get_py(0)/1000.;
+              gpz_st1[n_tracks] = g4hit->get_pz(0)/1000.;
+              break;
+            }
+          }
+        }
+      }
+
+      gnhits[n_tracks] =
+          parID_nhits_dc[parID] +
+          parID_nhits_hodo[parID] +
+          parID_nhits_prop[parID];
+
+      gndc[n_tracks] = parID_nhits_dc[parID];
+      gnhodo[n_tracks] = parID_nhits_hodo[parID];
+      gnprop[n_tracks] = parID_nhits_prop[parID];
+
+      for(auto detid_elmid : parID_detid_elmid[parID]) {
+        int detid = detid_elmid.first;
+        int elmid = detid_elmid.second;
+        if(detid>=55) {
+          LogWarning("detid>=55");
+          continue;
+        }
+        gelmid[n_tracks][detid] = elmid;
+      }
+
+      if(Verbosity() >= Fun4AllBase::VERBOSITY_A_LOT) LogInfo("particle eval finished");
+
+      ++n_tracks;
+      if(n_tracks>=1000) break;
+    }
+  }
+
+  _tout_truth->Fill();
+
+  if(Verbosity() >= Fun4AllBase::VERBOSITY_A_LOT)
+    std::cout << "Leaving PatternDBGen::TruthEval: " << _event << std::endl;
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int PatternDBGen::End(PHCompositeNode* topNode) {
+  if(Verbosity() >= Fun4AllBase::VERBOSITY_A_LOT)
+    std::cout << "PatternDBGen::End" << std::endl;
+
+  PHTFileServer::get().cd(_out_name.c_str());
+  _tout_truth->Write();
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int PatternDBGen::InitEvalTree() {
+  PHTFileServer::get().open(_out_name.c_str(), "RECREATE");
+
+  _tout_truth = new TTree("T", "Truth Eval");
+//  _tout_truth->Branch("runID",         &run_id,          "runID/I");
+//  _tout_truth->Branch("spillID",       &spill_id,        "spillID/I");
+//  _tout_truth->Branch("liveProton",    &target_pos,      "liveProton/F");
+//  _tout_truth->Branch("eventID",       &event_id,        "eventID/I");
+//
+  _tout_truth->Branch("n_tracks",      &n_tracks,           "n_tracks/I");
+  _tout_truth->Branch("pid",           pid,                 "pid[n_tracks]/I");
+//  _tout_truth->Branch("gvx",           gvx,                 "gvx[n_tracks]/F");
+//  _tout_truth->Branch("gvy",           gvy,                 "gvy[n_tracks]/F");
+//  _tout_truth->Branch("gvz",           gvz,                 "gvz[n_tracks]/F");
+//  _tout_truth->Branch("gpx",           gpx,                 "gpx[n_tracks]/F");
+//  _tout_truth->Branch("gpy",           gpy,                 "gpy[n_tracks]/F");
+//  _tout_truth->Branch("gpz",           gpz,                 "gpz[n_tracks]/F");
+//  _tout_truth->Branch("gpt",           gpt,                 "gpt[n_tracks]/F");
+//  _tout_truth->Branch("geta",          geta,                "geta[n_tracks]/F");
+//  _tout_truth->Branch("gphi",          gphi,                "gphi[n_tracks]/F");
+//  _tout_truth->Branch("gx_st1",        gx_st1,              "gx_st1[n_tracks]/F");
+//  _tout_truth->Branch("gy_st1",        gy_st1,              "gy_st1[n_tracks]/F");
+//  _tout_truth->Branch("gz_st1",        gz_st1,              "gz_st1[n_tracks]/F");
+//  _tout_truth->Branch("gpx_st1",       gpx_st1,             "gpx_st1[n_tracks]/F");
+//  _tout_truth->Branch("gpy_st1",       gpy_st1,             "gpy_st1[n_tracks]/F");
+//  _tout_truth->Branch("gpz_st1",       gpz_st1,             "gpz_st1[n_tracks]/F");
+//  _tout_truth->Branch("gnhits",        gnhits,              "gnhits[n_tracks]/I");
+  _tout_truth->Branch("gndc",          gndc,                "gndc[n_tracks]/I");
+//  _tout_truth->Branch("gnhodo",        gnhodo,              "gnhodo[n_tracks]/I");
+//  _tout_truth->Branch("gnprop",        gnprop,              "gnprop[n_tracks]/I");
+  _tout_truth->Branch("gelmid",        gelmid,              "gelmid[n_tracks][54]/I");
+
+  return 0;
+}
+
+int PatternDBGen::ResetEvalVars() {
+  run_id = std::numeric_limits<int>::max();
+  spill_id = std::numeric_limits<int>::max();
+  target_pos = std::numeric_limits<float>::max();
+  event_id = std::numeric_limits<int>::max();
+
+  n_tracks = 0;
+  for(int i=0; i<1000; ++i) {
+    pid[i]        = std::numeric_limits<int>::max();
+    gvx[i]        = std::numeric_limits<float>::max();
+    gvy[i]        = std::numeric_limits<float>::max();
+    gvz[i]        = std::numeric_limits<float>::max();
+    gpx[i]        = std::numeric_limits<float>::max();
+    gpy[i]        = std::numeric_limits<float>::max();
+    gpz[i]        = std::numeric_limits<float>::max();
+    gpt[i]        = std::numeric_limits<float>::max();
+    geta[i]       = std::numeric_limits<float>::max();
+    gphi[i]       = std::numeric_limits<float>::max();
+    gnhits[i]     = std::numeric_limits<int>::max();
+    gx_st1[i]     = std::numeric_limits<float>::max();
+    gy_st1[i]     = std::numeric_limits<float>::max();
+    gz_st1[i]     = std::numeric_limits<float>::max();
+    gpx_st1[i]    = std::numeric_limits<float>::max();
+    gpy_st1[i]    = std::numeric_limits<float>::max();
+    gpz_st1[i]    = std::numeric_limits<float>::max();
+    gndc[i]       = std::numeric_limits<int>::max();
+    gnhodo[i]     = std::numeric_limits<int>::max();
+    gnprop[i]     = std::numeric_limits<int>::max();
+
+    for(int j=0; j<55; ++j) {
+      gelmid[i][j] = std::numeric_limits<int>::max();
+    }
+  }
+
+  return 0;
+}
+
+int PatternDBGen::GetNodes(PHCompositeNode* topNode) {
+
+  if(_hit_container_type.find("Map") != std::string::npos) {
+    _hit_map = findNode::getClass<SQHitMap>(topNode, "SQHitMap");
+    if (!_hit_map) {
+      LogError("!_hit_map");
+      return Fun4AllReturnCodes::ABORTEVENT;
+    }
+  }
+
+  if(_hit_container_type.find("Vector") != std::string::npos) {
+    _hit_vector = findNode::getClass<SQHitVector>(topNode, "SQHitVector");
+    if (!_hit_vector) {
+      LogError("!_hit_vector");
+      return Fun4AllReturnCodes::ABORTEVENT;
+    }
+  }
+
+  _truth = findNode::getClass<PHG4TruthInfoContainer>(topNode, "G4TruthInfo");
+  if (!_truth) {
+    LogError("!_truth");
+    return Fun4AllReturnCodes::ABORTEVENT;
+  }
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+
+
+
+
+
+

--- a/packages/ktracker/PatternDBGen.cxx
+++ b/packages/ktracker/PatternDBGen.cxx
@@ -298,7 +298,7 @@ int PatternDBGen::InitEvalTree() {
   _tout_truth->Branch("gndc",          gndc,                "gndc[n_tracks]/I");
 //  _tout_truth->Branch("gnhodo",        gnhodo,              "gnhodo[n_tracks]/I");
 //  _tout_truth->Branch("gnprop",        gnprop,              "gnprop[n_tracks]/I");
-  _tout_truth->Branch("gelmid",        gelmid,              "gelmid[n_tracks][54]/I");
+  _tout_truth->Branch("gelmid",        gelmid,              "gelmid[n_tracks][55]/I");
 
   return 0;
 }

--- a/packages/ktracker/PatternDBGen.cxx
+++ b/packages/ktracker/PatternDBGen.cxx
@@ -98,11 +98,14 @@ int PatternDBGen::TruthEval(PHCompositeNode* topNode)
   if(Verbosity() >= Fun4AllBase::VERBOSITY_A_LOT)
     std::cout << "Entering PatternDBGen::TruthEval: " << _event << std::endl;
 
-  PHG4HitContainer *D1X_hits = findNode::getClass<PHG4HitContainer>(topNode, "G4HIT_D1X");
+  PHG4HitContainer *D1X_hits = findNode::getClass<PHG4HitContainer>(topNode, "G4HIT_D0X");
+  if (!D1X_hits)
+    D1X_hits = findNode::getClass<PHG4HitContainer>(topNode, "G4HIT_D1X");
+
   if (!D1X_hits)
   {
-    cout << Name() << " Could not locate g4 hit node " << "G4HIT_D1X" << endl;
-    return Fun4AllReturnCodes::ABORTRUN;
+    if(Verbosity() >= Fun4AllBase::VERBOSITY_A_LOT)
+        cout << Name() << " Could not locate g4 hit node " << "G4HIT_D0X or G4HIT_D1X" << endl;
   }
 
   ResetEvalVars();
@@ -202,7 +205,7 @@ int PatternDBGen::TruthEval(PHCompositeNode* topNode)
           if(verbosity >= 2) {
             hit->identify();
           }
-          if(hit) {
+          if(hit and D1X_hits) {
             PHG4Hit* g4hit =  D1X_hits->findHit(hit->get_g4hit_id());
             if (g4hit) {
               if(verbosity >= 2) {

--- a/packages/ktracker/PatternDBGen.h
+++ b/packages/ktracker/PatternDBGen.h
@@ -1,0 +1,130 @@
+/**
+ * \class PatternDBGen
+ * \brief General purposed evaluation module
+ * \author Haiwang Yu, yuhw@nmsu.edu
+ *
+ * Created: 08-27-2018
+ */
+
+#ifndef _H_PatternDBGen_H_
+#define _H_PatternDBGen_H_
+
+// ROOT
+#include <TSQLServer.h>
+#include <TSQLResult.h>
+#include <TSQLRow.h>
+
+// Fun4All includes
+#include <fun4all/SubsysReco.h>
+
+// STL includes
+#include <vector>
+#include <string>
+#include <iostream>
+#include <list>
+#include <map>
+//#include <algorithm>
+
+class SQRun;
+class SQSpillMap;
+
+class SQEvent;
+class SQHitMap;
+class SQHitVector;
+
+class PHG4TruthInfoContainer;
+
+class SRecEvent;
+
+class GeomSvc;
+
+class TFile;
+class TTree;
+
+class PatternDBGen: public SubsysReco {
+
+public:
+
+  PatternDBGen(const std::string &name = "PatternDBGen");
+  virtual ~PatternDBGen() {
+  }
+
+  int Init(PHCompositeNode *topNode);
+  int InitRun(PHCompositeNode *topNode);
+  int process_event(PHCompositeNode *topNode);
+  int End(PHCompositeNode *topNode);
+
+  int InitEvalTree();
+  int ResetEvalVars();
+
+  const std::string& get_hit_container_choice() const {
+    return _hit_container_type;
+  }
+
+  void set_hit_container_choice(const std::string& hitContainerChoice) {
+    _hit_container_type = hitContainerChoice;
+  }
+
+  const std::string& get_out_name() const {
+    return _out_name;
+  }
+
+  void set_out_name(const std::string& outName) {
+    _out_name = outName;
+  }
+
+private:
+
+  int GetNodes(PHCompositeNode *topNode);
+
+  int TruthEval(PHCompositeNode *topNode);
+
+  std::string _hit_container_type;
+
+  size_t _event;
+
+  SQEvent * _event_header;
+  SQHitMap *_hit_map;
+  SQHitVector *_hit_vector;
+
+  PHG4TruthInfoContainer* _truth;
+
+  SRecEvent* _recEvent;
+
+  std::string _out_name;
+  TTree* _tout_truth;
+
+  int run_id;
+  int spill_id;
+  float target_pos;
+  int event_id;
+
+  int n_tracks;
+  int pid[1000];
+  float gvx[1000];
+  float gvy[1000];
+  float gvz[1000];
+  float gpx[1000];
+  float gpy[1000];
+  float gpz[1000];
+  float gx_st1[1000];
+  float gy_st1[1000];
+  float gz_st1[1000];
+  float gpx_st1[1000];
+  float gpy_st1[1000];
+  float gpz_st1[1000];
+  float gpt[1000];
+  float geta[1000];
+  float gphi[1000];
+  int gnhits[1000];
+  int gndc[1000];
+  int gnhodo[1000];
+  int gnprop[1000];
+
+  int gelmid[1000][55];
+
+  GeomSvc *p_geomSvc;
+};
+
+
+#endif /* _H_PatternDBGen_H_ */

--- a/packages/ktracker/PatternDBGenLinkDef.h
+++ b/packages/ktracker/PatternDBGenLinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class PatternDBGen-!;
+
+#endif /* __CINT__ */

--- a/packages/ktracker/PatternDBUtil.cxx
+++ b/packages/ktracker/PatternDBUtil.cxx
@@ -125,13 +125,22 @@ int PatternDBUtil::BuildPatternDB(const std::string &fin, const std::string & fo
 
 			if(!(gndc[ipar]>17)) continue;
 
+#define _D1_1_6_
+#ifdef _D1_1_6_
+      unsigned int D1U  = elmid[ipar][1];
+      unsigned int D1Up = elmid[ipar][2];
+      unsigned int D1X  = elmid[ipar][3];
+      unsigned int D1Xp = elmid[ipar][4];
+      unsigned int D1V  = elmid[ipar][5];
+      unsigned int D1Vp = elmid[ipar][6];
+#else
 			unsigned int D1V  = elmid[ipar][7];
 			unsigned int D1Vp = elmid[ipar][8];
 			unsigned int D1X  = elmid[ipar][9];
 			unsigned int D1Xp = elmid[ipar][10];
 			unsigned int D1U  = elmid[ipar][11];
 			unsigned int D1Up = elmid[ipar][12];
-
+#endif
 			unsigned int D2V  = elmid[ipar][13];
 			unsigned int D2Vp = elmid[ipar][14];
 			unsigned int D2Xp = elmid[ipar][15];

--- a/packages/ktracker/PatternDBUtil.cxx
+++ b/packages/ktracker/PatternDBUtil.cxx
@@ -89,7 +89,7 @@ int PatternDBUtil::BuildPatternDB(const std::string &fin, const std::string & fo
 		return -1;
 	}
 
-	TTree *T = (TTree*) f_in->Get("Truth");
+	TTree *T = (TTree*) f_in->Get("T");
 	if(!T) {
 		LogInfo("TTree T not found in " << fin);
 		return -1;

--- a/simulation/g4detectors/DPDigitizer.cc
+++ b/simulation/g4detectors/DPDigitizer.cc
@@ -488,6 +488,13 @@ int DPDigitizer::Init(PHCompositeNode *topNode)
     }
   };
 
+  if(Verbosity() > Fun4AllBase::VERBOSITY_A_LOT) {
+    for(int i=1; i<55; ++i) {
+      std::cout << p_geomSvc->getPlane(i) << std::endl;
+      std::cout << digiPlanes[i] << std::endl;
+    }
+  }
+
   return Fun4AllReturnCodes::EVENT_OK;
 }
 #endif
@@ -701,8 +708,9 @@ int DPDigitizer::process_event(PHCompositeNode* topNode) {
     PHG4HitContainer *hits = findNode::getClass<PHG4HitContainer>(topNode, hitnodename.c_str());
     if (!hits)
     {
-      cout << Name() << " Could not locate g4 hit node " << hitnodename << endl;
-      exit(1);
+      if(Verbosity() > Fun4AllBase::VERBOSITY_A_LOT)
+        cout << Name() << " Could not locate g4 hit node " << hitnodename << endl;
+      continue;
     }
 
     if(Verbosity() > 2) {


### PR DESCRIPTION
Init PatternDBGen for dedicated DSearch tracking database simulation.

Updated GeomSvc and related modules to make the simulation compatible with run6 configuration (`$E1039_RESOURCE/alignment/run6`) and @liuk 's geometry schema `user_liuk_geometry_G9_run5_2`

**Seems this schema used detector id 7-12 for the DP trigger planes.
So DC1 shifted to use 1-6. This may won't be the case in the future.**

[e1039/analysis/CODAChainDev](https://github.com/E1039-Collaboration/e1039-analysis/tree/master/CODAChainDev) and [e1039/analysis/SimChainDev](https://github.com/E1039-Collaboration/e1039-analysis/tree/master/SimChainDev) updated accordingly.

