### PR TITLE
Works with D1 as 1-6; and some small fix

### DIFF
--- a/packages/ktracker/CMakeLists.txt
+++ b/packages/ktracker/CMakeLists.txt
@@ -64,7 +64,7 @@ string(REPLACE "-pedantic" "" GEANT4_CFLAGS ${GEANT4_CFLAGS})
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${GEANT4_CFLAGS} ${ROOT_CFLAGS} -std=c++11")
 set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -lphool")
 add_library(ktracker SHARED ${sources} ${dicts})
-target_link_libraries(ktracker -lgenfitexp -lgenfit2 -lphfield -lphgeom -linterface_main -lfun4all -lgeom_svc ${ROOT_LINK})
+target_link_libraries(ktracker -lgenfitexp -lgenfit2 -lphfield -lphgeom -linterface_main -lfun4all -lgeom_svc -lphg4hit ${ROOT_LINK})
 
 message(${CMAKE_PROJECT_NAME} " will be installed to " ${CMAKE_INSTALL_PREFIX})
 

--- a/packages/ktracker/KalmanDSTrk.cxx
+++ b/packages/ktracker/KalmanDSTrk.cxx
@@ -1503,7 +1503,7 @@ void KalmanDSTrk::buildTrackletsInStation(int stationID, int listID, double* pos
                   _timers["search_db_2"]->restart();
 
             		PatternDB::STATION station = PatternDB::ERROR_STATION;
-            		if(stationID==2) station = PatternDB::DC1;
+            		if(stationID==1 or stationID==2) station = PatternDB::DC1;
             		if(stationID==3) station = PatternDB::DC2;
             		if(stationID==4) station = PatternDB::DC3p;
             		if(stationID==5) station = PatternDB::DC3m;

--- a/packages/ktracker/PatternDBGen.cxx
+++ b/packages/ktracker/PatternDBGen.cxx
@@ -8,6 +8,7 @@
 
 
 #include "PatternDBGen.h"
+#include "SRecEvent.h"
 
 #include <interface_main/SQHit.h>
 #include <interface_main/SQHit_v1.h>
@@ -18,8 +19,6 @@
 #include <interface_main/SQRun_v1.h>
 #include <interface_main/SQSpill_v1.h>
 #include <interface_main/SQSpillMap_v1.h>
-
-#include <ktracker/SRecEvent.h>
 
 #include <geom_svc/GeomSvc.h>
 

--- a/packages/ktracker/PatternDBUtil.cxx
+++ b/packages/ktracker/PatternDBUtil.cxx
@@ -15,6 +15,8 @@
 
 #define _DEBUG_
 
+#define _D1_1_6_
+
 #define _RESOLUTION1_ 2
 #define _RESOLUTION2_ 2
 #define _RESOLUTION3_ 2
@@ -23,6 +25,13 @@ int PatternDBUtil::verbosity = 0;
 
 
 std::map<unsigned int, unsigned int> PatternDBUtil::_detid_view = {
+		{3, 0},
+		{4, 1},
+		{1, 2},
+		{2, 3},
+		{5, 4},
+		{6, 5},
+
 		{9,  0},
 		{10, 1},
 		{11, 2},
@@ -125,14 +134,13 @@ int PatternDBUtil::BuildPatternDB(const std::string &fin, const std::string & fo
 
 			if(!(gndc[ipar]>17)) continue;
 
-#define _D1_1_6_
 #ifdef _D1_1_6_
-      unsigned int D1U  = elmid[ipar][1];
-      unsigned int D1Up = elmid[ipar][2];
-      unsigned int D1X  = elmid[ipar][3];
-      unsigned int D1Xp = elmid[ipar][4];
-      unsigned int D1V  = elmid[ipar][5];
-      unsigned int D1Vp = elmid[ipar][6];
+      unsigned int D1U  = elmid[ipar][1];  // 1
+      unsigned int D1Up = elmid[ipar][2];  // 2
+      unsigned int D1X  = elmid[ipar][3];  // 3
+      unsigned int D1Xp = elmid[ipar][4];  // 4
+      unsigned int D1V  = elmid[ipar][5];  // 5
+      unsigned int D1Vp = elmid[ipar][6];  // 6
 #else
 			unsigned int D1V  = elmid[ipar][7];
 			unsigned int D1Vp = elmid[ipar][8];
@@ -442,7 +450,7 @@ TrackletKey PatternDBUtil::GetTrackletKey(
 		auto hit = &ptr_hit->hit;
 		if (hit->index < 0) continue;
 		unsigned int det_id = hit->detectorID;
-		if(station==PatternDB::DC1  and !(det_id>=7 and det_id<=12)) continue;
+		if(station==PatternDB::DC1  and !(det_id>=1 and det_id<=12)) continue;
 		if(station==PatternDB::DC2  and !(det_id>=13 and det_id<=18)) continue;
 		if(station==PatternDB::DC3p and !(det_id>=19 and det_id<=24)) continue;
 		if(station==PatternDB::DC3m and !(det_id>=25 and det_id<=30)) continue;
@@ -471,7 +479,7 @@ TrackletKey PatternDBUtil::GetTrackletKey(
 
 	for (auto pair : det_elem_pairs) {
 		unsigned int det_id = pair.first;
-		if(station==PatternDB::DC1  and !(det_id>=7 and det_id<=12)) continue;
+		if(station==PatternDB::DC1  and !(det_id>=1 and det_id<=12)) continue;
 		if(station==PatternDB::DC2  and !(det_id>=13 and det_id<=18)) continue;
 		if(station==PatternDB::DC3p and !(det_id>=19 and det_id<=24)) continue;
 		if(station==PatternDB::DC3m and !(det_id>=25 and det_id<=30)) continue;


### PR DESCRIPTION
Make the DSearch compatible with D1 using id 1 to 6.
Ref. [docDB#5911](https://seaquest-docdb.fnal.gov/cgi-bin/private/ShowDocument?docid=5911)

Other fix:
- small include fix for `PatternDBGen.cxx`
- library linking fix for `packages/ktracker`


