### PR TITLE
Update interface of DSearch

### DIFF
--- a/packages/ktracker/KalmanDSTrk.cxx
+++ b/packages/ktracker/KalmanDSTrk.cxx
@@ -108,6 +108,7 @@ KalmanDSTrk::KalmanDSTrk(
 			} else if(_sim_db_name != "") {
         std::cout <<"KalmanDSTrk::KalmanDSTrk: load DB from sim db: "<< _sim_db_name << std::endl;
 			  _timers["build_db"]->restart();
+        _pattern_db = new PatternDB();
         PatternDBUtil::BuildPatternDB(_sim_db_name, "PatternDB_tmp.root", *_pattern_db);
         _timers["build_db"]->stop();
 			} else {

--- a/packages/ktracker/KalmanDSTrk.cxx
+++ b/packages/ktracker/KalmanDSTrk.cxx
@@ -98,8 +98,6 @@ KalmanDSTrk::KalmanDSTrk(
 
   	if(_DS_level > KalmanDSTrk::NO_DS) {
 
-			PatternDBUtil::Verbosity(verbosity);
-
 			if(_pattern_db_name != "") {
 			  std::cout <<"KalmanDSTrk::KalmanDSTrk: load DB from pattern db: "<< _pattern_db_name << std::endl;
         _timers["load_db"]->restart();

--- a/packages/ktracker/KalmanDSTrk.cxx
+++ b/packages/ktracker/KalmanDSTrk.cxx
@@ -37,10 +37,15 @@ KalmanDSTrk::KalmanDSTrk(
 		const PHField* field,
 		const TGeoManager *geom,
 		bool enable_KF,
-		int  DS_level)
+		int  DS_level,
+    const std::string sim_db_name,
+    const std::string pattern_db_name
+		)
 : verbosity(10)
 ,_enable_KF(enable_KF)
 ,_DS_level(DS_level)
+,_sim_db_name(sim_db_name)
+,_pattern_db_name(pattern_db_name)
 , _pattern_db(nullptr)
 {
     using namespace std;
@@ -93,28 +98,32 @@ KalmanDSTrk::KalmanDSTrk(
 
   	if(_DS_level > KalmanDSTrk::NO_DS) {
 
-			PatternDBUtil::Verbosity(10);
-			_timers["load_db"]->restart();
-			_pattern_db = PatternDBUtil::LoadPatternDB("PatternDB.root");
-			_timers["load_db"]->stop();
-			if(_pattern_db) {
-				std::cout <<"KalmanDSTrk::KalmanDSTrk: DB loaded. St23 size: "<< _pattern_db->St23.size() << std::endl;
+			PatternDBUtil::Verbosity(verbosity);
+
+			if(_pattern_db_name != "") {
+			  std::cout <<"KalmanDSTrk::KalmanDSTrk: load DB from pattern db: "<< _pattern_db_name << std::endl;
+        _timers["load_db"]->restart();
+			  _pattern_db = PatternDBUtil::LoadPatternDB(_pattern_db_name);
+        _timers["load_db"]->stop();
+			} else if(_sim_db_name != "") {
+        std::cout <<"KalmanDSTrk::KalmanDSTrk: load DB from sim db: "<< _sim_db_name << std::endl;
+			  _timers["build_db"]->restart();
+        PatternDBUtil::BuildPatternDB(_sim_db_name, "PatternDB_tmp.root", *_pattern_db);
+        _timers["build_db"]->stop();
 			} else {
-				std::cout <<"KalmanDSTrk::KalmanDSTrk: DB NOT loaded. Try to build. " << std::endl;
-				_timers["build_db"]->restart();
-        _pattern_db = new PatternDB();
-				PatternDBUtil::BuildPatternDB("pattern_db.root", "PatternDB_tmp.root", *_pattern_db);
-				_timers["build_db"]->stop();
-				_timers["load_db"]->restart();
-				//_pattern_db = PatternDBUtil::LoadPatternDB("PatternDB.root");
-				_timers["load_db"]->stop();
+			  std::cout <<"KalmanDSTrk::KalmanDSTrk: no sim or pattern DB" << std::endl;
 			}
 
-			std::cout <<"KalmanDSTrk::KalmanDSTrk: St23 size: "<< _pattern_db->St23.size() << std::endl;
-    	std::cout << "================================================================" << std::endl;
-    	std::cout << "Build DB                    "<<_timers["build_db"]->get_accumulated_time()/1000. << " sec" <<std::endl;
-    	std::cout << "Load DB                     "<<_timers["load_db"]->get_accumulated_time()/1000. << " sec" <<std::endl;
-    	std::cout << "================================================================" << std::endl;
+			if(_pattern_db) {
+				std::cout <<"KalmanDSTrk::KalmanDSTrk: DB loaded. St23 size: "<< _pattern_db->St23.size() << std::endl;
+	      std::cout << "================================================================" << std::endl;
+	      std::cout << "Build DB                    "<<_timers["build_db"]->get_accumulated_time()/1000. << " sec" <<std::endl;
+	      std::cout << "Load DB                     "<<_timers["load_db"]->get_accumulated_time()/1000. << " sec" <<std::endl;
+	      std::cout << "================================================================" << std::endl;
+			} else {
+				std::cout <<"KalmanDSTrk::KalmanDSTrk: DB NOT loaded - _DS_level set to 0 " << std::endl;
+				_DS_level = 0;
+			}
     }
 
     //Initialize minuit minimizer

--- a/packages/ktracker/KalmanDSTrk.h
+++ b/packages/ktracker/KalmanDSTrk.h
@@ -49,7 +49,10 @@ public:
 			const PHField* field,
 			const TGeoManager *geom,
 			bool enable_KF = true,
-			int DS_level = KalmanDSTrk::NO_DS);
+			int DS_level = KalmanDSTrk::NO_DS,
+			const std::string sim_db_name = "",
+      const std::string pattern_db_name = ""
+			);
 
 	~KalmanDSTrk();
 
@@ -126,6 +129,22 @@ public:
 	/// Tool, a simple-minded chi square fit
 	/// Y = a*X + b
 	void chi2fit(int n, double x[], double y[], double& a, double& b);
+
+  const std::string& get_pattern_db_name() const {
+    return _pattern_db_name;
+  }
+
+  void set_pattern_db_name(const std::string& patternDbName) {
+    _pattern_db_name = patternDbName;
+  }
+
+  const std::string& get_sim_db_name() const {
+    return _sim_db_name;
+  }
+
+  void set_sim_db_name(const std::string& simDbName) {
+    _sim_db_name = simDbName;
+  }
 
 private:
 
@@ -222,7 +241,9 @@ private:
     const bool _enable_KF;
 
     // Dictionary search
-    const int _DS_level;
+    int _DS_level;
+    std::string _sim_db_name;
+    std::string _pattern_db_name;
 
     /*
     //typedef std::tuple<unsigned char, unsigned char, unsigned char, unsigned char> TrackletKey;

--- a/packages/ktracker/KalmanFastTrackingWrapper.cxx
+++ b/packages/ktracker/KalmanFastTrackingWrapper.cxx
@@ -60,6 +60,8 @@ SubsysReco(name),
 _enable_KF(true),
 _enable_event_reducer(false),
 _DS_level(KalmanDSTrk::NO_DS),
+_sim_db_name(""),
+_pattern_db_name(""),
 _hit_container_type("Vector"),
 _event(0),
 _run_header(nullptr),
@@ -107,7 +109,7 @@ int KalmanFastTrackingWrapper::InitRun(PHCompositeNode* topNode) {
   }
 
 	/// init KalmanDSTrk
-	fastfinder = new KalmanDSTrk(field, _t_geo_manager, _enable_KF, _DS_level);
+	fastfinder = new KalmanDSTrk(field, _t_geo_manager, _enable_KF, _DS_level,_sim_db_name,_pattern_db_name);
 	fastfinder->Verbosity(verbosity);
 
 	if(_enable_event_reducer) {

--- a/packages/ktracker/KalmanFastTrackingWrapper.h
+++ b/packages/ktracker/KalmanFastTrackingWrapper.h
@@ -109,6 +109,22 @@ public:
 		_enable_event_reducer = enableEventReducer;
 	}
 
+  const std::string& get_pattern_db_name() const {
+    return _pattern_db_name;
+  }
+
+  void set_pattern_db_name(const std::string& patternDbName) {
+    _pattern_db_name = patternDbName;
+  }
+
+  const std::string& get_sim_db_name() const {
+    return _sim_db_name;
+  }
+
+  void set_sim_db_name(const std::string& simDbName) {
+    _sim_db_name = simDbName;
+  }
+
 private:
 
 	int InitField(PHCompositeNode *topNode);
@@ -125,6 +141,8 @@ private:
 	bool _enable_KF;
 	bool _enable_event_reducer;
 	int _DS_level;
+	std::string _sim_db_name;
+	std::string _pattern_db_name;
 
 	SRawEvent* BuildSRawEvent();
 

--- a/packages/ktracker/PatternDBUtil.cxx
+++ b/packages/ktracker/PatternDBUtil.cxx
@@ -17,12 +17,15 @@
 
 #define _D1_1_6_
 
-#define _RESOLUTION1_ 2
-#define _RESOLUTION2_ 2
-#define _RESOLUTION3_ 2
+//#define _RESOLUTION1_ 2
+//#define _RESOLUTION2_ 2
+//#define _RESOLUTION3_ 2
 
 int PatternDBUtil::verbosity = 0;
-
+bool PatternDBUtil::_loose_mode = false;
+int PatternDBUtil::_RESOLUTION1_ = 2;
+int PatternDBUtil::_RESOLUTION2_ = 2;
+int PatternDBUtil::_RESOLUTION3_ = 2;
 
 std::map<unsigned int, unsigned int> PatternDBUtil::_detid_view = {
 		{3, 0},
@@ -242,7 +245,7 @@ int PatternDBUtil::BuildPatternDB(const std::string &fin, const std::string & fo
 	if(verbosity >= 2) {
 		LogInfo("PatternDBUtil::BuildPatternDB from " << fin);
 		LogInfo("db_st23.size(): " << db.St23.size());
-		//db.print();
+		db.print();
 	}
 
 	//TODO remove this debug code
@@ -424,16 +427,26 @@ TrackletKey PatternDBUtil::EncodeTrackletKey(
 		return PatternDB::ERR_KEY;
 	}
 
-	if(X == 0 and U == 0 and V == 0) {
+  int x = X;
+  int u = U;
+  int v = V;
+
+  if(_loose_mode) {
+    x = X > 0 ? X : Xp;
+    u = U > 0 ? U : Up;
+    v = V > 0 ? V : Vp;
+  }
+
+	if(x == 0 and u == 0 and v == 0) {
 		return PatternDB::ERR_KEY;
 	}
 
 	if(ST == PatternDB::DC1)
-		return TrackletKey(ST, X/_RESOLUTION1_, U/_RESOLUTION1_, V/_RESOLUTION1_);
+		return TrackletKey(ST, x/_RESOLUTION1_, u/_RESOLUTION1_, v/_RESOLUTION1_);
 	else if(ST == PatternDB::DC2)
-		return TrackletKey(ST, X/_RESOLUTION2_, U/_RESOLUTION2_, V/_RESOLUTION2_);
+		return TrackletKey(ST, x/_RESOLUTION2_, u/_RESOLUTION2_, v/_RESOLUTION2_);
 	else
-		return TrackletKey(ST, X/_RESOLUTION3_, U/_RESOLUTION3_, V/_RESOLUTION3_);
+		return TrackletKey(ST, x/_RESOLUTION3_, u/_RESOLUTION3_, v/_RESOLUTION3_);
 }
 
 TrackletKey PatternDBUtil::GetTrackletKey(

--- a/packages/ktracker/PatternDBUtil.cxx
+++ b/packages/ktracker/PatternDBUtil.cxx
@@ -106,7 +106,7 @@ int PatternDBUtil::BuildPatternDB(const std::string &fin, const std::string & fo
 
 	int n_particles = 0;
 	int gndc[1000];
-	int elmid [1000][55];
+	int elmid [1000][128];
 
 	T->SetBranchAddress("n_tracks", &n_particles);
 	T->SetBranchAddress("gelmid", &elmid);
@@ -227,12 +227,12 @@ int PatternDBUtil::BuildPatternDB(const std::string &fin, const std::string & fo
 	      nacc_23 = 0;
 	      nacc_123 = 0;
 
-				LogInfo("ntrack: "<< ntrack);
-				LogInfo("acc_prob_1: "<< acc_prob_1);
-				LogInfo("acc_prob_2: "<< acc_prob_2);
-				LogInfo("acc_prob_3: "<< acc_prob_3);
-				LogInfo("acc_prob_23: "<< acc_prob_23);
-				LogInfo("acc_prob_123: "<< acc_prob_123);
+        //LogInfo("ntrack: "<< ntrack);
+        //LogInfo("acc_prob_1: "<< acc_prob_1);
+        //LogInfo("acc_prob_2: "<< acc_prob_2);
+        //LogInfo("acc_prob_3: "<< acc_prob_3);
+        //LogInfo("acc_prob_23: "<< acc_prob_23);
+        //LogInfo("acc_prob_123: "<< acc_prob_123);
 			}
 			++ntrack;
 #endif
@@ -242,7 +242,7 @@ int PatternDBUtil::BuildPatternDB(const std::string &fin, const std::string & fo
 	if(verbosity >= 2) {
 		LogInfo("PatternDBUtil::BuildPatternDB from " << fin);
 		LogInfo("db_st23.size(): " << db.St23.size());
-		db.print();
+		//db.print();
 	}
 
 	//TODO remove this debug code

--- a/packages/ktracker/PatternDBUtil.cxx
+++ b/packages/ktracker/PatternDBUtil.cxx
@@ -106,7 +106,7 @@ int PatternDBUtil::BuildPatternDB(const std::string &fin, const std::string & fo
 
 	int n_particles = 0;
 	int gndc[1000];
-	int elmid [1000][128];
+	int elmid [1000][55];
 
 	T->SetBranchAddress("n_tracks", &n_particles);
 	T->SetBranchAddress("gelmid", &elmid);

--- a/packages/ktracker/PatternDBUtil.h
+++ b/packages/ktracker/PatternDBUtil.h
@@ -37,6 +37,38 @@ class PatternDBUtil
 			const std::vector< std::pair<unsigned int, unsigned int> > & det_elem_pairs,
 			const PatternDB::STATION &station);
 
+	static int LooseMode() {
+		return PatternDBUtil::_loose_mode;
+	}
+
+	static void LooseMode(bool a = true) {
+		PatternDBUtil::_loose_mode = a;
+	}
+
+	static int ResScaleDC1() {
+		return PatternDBUtil::_RESOLUTION1_;
+	}
+
+	static void ResScaleDC1(const int a) {
+		PatternDBUtil::_RESOLUTION1_ = a;
+	}
+
+	static int ResScaleDC2() {
+		return PatternDBUtil::_RESOLUTION2_;
+	}
+
+	static void ResScaleDC2(const int a) {
+		PatternDBUtil::_RESOLUTION2_ = a;
+	}
+
+	static int ResScaleDC3() {
+		return PatternDBUtil::_RESOLUTION3_;
+	}
+
+	static void ResScaleDC3(const int a) {
+		PatternDBUtil::_RESOLUTION3_ = a;
+	}
+
 	static int Verbosity() {
 		return PatternDBUtil::verbosity;
 	}
@@ -56,6 +88,10 @@ class PatternDBUtil
 	static std::map<unsigned int, unsigned int> _detid_view;
 
 	static int verbosity;
+	static bool _loose_mode;
+	static int _RESOLUTION1_;
+	static int _RESOLUTION2_;
+	static int _RESOLUTION3_;
 };
 
 


### PR DESCRIPTION
DSearch level:
 - 0 : no filter
 - 1 : in-station filter
 - 2: in-station + station 23 liking
```C++
KalmanFastTrackingWrapper::set_DS_level(int level)
```

Input DB file name
 - sim db : raw tracks from simulation
 - pattern db : `TrackletKey`
If both are set, pattern db would be used.
```C++
KalmanFastTrackingWrapper::set_sim_db_name(string name);
KalmanFastTrackingWrapper::set_pattern_db_name(string name);
```