### PR TITLE
Event display update; event filter

### DIFF
--- a/packages/Display/interface/PHEventDisplay.h
+++ b/packages/Display/interface/PHEventDisplay.h
@@ -53,7 +53,7 @@ public:
   int End(PHCompositeNode *topNode);
 
   /// Threaded access to Fun4All server
-  void run_evt_in_thread();
+  //void run_evt_in_thread();
   void start_rotation();
   void go_fullscreen();
   void set_jet_pt_threshold(float pt){jet_pt_threshold = pt;}
@@ -68,8 +68,8 @@ public:
 
 private:
   void reco_thread();
-  void draw_default();  
-  void update_scene();
+  void draw_default(PHCompositeNode *topNode);
+  void update_scene(PHCompositeNode *topNode);
 
 #ifndef _CLING__
   typedef boost::shared_ptr<mPHEveModuleBase> pBase;

--- a/packages/Display/modules/mTrkEveDisplay.cxx
+++ b/packages/Display/modules/mTrkEveDisplay.cxx
@@ -177,6 +177,12 @@ int mTrkEveDisplay::hit_to_wire(const int det_id, const int elm_id, double& x, d
 void
 mTrkEveDisplay::draw_hits()
 {
+  if(!_sqhit_col) {
+    if(verbosity > 0)
+      LogInfo(!_sqhit_col);
+    return;
+  }
+
   for (SQHitVector::ConstIter it = _sqhit_col->begin(); it != _sqhit_col->end(); it++) {
     try {
       SQHit * hit = *it;
@@ -236,6 +242,12 @@ mTrkEveDisplay::draw_hits()
 void
 mTrkEveDisplay::draw_tracks()
 {
+  if(!_recEvent) {
+    if(verbosity > 0)
+      LogInfo(!_recEvent);
+    return;
+  }
+
   if(verbosity > 0)
     LogInfo(_recEvent->getNTracks());
   if(_recEvent->getNTracks()<=0) return;

--- a/packages/Display/modules/mTrkEveDisplay.cxx
+++ b/packages/Display/modules/mTrkEveDisplay.cxx
@@ -202,7 +202,7 @@ mTrkEveDisplay::draw_hits()
         << std::endl;
       }
 
-      if(det_id < 0 or det_id >= NDETPLANES) {
+      if(det_id <= 0 or det_id >= NDETPLANES) {
          if(verbosity > 2) LogInfo(det_id);
          continue;
       }
@@ -214,7 +214,12 @@ mTrkEveDisplay::draw_hits()
       }
 
       const float geom_limit = 1000;
-      if(fabs(x) > geom_limit or fabs(y) > geom_limit or fabs(dx) > geom_limit or fabs(dy) > geom_limit) {
+      if(
+          !(fabs(x) < geom_limit) or
+          !(fabs(y) < geom_limit) or
+          !(fabs(dx) < geom_limit) or
+          !(fabs(dy) < geom_limit)
+          ) {
          if(verbosity > 2) LogInfo(" {" << x << ", " << y << ", " << dx << ", " << dy << "}");
          continue;
       }

--- a/packages/dptrigger/DPTriggerAnalyzer.cxx
+++ b/packages/dptrigger/DPTriggerAnalyzer.cxx
@@ -364,8 +364,10 @@ int DPTriggerAnalyzer::process_event(PHCompositeNode* topNode) {
     _event_header->identify();
   }
 
+  _event++;
+
   if(Verbosity() >= Fun4AllBase::VERBOSITY_EVEN_MORE)
-    std::cout << "Leaving DPTriggerAnalyzer::process_event: " << _event++ << std::endl;
+    std::cout << "Leaving DPTriggerAnalyzer::process_event: " << _event << std::endl;
 
   return Fun4AllReturnCodes::EVENT_OK;
 

--- a/packages/evt_filter/CMakeLists.txt
+++ b/packages/evt_filter/CMakeLists.txt
@@ -1,0 +1,51 @@
+# Setup the project
+cmake_minimum_required(VERSION 2.6 FATAL_ERROR)
+project(evt_filter CXX C)
+
+# ROOT dict generation
+file(GLOB dicts "")
+file(GLOB LinkDefhs ${PROJECT_SOURCE_DIR}/*LinkDef.h)
+foreach(LinkDefh ${LinkDefhs})
+	string(REPLACE "LinkDef.h" ".h" Dicth ${LinkDefh})
+	string(REPLACE "LinkDef.h" "_Dict.C" DictC ${LinkDefh})
+	string(REPLACE "${PROJECT_SOURCE_DIR}/" "" DictC ${DictC})
+	list(APPEND dicts ${DictC})
+	add_custom_command(OUTPUT ${DictC} COMMAND rootcint ARGS -f ${DictC} -noIncludePaths -inlineInputHeader -c -p -I${PROJECT_SOURCE_DIR}/ ${Dicth} ${LinkDefh})
+endforeach(LinkDefh)
+
+# source code
+include_directories("${PROJECT_SOURCE_DIR}/")
+file(GLOB sources ${PROJECT_SOURCE_DIR}/*.cxx)
+file(GLOB headers ${PROJECT_SOURCE_DIR}/*.h)
+
+# ROOT
+find_program(ROOTCONF "root-config")
+if(ROOTCONF)
+  message("-- Detecting ROOT:    found at ${ROOTCONF}")
+else()
+  message(FATAL_ERROR "-- Detecting ROOT:    not found")
+endif()
+execute_process(COMMAND root-config --prefix OUTPUT_VARIABLE ROOT_PREFIX  OUTPUT_STRIP_TRAILING_WHITESPACE)
+execute_process(COMMAND root-config --cflags OUTPUT_VARIABLE ROOT_CFLAGS  OUTPUT_STRIP_TRAILING_WHITESPACE)
+execute_process(COMMAND root-config --libs   OUTPUT_VARIABLE ROOT_LINK    OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x ${ROOT_CFLAGS}")
+add_library(evt_filter SHARED ${sources} ${dicts})
+target_link_libraries(evt_filter -linterface_main -lSubsysReco )
+
+message(${CMAKE_PROJECT_NAME} " will be installed to " ${CMAKE_INSTALL_PREFIX})
+
+install(TARGETS evt_filter DESTINATION ${CMAKE_INSTALL_PREFIX}/lib)
+
+file(GLOB dist_headers ${PROJECT_SOURCE_DIR}/*.h)
+file(GLOB non_dist_headers ${PROJECT_SOURCE_DIR}/*LinkDef.h)
+list(REMOVE_ITEM dist_headers ${non_dist_headers})
+install(FILES ${dist_headers} DESTINATION ${CMAKE_INSTALL_PREFIX}/include/${CMAKE_PROJECT_NAME}/)
+
+# Install the pcm files in case of ROOT 6.
+execute_process(COMMAND root-config --version OUTPUT_VARIABLE ROOT_VER)
+string(SUBSTRING ${ROOT_VER} 0 1 ROOT_VER)
+if (ROOT_VER GREATER 5)
+   add_custom_target(install_pcm ALL COMMAND mkdir -p ${CMAKE_INSTALL_PREFIX}/lib COMMAND cp -up *_rdict.pcm ${CMAKE_INSTALL_PREFIX}/lib)
+   add_dependencies(install_pcm evt_filter)
+endif()

--- a/packages/evt_filter/EvtFilter.cxx
+++ b/packages/evt_filter/EvtFilter.cxx
@@ -47,10 +47,6 @@ EvtFilter::~EvtFilter()
 
 int EvtFilter::InitRun(PHCompositeNode* topNode) {
 
-  int ret = GetNodes(topNode);
-  if (ret != Fun4AllReturnCodes::EVENT_OK)
-    return ret;
-
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
@@ -58,6 +54,10 @@ int EvtFilter::process_event(PHCompositeNode* topNode) {
 
   if(Verbosity() >= Fun4AllBase::VERBOSITY_EVEN_MORE)
     std::cout << "Entering EvtFilter::process_event: " << _event << std::endl;
+
+  int ret = GetNodes(topNode);
+  if (ret != Fun4AllReturnCodes::EVENT_OK)
+    return ret;
 
   if(_event_header) {
     if(Verbosity() >= Fun4AllBase::VERBOSITY_A_LOT) {

--- a/packages/evt_filter/EvtFilter.cxx
+++ b/packages/evt_filter/EvtFilter.cxx
@@ -1,0 +1,109 @@
+#include "EvtFilter.h"
+
+
+#include <interface_main/SQHit.h>
+#include <interface_main/SQHit_v1.h>
+#include <interface_main/SQHitMap_v1.h>
+#include <interface_main/SQHitVector_v1.h>
+#include <interface_main/SQEvent_v1.h>
+#include <interface_main/SQRun_v1.h>
+#include <interface_main/SQSpill_v1.h>
+#include <interface_main/SQSpillMap_v1.h>
+
+#include <fun4all/Fun4AllBase.h>
+#include <fun4all/Fun4AllReturnCodes.h>
+#include <phool/PHNodeIterator.h>
+#include <phool/PHCompositeNode.h>
+#include <phool/PHIODataNode.h>
+#include <phool/getClass.h>
+
+#include <iomanip>
+#include <cmath>
+#include <fstream>
+#include <sstream>
+#include <string>
+
+#define LogInfo(message) std::cout << "DEBUG: " << __FILE__ << "  " << __LINE__ << "  " << __FUNCTION__ << " :::  " << message << std::endl
+
+using namespace std;
+
+int EvtFilter::Init(PHCompositeNode *topNode)
+{
+ return Fun4AllReturnCodes::EVENT_OK;
+}
+
+EvtFilter::EvtFilter(const std::string& name) :
+  SubsysReco(name),
+  _event(0),
+  _trigger_req(0),
+  _event_id_req(-1),
+  _event_header(nullptr)
+{
+}
+
+EvtFilter::~EvtFilter()
+{
+}
+
+int EvtFilter::InitRun(PHCompositeNode* topNode) {
+
+  int ret = GetNodes(topNode);
+  if (ret != Fun4AllReturnCodes::EVENT_OK)
+    return ret;
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int EvtFilter::process_event(PHCompositeNode* topNode) {
+
+  if(Verbosity() >= Fun4AllBase::VERBOSITY_EVEN_MORE)
+    std::cout << "Entering EvtFilter::process_event: " << _event << std::endl;
+
+  if(_event_header) {
+    if(Verbosity() >= Fun4AllBase::VERBOSITY_A_LOT) {
+      _event_header->identify();
+    }
+
+    unsigned short trig = _event_header->get_trigger();
+
+    if(Verbosity() >= Fun4AllBase::VERBOSITY_A_LOT)
+      LogInfo("_trigger_req: " << _trigger_req << ", trig" << trig);
+
+    if(_trigger_req!=0) {
+      if((_trigger_req & trig) == 0) {
+        if(Verbosity() >= Fun4AllBase::VERBOSITY_A_LOT) LogInfo("_trigger_req & trig == 0");
+        return Fun4AllReturnCodes::ABORTEVENT;
+      }
+    }
+
+    if(_event_id_req > -1) {
+
+      if(_event_id_req != _event_header->get_event_id()) {
+        if(Verbosity() >= Fun4AllBase::VERBOSITY_A_LOT) LogInfo("_trigger_req & trig == 0");
+        return Fun4AllReturnCodes::ABORTEVENT;
+      }
+    }
+  }
+    
+  if(Verbosity() >= Fun4AllBase::VERBOSITY_EVEN_MORE)
+    std::cout << "Leaving EvtFilter::process_event: " << _event++ << std::endl;
+
+  return Fun4AllReturnCodes::EVENT_OK;
+
+}
+
+int EvtFilter::End(PHCompositeNode* topNode) {
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int EvtFilter::GetNodes(PHCompositeNode* topNode) {
+  
+  _event_header = findNode::getClass<SQEvent>(topNode, "SQEvent");
+  if (!_event_header) {
+    LogInfo("!_event_header");
+    return Fun4AllReturnCodes::ABORTRUN;
+  }
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+

--- a/packages/evt_filter/EvtFilter.h
+++ b/packages/evt_filter/EvtFilter.h
@@ -1,0 +1,72 @@
+#ifndef EvtFilter_H
+#define EvtFilter_H
+
+// ROOT
+#include <TString.h>
+
+// Fun4All includes
+#include <fun4all/SubsysReco.h>
+
+// STL includes
+#include <vector>
+#include <string>
+#include <iostream>
+#include <set>
+#include <list>
+#include <map>
+#include <string>
+
+class SQEvent;
+
+
+class EvtFilter : public SubsysReco
+{
+public:
+
+public:
+    EvtFilter(const std::string &name = "EvtFilter");
+    virtual ~EvtFilter();
+
+#ifndef __CINT__
+    int Init(PHCompositeNode *topNode);
+#endif
+    
+    //! module initialization
+    int InitRun(PHCompositeNode *topNode);
+    
+    //! event processing
+    int process_event(PHCompositeNode *topNode);
+
+    int End(PHCompositeNode *topNode);
+
+  unsigned short get_trigger_req() const {
+    return _trigger_req;
+  }
+
+  void set_trigger_req(unsigned short triggerReq) {
+    _trigger_req = triggerReq;
+  }
+
+  int get_event_id_req() const {
+    return _event_id_req;
+  }
+
+  void set_event_id_req(int eventIdReq) {
+    _event_id_req = eventIdReq;
+  }
+
+private:
+
+    int GetNodes(PHCompositeNode *topNode);
+
+    size_t _event;
+
+    unsigned short _trigger_req;
+    int _event_id_req;
+
+
+    SQEvent* _event_header;
+};
+
+
+#endif

--- a/packages/evt_filter/EvtFilterLinkDef.h
+++ b/packages/evt_filter/EvtFilterLinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class EvtFilter-!;
+
+#endif /* __CINT__ */


### PR DESCRIPTION
- init of Event filter `EvtFilter`
  - Using `EvtFilter` to control interested event type, implemented in macro, [example](https://github.com/E1039-Collaboration/e1039-analysis/blob/master/CODAChainDev/eve_disp_dst.C)
- Add event information in the main tab of the event display

Example:
![image](https://user-images.githubusercontent.com/10383186/59987347-79dde200-9608-11e9-83c9-d7e308148a7c.png)
