### PR TITLE
Massive updates on the online code

### DIFF
--- a/online/decoder_maindaq/CodaInputManager.cc
+++ b/online/decoder_maindaq/CodaInputManager.cc
@@ -79,15 +79,13 @@ bool CodaInputManager::NextCodaEvent(unsigned int& coda_id, int*& words)
   int ret = evRead(m_handle, event_words, buflen);
   if (ret != 0 && m_online && m_run > 0) { // try to recover
     cout << "No new event seems available for now.  Try to recover." << endl;
-    string fn_end = UtilOnline::GetEndFileDir() + "/" + UtilOnline::RunNum2EndFile(m_run);
-    if (file_exists(fn_end)) {
+    if (file_exists(UtilOnline::GetEndFilePath(m_run))) {
       cout << "Exiting since the END file exists.\n";
       ForceEnd();
       return false;
     }
 
-    string fn_next_run = UtilOnline::GetCodaFileDir() + "/" + UtilOnline::RunNum2CodaFile(m_run+1);
-    if (file_exists(fn_next_run)) {
+    if (file_exists(UtilOnline::GetCodaFilePath(m_run+1))) {
       cout << "Exiting since the next run file exists.\n";
       ForceEnd();
       return false;

--- a/online/decoder_maindaq/CodaInputManager.cc
+++ b/online/decoder_maindaq/CodaInputManager.cc
@@ -18,8 +18,7 @@ CodaInputManager::CodaInputManager() :
 int CodaInputManager::OpenFile(const std::string fname, const int file_size_min, const int sec_wait, const int n_wait, const int n_evt_pre_read)
 {
   if (! file_exists(fname)) {
-    cerr << "!!ERROR!!  Coda file does not exist: " << fname << ".\n"
-	 << "Exiting...\n";
+    cerr << "!!ERROR!!  Coda file does not exist: " << fname << "." << endl;
     return 1;
   }
   m_fname = fname;
@@ -80,18 +79,18 @@ bool CodaInputManager::NextCodaEvent(unsigned int& coda_id, int*& words)
   if (ret != 0 && m_online && m_run > 0) { // try to recover
     cout << "No new event seems available for now.  Try to recover." << endl;
     if (file_exists(UtilOnline::GetEndFilePath(m_run))) {
-      cout << "Exiting since the END file exists.\n";
+      cout << "Exiting since the END file exists." << endl;
       ForceEnd();
       return false;
     }
 
     if (file_exists(UtilOnline::GetCodaFilePath(m_run+1))) {
-      cout << "Exiting since the next run file exists.\n";
+      cout << "Exiting since the next run file exists." << endl;
       ForceEnd();
       return false;
     }
     // Re-open the file, requring a larger file size
-    ret = OpenFile(m_fname, m_file_size + 32768, 5, 20, m_event_count);
+    ret = OpenFile(m_fname, m_file_size + 32768, 10, 20, m_event_count);
   }
   if (ret != 0) {
     ForceEnd();

--- a/online/decoder_maindaq/DecoParam.cc
+++ b/online/decoder_maindaq/DecoParam.cc
@@ -8,7 +8,7 @@ DecoParam::DecoParam() :
   fn_in(""), dir_param(""), sampling(0), verbose(0), time_wait(0), 
   runID(0), spillID(0), spillID_cntr(0), spillID_slow(0),
   targPos(0), targPos_slow(0), codaID(0), rocID(0), eventIDstd(0), hitID(0), 
-  at_bos(false), turn_id_max(0)
+  has_1st_bos(false), at_bos(false), turn_id_max(0)
 {
   ;
 }

--- a/online/decoder_maindaq/DecoParam.h
+++ b/online/decoder_maindaq/DecoParam.h
@@ -42,7 +42,19 @@ struct DecoParam {
   int eventIDstd; //< current event ID of standard physics events
   long int hitID; //< current hit ID, commonly used by Hit and TriggerHit.
 
-  bool at_bos;
+  bool has_1st_bos; //< Set 'true' at the 1st BOS event.
+  bool at_bos; //< Set 'true' at BOS, which triggers parsing the data in one spill.
+
+  typedef enum {
+    WORD_ONLY89     = 0x01,
+    WORD_OVERFLOW   = 0x02,
+    MULTIPLE_HEADER = 0x04,
+    NO_EVT_ID       = 0x08,
+    START_WO_STOP   = 0x10,
+    START_NOT_RISE  = 0x20,
+    DIRTY_FINISH    = 0x40
+  } CodaPhysEvtStatus_t;
+  int coda_phys_evt_status; //< Bits to hold the status of an Coda event.
   
   /// Max turnOnset in a spill.  Used to drop NIM3 events that came after the beam stops.  See elog 15010
   unsigned int turn_id_max;

--- a/online/decoder_maindaq/DecoStatusDb.cc
+++ b/online/decoder_maindaq/DecoStatusDb.cc
@@ -1,0 +1,72 @@
+#include <iostream>
+#include <TSQLServer.h>
+#include <db_svc/DbSvc.h>
+#include "DecoStatusDb.h"
+using namespace std;
+
+DecoStatusDb::DecoStatusDb() :
+  m_name_schema("user_e1039_maindaq_decoder"),
+  m_name_table ("deco_status")
+{
+  m_db = new DbSvc(DbSvc::DB1);
+  m_db->UseSchema(m_name_schema, true);
+
+  //m_stat_map["Unknown"    ] = 0;
+  //m_stat_map["Started"    ] = 1;
+  //m_stat_map["Finished OK"] = 2;
+  //m_stat_map["Finished NG"] = 3;
+}
+
+void DecoStatusDb::InitTable(const bool refresh)
+{
+
+  if (refresh && m_db->HasTable(m_name_table)) m_db->DropTable(m_name_table);
+  if (! m_db->HasTable(m_name_table)) {
+    DbSvc::VarList list;
+    list.Add("run"    , "INT", true);
+    list.Add("status" , "INT");
+    list.Add("utime_b", "INT");
+    list.Add("utime_e", "INT");
+    list.Add("result" , "INT");
+    m_db->CreateTable(m_name_table, list);
+  }
+
+  //const char* table_name = "deco_status_map";
+  //if (! m_db->HasTable(table_name)) {
+  //  DbSvc::VarList list;
+  //  list.Add("status", "INT", true);
+  //  list.Add("label" , "VARCHAR(64)");
+  //  m_db->CreateTable(table_name, list);
+  //}
+}
+
+void DecoStatusDb::RunStarted(const int run, int utime)
+{
+  if (utime == 0) utime = time(0);
+  InitTable();
+
+  ostringstream oss;
+  oss << "delete from " << m_name_table << " where run = " << run;
+  if (! m_db->Con()->Exec(oss.str().c_str())) {
+    cerr << "!!ERROR!!  DecoStatusDb::RunStarted()." << endl;
+    return;
+  }
+  oss.str("");
+  oss << "insert into " << m_name_table << " values" << " (" << run << ", " << STARTED << ", " << utime << ", 0, 0)";
+  if (! m_db->Con()->Exec(oss.str().c_str())) {
+    cerr << "!!ERROR!!  DecoStatusDb::RunStarted()." << endl;
+    return;
+  }
+}
+
+void DecoStatusDb::RunFinished(const int run, const int result, int utime)
+{
+  if (utime == 0) utime = time(0);
+
+  ostringstream oss;
+  oss << "update " << m_name_table << " set status = " << FINISHED << ", utime_e = " << utime << ", result = " << result << " where run = " << run;
+  if (! m_db->Con()->Exec(oss.str().c_str())) {
+    cerr << "!!ERROR!!  DecoStatusDb::RunFinished()." << endl;
+    return;
+  }
+}

--- a/online/decoder_maindaq/DecoStatusDb.cc
+++ b/online/decoder_maindaq/DecoStatusDb.cc
@@ -5,7 +5,7 @@
 using namespace std;
 
 DecoStatusDb::DecoStatusDb() :
-  m_name_schema("user_e1039_maindaq_decoder"),
+  m_name_schema("user_e1039_maindaq"),
   m_name_table ("deco_status")
 {
   m_db = new DbSvc(DbSvc::DB1);
@@ -23,11 +23,11 @@ void DecoStatusDb::InitTable(const bool refresh)
   if (refresh && m_db->HasTable(m_name_table)) m_db->DropTable(m_name_table);
   if (! m_db->HasTable(m_name_table)) {
     DbSvc::VarList list;
-    list.Add("run"    , "INT", true);
-    list.Add("status" , "INT");
-    list.Add("utime_b", "INT");
-    list.Add("utime_e", "INT");
-    list.Add("result" , "INT");
+    list.Add("run_id" , "INT", true);
+    list.Add("deco_status" , "INT");
+    list.Add("deco_utime_b", "INT");
+    list.Add("deco_utime_e", "INT");
+    list.Add("deco_result" , "INT");
     m_db->CreateTable(m_name_table, list);
   }
 
@@ -46,7 +46,7 @@ void DecoStatusDb::RunStarted(const int run, int utime)
   InitTable();
 
   ostringstream oss;
-  oss << "delete from " << m_name_table << " where run = " << run;
+  oss << "delete from " << m_name_table << " where run_id = " << run;
   if (! m_db->Con()->Exec(oss.str().c_str())) {
     cerr << "!!ERROR!!  DecoStatusDb::RunStarted()." << endl;
     return;
@@ -64,7 +64,7 @@ void DecoStatusDb::RunFinished(const int run, const int result, int utime)
   if (utime == 0) utime = time(0);
 
   ostringstream oss;
-  oss << "update " << m_name_table << " set status = " << FINISHED << ", utime_e = " << utime << ", result = " << result << " where run = " << run;
+  oss << "update " << m_name_table << " set deco_status = " << FINISHED << ", deco_utime_e = " << utime << ", deco_result = " << result << " where run_id = " << run;
   if (! m_db->Con()->Exec(oss.str().c_str())) {
     cerr << "!!ERROR!!  DecoStatusDb::RunFinished()." << endl;
     return;

--- a/online/decoder_maindaq/DecoStatusDb.h
+++ b/online/decoder_maindaq/DecoStatusDb.h
@@ -1,0 +1,28 @@
+#ifndef _DECO_STATUS_DB__H_
+#define _DECO_STATUS_DB__H_
+class DbSvc;
+
+class DecoStatusDb {
+  typedef enum {
+    UNKNOWN  = 0,
+    STARTED  = 1,
+    FINISHED = 2
+  } Status_t;
+
+  std::string m_name_schema;
+  std::string m_name_table;
+  DbSvc* m_db;
+
+  //typedef std::map<std::string, int> StatusMap_t;
+  //StatusMap_t m_stat_map;
+
+ public:
+  DecoStatusDb();
+  virtual ~DecoStatusDb() {}
+
+  void InitTable(const bool refresh=false);
+  void RunStarted (const int run, int utime=0);
+  void RunFinished(const int run, const int result, int utime=0);
+};
+
+#endif /* _DECO_STATUS_DB__H_ */

--- a/online/decoder_maindaq/DecoStatusDbLinkDef.h
+++ b/online/decoder_maindaq/DecoStatusDbLinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class DecoStatusDb-!;
+
+#endif /* __CINT__ */

--- a/online/decoder_maindaq/MainDaqParser.cc
+++ b/online/decoder_maindaq/MainDaqParser.cc
@@ -60,7 +60,7 @@ int MainDaqParser::ParseOneSpill()
   if (call_1st) call_1st = false;
   else if (dec_par.time_wait > 0) {
     cout << "...sleep(" << dec_par.time_wait << ") to pretend waiting for next spill..." << endl;
-    sleep(dec_par.time_wait);
+    for (int ii = dec_par.time_wait; ii > 0; ii--) sleep(1); // Looped to accept the online-monitor connection.
     cout << "...done." << endl;
   }
 

--- a/online/decoder_maindaq/UtilOnline.cc
+++ b/online/decoder_maindaq/UtilOnline.cc
@@ -44,3 +44,18 @@ std::string UtilOnline::RunNum2DstFile(const int run)
   oss << setfill('0') << "run_" << setw(6) << run << "_spin.root";
   return oss.str();
 }
+
+std::string UtilOnline::GetCodaFilePath(const int run)
+{
+  return GetCodaFileDir() + "/" + RunNum2CodaFile(run);
+}
+
+std::string UtilOnline::GetEndFilePath(const int run)
+{
+  return GetEndFileDir() + "/" + RunNum2EndFile(run);
+}
+
+std::string UtilOnline::GetDstFilePath(const int run)
+{
+  return GetDstFileDir() + "/" + RunNum2DstFile(run);
+}

--- a/online/decoder_maindaq/UtilOnline.h
+++ b/online/decoder_maindaq/UtilOnline.h
@@ -8,9 +8,9 @@ class UtilOnline {
   static std::string m_dir_dst;
 
  public:
-  static void GetEndFileDir (const std::string dir) { m_dir_end  = dir; }
-  static void GetCodaFileDir(const std::string dir) { m_dir_coda = dir; }
-  static void GetDstFileDir (const std::string dir) { m_dir_dst  = dir; }
+  static void SetEndFileDir (const std::string dir) { m_dir_end  = dir; }
+  static void SetCodaFileDir(const std::string dir) { m_dir_coda = dir; }
+  static void SetDstFileDir (const std::string dir) { m_dir_dst  = dir; }
 
   static std::string GetEndFileDir () { return m_dir_end ; }
   static std::string GetCodaFileDir() { return m_dir_coda; }
@@ -20,6 +20,10 @@ class UtilOnline {
   static std::string RunNum2CodaFile(const int run);
   static std::string RunNum2EndFile(const int run);
   static std::string RunNum2DstFile(const int run);
+
+  static std::string GetCodaFilePath(const int run);
+  static std::string GetEndFilePath(const int run);
+  static std::string GetDstFilePath(const int run);
 };
 
 #endif /* _UTIL_ONLINE__H_ */

--- a/online/macros/Daemon4MainDaq.C
+++ b/online/macros/Daemon4MainDaq.C
@@ -24,7 +24,7 @@ void FindExistingRuns(vector<int>& list_run)
   //cout << endl;
 }
 
-void StartDecoder(const int run)
+void StartDecoder(const int run, const int n_evt=0, const bool is_online=true)
 {
   ostringstream oss;
   oss << "/dev/shm/decoder_maindaq";
@@ -33,7 +33,7 @@ void StartDecoder(const int run)
   string fn_log = oss.str();
   oss.str("");
   oss << "root.exe -b -q '" << gSystem->Getenv("E1039_CORE")
-      << "/macros/Fun4MainDaq.C(" << run << ", 0, true)' &>" << fn_log << " &";
+      << "/macros/Fun4MainDaq.C(" << run << ", " << n_evt << ", " << is_online << ")' &>" << fn_log << " &";
 
   cout << "Start the decoder for run " << run << ":\n"
        << "  Log file = " << fn_log << "\n"

--- a/online/macros/Fun4MainDaq.C
+++ b/online/macros/Fun4MainDaq.C
@@ -40,7 +40,7 @@ int Fun4MainDaq(const int run=46, const int nevent=0, const bool is_online=false
   se->registerSubsystem(new CalibXT());
 
   if (use_onlmon) { // Register the online-monitoring clients
-    se->StartServer();
+    if (is_online) se->StartServer();
     se->registerSubsystem(new OnlMonMainDaq());
     se->registerSubsystem(new OnlMonTrigSig());
     se->registerSubsystem(new OnlMonV1495(OnlMonV1495::H1X, 1));

--- a/online/macros/Fun4MainDaq.C
+++ b/online/macros/Fun4MainDaq.C
@@ -10,8 +10,10 @@ int Fun4MainDaq(const int run=46, const int nevent=0, const bool is_online=false
   gSystem->Load("libinterface_main.so");
   gSystem->Load("libdecoder_maindaq.so");
   gSystem->Load("libonlmonserver.so");
-
   const bool use_onlmon = true;
+
+  DecoStatusDb deco_stat;
+  deco_stat.RunStarted(run);
 
   ostringstream oss;
   oss << UtilOnline::GetCodaFileDir() << "/" << UtilOnline::RunNum2CodaFile(run);
@@ -66,6 +68,7 @@ int Fun4MainDaq(const int run=46, const int nevent=0, const bool is_online=false
 
   se->run(nevent);
   se->End();
+  deco_stat.RunFinished(run, 0); // always "result = 0" for now.
   
   delete se;
   cout << "Fun4MainDaq Done!" << endl;

--- a/online/macros/OnlMon4MainDaq.C
+++ b/online/macros/OnlMon4MainDaq.C
@@ -1,13 +1,8 @@
 /// OnlMon4MainDaq.C:  Macro to launch an online-monitor client for MainDaq.
 #if ROOT_VERSION_CODE >= ROOT_VERSION(6,00,0)
-#include <TGClient.h>
-#include <TGButton.h>
-#include <TGFrame.h>
 R__LOAD_LIBRARY(libinterface_main)
 R__LOAD_LIBRARY(libonlmonserver)
 #endif
-
-#include <vector>
 
 int OnlMon4MainDaq()
 {
@@ -20,35 +15,33 @@ int OnlMon4MainDaq()
 
   OnlMonServer::SetHost("192.168.24.211"); // default = localhost
 
-  //OnlMonClientList_t list_omc;
-  //list_omc.push_back(new OnlMonMainDaq());
-  //list_omc.push_back(new OnlMonTrigSig());
-  //list_omc.push_back(new OnlMonV1495(OnlMonV1495::H1X, 1));
-  //list_omc.push_back(new OnlMonV1495(OnlMonV1495::H2X, 1));
-  //list_omc.push_back(new OnlMonV1495(OnlMonV1495::H3X, 1));
-  //list_omc.push_back(new OnlMonV1495(OnlMonV1495::H4X, 1));
-  //list_omc.push_back(new OnlMonHodo (OnlMonHodo ::H1X ));
-  //list_omc.push_back(new OnlMonHodo (OnlMonHodo ::H2X ));
-  //list_omc.push_back(new OnlMonHodo (OnlMonHodo ::H3X ));
-  //list_omc.push_back(new OnlMonHodo (OnlMonHodo ::H4X ));
-  //list_omc.push_back(new OnlMonHodo (OnlMonHodo ::H1Y ));
-  //list_omc.push_back(new OnlMonHodo (OnlMonHodo ::H2Y ));
-  //list_omc.push_back(new OnlMonHodo (OnlMonHodo ::H4Y1));
-  //list_omc.push_back(new OnlMonHodo (OnlMonHodo ::H4Y2));
-  //list_omc.push_back(new OnlMonCham (OnlMonCham ::D0 ));
-  //list_omc.push_back(new OnlMonCham (OnlMonCham ::D1 ));
-  //list_omc.push_back(new OnlMonCham (OnlMonCham ::D2 ));
-  //list_omc.push_back(new OnlMonCham (OnlMonCham ::D3p));
-  //list_omc.push_back(new OnlMonCham (OnlMonCham ::D3m));
-  //list_omc.push_back(new OnlMonProp (OnlMonProp ::P1 ));
-  //list_omc.push_back(new OnlMonProp (OnlMonProp ::P2 ));
+  OnlMonClientList_t list_omc;
+  list_omc.push_back(new OnlMonMainDaq());
+  list_omc.push_back(new OnlMonTrigSig());
+  list_omc.push_back(new OnlMonV1495(OnlMonV1495::H1X, 1));
+  list_omc.push_back(new OnlMonV1495(OnlMonV1495::H2X, 1));
+  list_omc.push_back(new OnlMonV1495(OnlMonV1495::H3X, 1));
+  list_omc.push_back(new OnlMonV1495(OnlMonV1495::H4X, 1));
+  list_omc.push_back(new OnlMonHodo (OnlMonHodo ::H1X ));
+  list_omc.push_back(new OnlMonHodo (OnlMonHodo ::H2X ));
+  list_omc.push_back(new OnlMonHodo (OnlMonHodo ::H3X ));
+  list_omc.push_back(new OnlMonHodo (OnlMonHodo ::H4X ));
+  list_omc.push_back(new OnlMonHodo (OnlMonHodo ::H1Y ));
+  list_omc.push_back(new OnlMonHodo (OnlMonHodo ::H2Y ));
+  list_omc.push_back(new OnlMonHodo (OnlMonHodo ::H4Y1));
+  list_omc.push_back(new OnlMonHodo (OnlMonHodo ::H4Y2));
+  list_omc.push_back(new OnlMonCham (OnlMonCham ::D0 ));
+  list_omc.push_back(new OnlMonCham (OnlMonCham ::D1 ));
+  list_omc.push_back(new OnlMonCham (OnlMonCham ::D2 ));
+  list_omc.push_back(new OnlMonCham (OnlMonCham ::D3p));
+  list_omc.push_back(new OnlMonCham (OnlMonCham ::D3m));
+  list_omc.push_back(new OnlMonProp (OnlMonProp ::P1 ));
+  list_omc.push_back(new OnlMonProp (OnlMonProp ::P2 ));
 
-  OnlMonUI* ui = new OnlMonUI(0);
-  //OnlMonUI* ui = new OnlMonUI(&list_omc);
+  OnlMonUI* ui = new OnlMonUI(&list_omc);
   //ui->SetCycleInterval(5); // default = 10 sec
   //ui->SetAutoCycleFlag(true); // default = false
-  //ui->BuildInterface();
-  //ui->StartAutoCycle();
+  ui->Run();
   
   return 0;
 }

--- a/online/onlmonserver/OnlMonCanvas.cc
+++ b/online/onlmonserver/OnlMonCanvas.cc
@@ -13,7 +13,7 @@ using namespace std;
 
 OnlMonCanvas::OnlMonCanvas(const std::string name, const std::string title, const int num) :
   m_name(name), m_title(title), m_num(num), 
-  m_can("c1", "", 5+600*num, 5, 600, 800), 
+  m_can("c1", "", 200+600*num, 20, 600, 800), 
   m_pad_title("title", "", 0.0, 0.9, 1.0, 1.0),
   m_pad_main ("main" , "", 0.0, 0.1, 1.0, 0.9),
   m_pad_msg  ("msg"  , "", 0.0, 0.0, 1.0, 0.1),
@@ -40,6 +40,25 @@ void OnlMonCanvas::SetBasicInfo(const int run_id, const int spill_id, const int 
 void OnlMonCanvas::AddMessage(const char* msg)
 {
   m_pate_msg.AddText(msg);
+}
+
+
+void OnlMonCanvas::SetWorseStatus(const MonStatus_t stat)
+{
+  switch (stat) {
+  case OK:
+    if (m_mon_status == UNDEF) m_mon_status = OK;
+    break;
+  case WARN:  
+    if (m_mon_status == UNDEF || m_mon_status == OK) m_mon_status = WARN;
+    break;
+  case ERROR:
+    m_mon_status = ERROR;
+    break;
+  case UNDEF:
+    m_mon_status = UNDEF;
+    break;
+  }
 }
 
 TPad* OnlMonCanvas::GetMainPad()

--- a/online/onlmonserver/OnlMonCanvas.cc
+++ b/online/onlmonserver/OnlMonCanvas.cc
@@ -1,4 +1,5 @@
 #include <iostream>
+#include <fstream>
 #include <sstream>
 #include <iomanip>
 #include <TROOT.h>
@@ -121,10 +122,20 @@ void OnlMonCanvas::PostDraw(const bool at_end)
     oss << OnlMonServer::GetOutDir() << "/" << setfill('0') << setw(6) << m_run;
     gSystem->mkdir(oss.str().c_str(), true);
 
+    oss << "/" << m_name << "_can" << m_num;
+    string path_base = oss.str(); // path without suffix
+
     int lvl = gErrorIgnoreLevel;
     gErrorIgnoreLevel = 1111; // Suppress the message by TCanvas::SaveAs().
-    oss << "/" << m_name << "_can" << m_num << ".png";
+    oss.str("");
+    oss << path_base << ".png";
     m_can.SaveAs(oss.str().c_str());
     gErrorIgnoreLevel = lvl;
+
+    oss.str("");
+    oss << path_base << ".txt";
+    ofstream ofs(oss.str().c_str());
+    ofs << m_mon_status << endl;
+    ofs.close();
   }
 }

--- a/online/onlmonserver/OnlMonCanvas.cc
+++ b/online/onlmonserver/OnlMonCanvas.cc
@@ -80,7 +80,7 @@ void OnlMonCanvas::PreDraw(const bool at_end)
   m_pad_title.cd();
   TPaveText* pate = new TPaveText(.02, .52, .98, .98);
   oss.str("");
-  oss << m_title << " #" << m_num;
+  oss << m_title << ": C" << m_num;
   pate->AddText(oss.str().c_str());
   pate->Draw();
 

--- a/online/onlmonserver/OnlMonCanvas.h
+++ b/online/onlmonserver/OnlMonCanvas.h
@@ -34,7 +34,9 @@ class OnlMonCanvas {
 
   void SetBasicInfo(const int run_id, const int spill_id=0, const int event_id=0, const int n_evt=0);
   void AddMessage(const char* msg);
+  MonStatus_t GetStatus() { return m_mon_status; }
   void SetStatus(const MonStatus_t stat) { m_mon_status = stat; }
+  void SetWorseStatus(const MonStatus_t stat);
   TPad* GetMainPad();
 
   void  PreDraw(const bool at_end=false);

--- a/online/onlmonserver/OnlMonCham.cc
+++ b/online/onlmonserver/OnlMonCham.cc
@@ -19,11 +19,11 @@ OnlMonCham::OnlMonCham(const ChamType_t type) : m_type(type)
 {
   NumCanvases(2);
   switch (m_type) {
-  case D0 :  m_pl0 =  1;  Name("OnlMonChamD0" );  Title( "D0 Chamber");  break;
-  case D1 :  m_pl0 =  7;  Name("OnlMonChamD1" );  Title( "D1 Chamber");  break;
-  case D2 :  m_pl0 = 13;  Name("OnlMonChamD2" );  Title( "D2 Chamber");  break;
-  case D3p:  m_pl0 = 19;  Name("OnlMonChamD3p");  Title("D3p Chamber");  break;
-  case D3m:  m_pl0 = 25;  Name("OnlMonChamD3m");  Title("D3m Chamber");  break;
+  case D0 :  m_pl0 =  1;  Name("OnlMonChamD0" );  Title("Chamber: D0" );  break;
+  case D1 :  m_pl0 =  7;  Name("OnlMonChamD1" );  Title("Chamber: D1" );  break;
+  case D2 :  m_pl0 = 13;  Name("OnlMonChamD2" );  Title("Chamber: D2" );  break;
+  case D3p:  m_pl0 = 19;  Name("OnlMonChamD3p");  Title("Chamber: D3p");  break;
+  case D3m:  m_pl0 = 25;  Name("OnlMonChamD3m");  Title("Chamber: D3m");  break;
   }
 }
 

--- a/online/onlmonserver/OnlMonClient.cc
+++ b/online/onlmonserver/OnlMonClient.cc
@@ -234,11 +234,12 @@ void OnlMonClient::RegisterHist(TH1* h1)
 int OnlMonClient::ReceiveHist()
 {
   string host = OnlMonServer::GetHost();
-  int   port0 = OnlMonServer::GetPort();
-  int  n_port = OnlMonServer::GetNumPorts();
+  int   port  = OnlMonServer::GetPort();
+  int   port0 = OnlMonServer::GetPort0();
+  int n_port  = OnlMonServer::GetNumPorts();
 
   TSocket* sock = 0;
-  for (int port = port0; port < port0 + n_port; port++) {
+  for (int ip = 0; ip < n_port; ip++) {
     bool port_ok = false;
     sock = new TSocket(host.c_str(), port);
     if (sock->IsValid()) {
@@ -260,8 +261,11 @@ int OnlMonClient::ReceiveHist()
     }
     delete sock;
     sock = 0;
+    port++;
+    if (port >= port0 + n_port) port -= n_port;
   }
   if (! sock) return 1;
+  OnlMonServer::SetPort(port);
   
   string comm = "SUBSYS:";
   comm += Name();

--- a/online/onlmonserver/OnlMonClient.cc
+++ b/online/onlmonserver/OnlMonClient.cc
@@ -76,11 +76,18 @@ int OnlMonClient::process_event(PHCompositeNode* topNode)
 {
   SQEvent* event = findNode::getClass<SQEvent>(topNode, "SQEvent");
   if (!event) return Fun4AllReturnCodes::ABORTEVENT;
+
+  pthread_mutex_t mutex;
+  OnlMonServer::instance()->GetMutex(mutex);
+  pthread_mutex_lock(&mutex);
+
   m_h1_basic_info->SetBinContent(BIN_SPILL, event->get_spill_id());
   m_h1_basic_info->SetBinContent(BIN_EVENT, event->get_event_id());
   m_h1_basic_info->AddBinContent(BIN_N_EVT, 1);
 
-  return ProcessEventOnlMon(topNode);
+  int ret = ProcessEventOnlMon(topNode);
+  pthread_mutex_unlock(&mutex);
+  return ret;
 }
 
 int OnlMonClient::End(PHCompositeNode* topNode)

--- a/online/onlmonserver/OnlMonHodo.cc
+++ b/online/onlmonserver/OnlMonHodo.cc
@@ -20,14 +20,14 @@ OnlMonHodo::OnlMonHodo(const HodoType_t type) : m_type(type)
   NumCanvases(2);
   m_n_pl = 2;
   switch (m_type) {
-  case H1X:  m_pl0 = 31;  Name("OnlMonHodoH1X" );  Title("H1X Hodo" );  break;
-  case H2X:  m_pl0 = 37;  Name("OnlMonHodoH2X" );  Title("H2X Hodo" );  break;
-  case H3X:  m_pl0 = 39;  Name("OnlMonHodoH3X" );  Title("H3X Hodo" );  break;
-  case H4X:  m_pl0 = 45;  Name("OnlMonHodoH4X" );  Title("H4X Hodo" );  break;
-  case H1Y:  m_pl0 = 33;  Name("OnlMonHodoH1Y" );  Title("H1Y Hodo" );  break;
-  case H2Y:  m_pl0 = 35;  Name("OnlMonHodoH2Y" );  Title("H2Y Hodo" );  break;
-  case H4Y1: m_pl0 = 41;  Name("OnlMonHodoH4Y1");  Title("H4Y1 Hodo");  break;
-  case H4Y2: m_pl0 = 43;  Name("OnlMonHodoH4Y2");  Title("H4Y2 Hodo");  break;
+  case H1X:  m_pl0 = 31;  Name("OnlMonHodoH1X" );  Title("Hodo: H1X" );  break;
+  case H2X:  m_pl0 = 37;  Name("OnlMonHodoH2X" );  Title("Hodo: H2X" );  break;
+  case H3X:  m_pl0 = 39;  Name("OnlMonHodoH3X" );  Title("Hodo: H3X" );  break;
+  case H4X:  m_pl0 = 45;  Name("OnlMonHodoH4X" );  Title("Hodo: H4X" );  break;
+  case H1Y:  m_pl0 = 33;  Name("OnlMonHodoH1Y" );  Title("Hodo: H1Y" );  break;
+  case H2Y:  m_pl0 = 35;  Name("OnlMonHodoH2Y" );  Title("Hodo: H2Y" );  break;
+  case H4Y1: m_pl0 = 41;  Name("OnlMonHodoH4Y1");  Title("Hodo: H4Y1");  break;
+  case H4Y2: m_pl0 = 43;  Name("OnlMonHodoH4Y2");  Title("Hodo: H4Y2");  break;
   }
 }
 
@@ -148,9 +148,11 @@ int OnlMonHodo::FindAllMonHist()
 int OnlMonHodo::DrawMonitor()
 {
   OnlMonCanvas* can0 = GetCanvas(0);
+  can0->SetStatus(OnlMonCanvas::OK);
   TPad* pad0 = can0->GetMainPad();
   pad0->SetGrid();
   pad0->Divide(1, 2);
+  bool empty_ele = false;
   for (int pl = 0; pl < m_n_pl; pl++) {
     pad0->cd(pl+1);
     h1_ele[pl]->SetLineColor(kBlack);
@@ -158,11 +160,17 @@ int OnlMonHodo::DrawMonitor()
     h1_ele_in[pl]->SetLineColor(kBlue);
     h1_ele_in[pl]->SetFillColor(kBlue-7);
     h1_ele_in[pl]->Draw("same");
+    if (h1_ele[pl]->GetMinimum() == 0) empty_ele = true;
   }
-  can0->AddMessage("OK");
-  can0->SetStatus(OnlMonCanvas::OK);
+  if (empty_ele) {
+    can0->SetStatus(OnlMonCanvas::WARN);
+    can0->AddMessage("No-hit element.");
+  } else {
+    can0->AddMessage("OK");
+  }
 
   OnlMonCanvas* can1 = GetCanvas(1);
+  can1->SetStatus(OnlMonCanvas::OK);
   TPad* pad1 = can1->GetMainPad();
   pad1->SetGrid();
   pad1->Divide(1, 2);
@@ -175,8 +183,7 @@ int OnlMonHodo::DrawMonitor()
     h1_time_in[pl]->SetFillColor(kBlue-7);
     h1_time_in[pl]->Draw("same");
   }
-  can1->AddMessage("OK");
-  can1->SetStatus(OnlMonCanvas::OK);
+  if (can1->GetStatus() == OnlMonCanvas::OK) can1->AddMessage("OK");
 
   return 0;
 }

--- a/online/onlmonserver/OnlMonMainDaq.cc
+++ b/online/onlmonserver/OnlMonMainDaq.cc
@@ -129,6 +129,8 @@ int OnlMonMainDaq::FindAllMonHist()
 int OnlMonMainDaq::DrawMonitor()
 {
   OnlMonCanvas* can = GetCanvas();
+  can->SetStatus(OnlMonCanvas::OK);
+
   TPad* pad = can->GetMainPad();
   pad->SetGrid();
   pad->Divide(1, 3);
@@ -152,25 +154,69 @@ int OnlMonMainDaq::DrawMonitor()
   oss.str("");
   oss << "N of triggered events = " << h1_cnt->GetBinContent(2) << " (all), " << h1_cnt->GetBinContent(3) << " (decoded)";
   pate->AddText(oss.str().c_str());
+
+  double n_all = h1_cnt->GetBinContent(4);
+  double n_bad = h1_cnt->GetBinContent(5);
   oss.str("");
-  oss << "N of Coda physics events = " << h1_cnt->GetBinContent(4) << " (all), " << h1_cnt->GetBinContent(5) << " (bad)";
+  oss << "N of Coda physics events = " << n_all << " (all), " << n_bad << " (bad)";
   pate->AddText(oss.str().c_str());
+
+  n_all = h1_cnt->GetBinContent(6);
+  n_bad = h1_cnt->GetBinContent(7);
   oss.str("");
-  oss << "N of Coda flush events = " << h1_cnt->GetBinContent(6) << " (all), " << h1_cnt->GetBinContent(7) << " (bad)";
+  oss << "N of Coda flush events = " << n_all << " (all), " << n_bad << " (bad)";
   pate->AddText(oss.str().c_str());
+  if (n_bad / n_all > 0.05) {
+    can->SetWorseStatus(OnlMonCanvas::ERROR);
+    can->AddMessage("Errors in >5% of Coda flush events.");
+  } else if (n_bad / n_all > 0.01) {
+    can->SetWorseStatus(OnlMonCanvas::WARN);
+    can->AddMessage("Errors in >1% of Coda flush events.");
+  }
+
+  n_all = h1_cnt->GetBinContent(8);
+  n_bad = h1_cnt->GetBinContent(10);
   oss.str("");
-  oss << "N of Taiwan TDC hits = " << h1_cnt->GetBinContent(8) << " (all), " << h1_cnt->GetBinContent(10) << " (bad)";
+  oss << "N of Taiwan TDC hits = " << n_all << " (all), " << n_bad << " (bad)";
   pate->AddText(oss.str().c_str());
+  if (n_bad / n_all > 0.05) {
+    can->SetWorseStatus(OnlMonCanvas::ERROR);
+    can->AddMessage("Errors in >5% of Taiwan TDC hits.");
+  } else if (n_bad / n_all > 0.01) {
+    can->SetWorseStatus(OnlMonCanvas::WARN);
+    can->AddMessage("Errors in >1% of Taiwan TDC hits.");
+  }
+
+  n_all = h1_cnt->GetBinContent(9);
+  n_bad = h1_cnt->GetBinContent(11);
   oss.str("");
-  oss << "N of v1495 TDC hits = " << h1_cnt->GetBinContent(9) << " (all), " << h1_cnt->GetBinContent(11) << " (bad)";
+  oss << "N of v1495 TDC hits = " << n_all << " (all), " << n_bad << " (bad)";
   pate->AddText(oss.str().c_str());
+  if (n_bad / n_all > 0.05) {
+    can->SetWorseStatus(OnlMonCanvas::ERROR);
+    can->AddMessage("Errors in >5% of v1495 TDC hits.");
+  } else if (n_bad / n_all > 0.01) {
+    can->SetWorseStatus(OnlMonCanvas::WARN);
+    can->AddMessage("Errors in >1% of v1495 TDC hits.");
+  }
+
+  n_all         = h1_cnt->GetBinContent(12);
+  double n_d1ad = h1_cnt->GetBinContent(13);
+  double n_d2ad = h1_cnt->GetBinContent(14);
+  double n_d3ad = h1_cnt->GetBinContent(15);
   oss.str("");
-  oss << "N of v1495 events = " << h1_cnt->GetBinContent(12) << " (all), " << h1_cnt->GetBinContent(13) << " (d1ad), " << h1_cnt->GetBinContent(14) << " (d2ad), " << h1_cnt->GetBinContent(15) << " (d3ad)";
+  oss << "N of v1495 events = " << n_all << " (all), " << n_d1ad << " (d1ad), " << n_d2ad << " (d2ad), " << n_d3ad << " (d3ad)";
   pate->AddText(oss.str().c_str());
   pate->Draw();
+  if ((n_d1ad + n_d2ad + n_d3ad) / n_all > 0.05) {
+    can->SetWorseStatus(OnlMonCanvas::ERROR);
+    can->AddMessage("Errors in >5% of v1495 events.");
+  } else if ((n_d1ad + n_d2ad + n_d3ad) / n_all > 0.01) {
+    can->SetWorseStatus(OnlMonCanvas::WARN);
+    can->AddMessage("Errors in >1% of v1495 events.");
+  }
 
-  can->AddMessage("OK");
-  can->SetStatus(OnlMonCanvas::OK);
+  if (can->GetStatus() == OnlMonCanvas::OK) can->AddMessage("OK");
 
   return 0;
 }

--- a/online/onlmonserver/OnlMonProp.cc
+++ b/online/onlmonserver/OnlMonProp.cc
@@ -19,8 +19,8 @@ OnlMonProp::OnlMonProp(const PropType_t type) : m_type(type)
 {
   NumCanvases(2);
   switch (m_type) {
-  case P1 :  m_pl0 = 47;  Name("OnlMonPropP1" );  Title( "P1 Prop Tube");  break;
-  case P2 :  m_pl0 = 51;  Name("OnlMonPropP2" );  Title( "P2 Prop Tube");  break;
+  case P1 :  m_pl0 = 47;  Name("OnlMonPropP1" );  Title( "Prop Tube: P1");  break;
+  case P2 :  m_pl0 = 51;  Name("OnlMonPropP2" );  Title( "Prop Tube: P2");  break;
   }
 }
 

--- a/online/onlmonserver/OnlMonServer.cc
+++ b/online/onlmonserver/OnlMonServer.cc
@@ -26,6 +26,7 @@ static TThread *ServerThread = NULL;
 std::string OnlMonServer::m_out_dir    = "/data2/e1039/onlmon/plots";
 std::string OnlMonServer::m_mon_host   = "localhost";
 int         OnlMonServer::m_mon_port   = 9081;
+int         OnlMonServer::m_mon_port_0 = 9081;
 int         OnlMonServer::m_mon_n_port = 5;
 
 OnlMonServer *OnlMonServer::instance()
@@ -110,7 +111,7 @@ void* OnlMonServer::FuncServer(void* arg)
   sleep(5);
   TServerSocket* ss = 0;
   int port;
-  for (port = m_mon_port; port < m_mon_port + m_mon_n_port; port++) {
+  for (port = m_mon_port_0; port < m_mon_port_0 + m_mon_n_port; port++) {
     if (se->CloseExistingServer(port)) continue; // Not try to use the port closed now
     ss = new TServerSocket(port, kTRUE);
     if (ss->IsValid()) break;
@@ -189,8 +190,9 @@ void OnlMonServer::HandleConnection(TSocket* sock)
         break;
       } else if (msg_str == "Suicide") {
         cout << "OnlMonServer::HandleConnection():  Suicide." << endl;
-        m_go_end = true;
         sock->Send("OK");
+        m_go_end = true;
+        break;
       } else if (msg_str == "Ping") {
         if (Verbosity() > 2) cout << "  Ping." << endl;
         sock->Send("Pong");
@@ -215,9 +217,8 @@ void OnlMonServer::HandleConnection(TSocket* sock)
 
         sock->Send("Finished");
       } else {
-        if (Verbosity() > 2) cout << "  Unexpected string message (" << msg_str << ").  Ignore it." << endl;
-        delete mess;
-        mess = 0;
+        //if (Verbosity() > 2) 
+        cout << "  Unexpected string message (" << msg_str << ").  Ignore it." << endl;
       }
     } else {
       cerr << "OnlMonServer::HandleConnection():  Unexpected message ("

--- a/online/onlmonserver/OnlMonServer.h
+++ b/online/onlmonserver/OnlMonServer.h
@@ -9,8 +9,9 @@ class OnlMonServer : public Fun4AllServer
 {
   static std::string m_out_dir;
   static std::string m_mon_host;
-  static int         m_mon_port;
-  static int         m_mon_n_port;
+  static int         m_mon_port; //< The port being used
+  static int         m_mon_port_0; //< The 1st number of available ports
+  static int         m_mon_n_port; //< The number of available ports
 
   bool m_go_end;
 
@@ -21,10 +22,12 @@ class OnlMonServer : public Fun4AllServer
   static void SetOutDir  (const std::string dir)  { m_out_dir    = dir ; }
   static void SetHost    (const std::string host) { m_mon_host   = host; }
   static void SetPort    (const int port)         { m_mon_port   = port; }
+  static void SetPort0   (const int port)         { m_mon_port_0 = port; }
   static void SetNumPorts(const int num )         { m_mon_n_port = num ; }
   static std::string GetOutDir  () { return m_out_dir   ; }
   static std::string GetHost    () { return m_mon_host  ; }
   static int         GetPort    () { return m_mon_port  ; }
+  static int         GetPort0   () { return m_mon_port_0; }
   static int         GetNumPorts() { return m_mon_n_port; }
 
   void StartServer();

--- a/online/onlmonserver/OnlMonServer.h
+++ b/online/onlmonserver/OnlMonServer.h
@@ -40,7 +40,7 @@ class OnlMonServer : public Fun4AllServer
   OnlMonServer(const std::string &name = "OnlMonServer");
 
 #ifndef __CINT__
-  pthread_mutex_t mutex;
+  pthread_mutex_t mutex; //< Control the access to subsystem histograms.
   pthread_t serverthreadid;
 #endif
 

--- a/online/onlmonserver/OnlMonServer.h
+++ b/online/onlmonserver/OnlMonServer.h
@@ -8,8 +8,9 @@ class TSocket;
 class OnlMonServer : public Fun4AllServer
 {
   static std::string m_out_dir;
-  static std::string m_onl_mon_host;
-  static int         m_onl_mon_port;
+  static std::string m_mon_host;
+  static int         m_mon_port;
+  static int         m_mon_n_port;
 
   bool m_go_end;
 
@@ -17,15 +18,17 @@ class OnlMonServer : public Fun4AllServer
   static OnlMonServer *instance();
   virtual ~OnlMonServer();
 
-  static void SetOutDir(const std::string dir)  { m_out_dir      = dir ; }
-  static void SetHost  (const std::string host) { m_onl_mon_host = host; }
-  static void SetPort  (const int port)         { m_onl_mon_port = port; }
-  static std::string GetOutDir() { return m_out_dir; }
-  static std::string GetHost  () { return m_onl_mon_host; }
-  static int         GetPort  () { return m_onl_mon_port; }
+  static void SetOutDir  (const std::string dir)  { m_out_dir    = dir ; }
+  static void SetHost    (const std::string host) { m_mon_host   = host; }
+  static void SetPort    (const int port)         { m_mon_port   = port; }
+  static void SetNumPorts(const int num )         { m_mon_n_port = num ; }
+  static std::string GetOutDir  () { return m_out_dir   ; }
+  static std::string GetHost    () { return m_mon_host  ; }
+  static int         GetPort    () { return m_mon_port  ; }
+  static int         GetNumPorts() { return m_mon_n_port; }
 
   void StartServer();
-  bool CloseExistingServer();
+  bool CloseExistingServer(const int port);
   static void* FuncServer(void* arg);
   void HandleConnection(TSocket* sock);
   void SetGoEnd(const bool val) { m_go_end = val; }

--- a/online/onlmonserver/OnlMonUI.cc
+++ b/online/onlmonserver/OnlMonUI.cc
@@ -50,7 +50,7 @@ OnlMonUI::OnlMonUI(OnlMonClientList_t* list) :
 void OnlMonUI::BuildInterface()
 {
   TGMainFrame* frame = new TGMainFrame(gClient->GetRoot(), 200, 900);
-  //frame->SetWMPosition(50, 50); // This function doesn't work...
+  frame->SetWMPosition(0, 0); // Often ignored by the window manager
 
   TGTextView* head = new TGTextView(frame, 200, 50, "E1039 OnlMon Selector");
   frame->AddFrame(head); 

--- a/online/onlmonserver/OnlMonUI.cc
+++ b/online/onlmonserver/OnlMonUI.cc
@@ -49,7 +49,8 @@ OnlMonUI::OnlMonUI(OnlMonClientList_t* list) :
 
 void OnlMonUI::BuildInterface()
 {
-  TGMainFrame* frame = new TGMainFrame(gClient->GetRoot(), 200, 800);
+  TGMainFrame* frame = new TGMainFrame(gClient->GetRoot(), 200, 900);
+  //frame->SetWMPosition(50, 50); // This function doesn't work...
 
   TGTextView* head = new TGTextView(frame, 200, 50, "E1039 OnlMon Selector");
   frame->AddFrame(head); 

--- a/online/onlmonserver/OnlMonUI.cc
+++ b/online/onlmonserver/OnlMonUI.cc
@@ -1,4 +1,6 @@
 #include <iostream>
+#include <sys/stat.h>
+#include <TSystem.h>
 #include <TGFrame.h>
 #include <TGTextView.h>
 #include <TGButton.h>
@@ -23,8 +25,17 @@ void OnlMonUI::BuildInterface()
   TGMainFrame* frame = new TGMainFrame(gClient->GetRoot(), 200, 900);
   frame->SetWMPosition(0, 0); // Often ignored by the window manager
 
-  TGTextView* head = new TGTextView(frame, 200, 50, "E1039 OnlMon Selector");
-  frame->AddFrame(head); 
+  string fn_img = gSystem->Getenv("E1039_RESOURCE");
+  fn_img += "/image/onlmon_banner.png";
+  struct stat st;
+  if (stat(fn_img.c_str(), &st) == 0) {
+    TGPictureButton* head2 = new TGPictureButton(frame, fn_img.c_str());
+    head2->SetCommand("cout << \">> E1039 Online Monitor <<\" << endl;");
+    frame->AddFrame(head2);
+  } else {
+    TGTextView* head = new TGTextView(frame, 200, 40, "E1039 Online Monitor");
+    frame->AddFrame(head); 
+  }
 
   TGTextButton*  button[99];
   for (unsigned int ii = 0; ii < m_list_omc->size(); ii++) {

--- a/online/onlmonserver/OnlMonUI.h
+++ b/online/onlmonserver/OnlMonUI.h
@@ -10,9 +10,7 @@ class OnlMonUI {
   bool m_auto_cycle;
   int  m_interval; //< Cycle interval in second
   pthread_t m_thread_id;
-  OnlMonClientList_t m_list_omc;
-
-  TGTextButton*  button[99];
+  OnlMonClientList_t* m_list_omc;
 
  public:
   OnlMonUI(OnlMonClientList_t* list);
@@ -22,11 +20,11 @@ class OnlMonUI {
   bool GetAutoCycleFlag()    { return m_auto_cycle; }
   void SetCycleInterval(int val) { m_interval = val; }
   int  GetCycleInterval() { return m_interval; }
-
-  void BuildInterface();
-  void StartAutoCycle();
+  void Run();
 
  protected:
+  void BuildInterface();
+  void StartAutoCycle();
   static void* FuncAutoCycle(void* arg);
   void RunAutoCycle();
 };

--- a/online/onlmonserver/OnlMonV1495.cc
+++ b/online/onlmonserver/OnlMonV1495.cc
@@ -20,14 +20,14 @@ OnlMonV1495::OnlMonV1495(const HodoType_t type, const int lvl) : m_type(type), m
   NumCanvases(2);
   m_n_pl = 2;
   switch (m_type) {
-  case H1X:  m_pl0 = 31;  Name("OnlMonV1495H1X" );  Title("H1X v1495" );  break;
-  case H2X:  m_pl0 = 37;  Name("OnlMonV1495H2X" );  Title("H2X v1495" );  break;
-  case H3X:  m_pl0 = 39;  Name("OnlMonV1495H3X" );  Title("H3X v1495" );  break;
-  case H4X:  m_pl0 = 45;  Name("OnlMonV1495H4X" );  Title("H4X v1495" );  break;
-  case H1Y:  m_pl0 = 33;  Name("OnlMonV1495H1Y" );  Title("H1Y v1495" );  break;
-  case H2Y:  m_pl0 = 35;  Name("OnlMonV1495H2Y" );  Title("H2Y v1495" );  break;
-  case H4Y1: m_pl0 = 41;  Name("OnlMonV1495H4Y1");  Title("H4Y1 v1495");  break;
-  case H4Y2: m_pl0 = 43;  Name("OnlMonV1495H4Y2");  Title("H4Y2 v1495");  break;
+  case H1X:  m_pl0 = 31;  Name("OnlMonV1495H1X" );  Title("V1495: H1X" );  break;
+  case H2X:  m_pl0 = 37;  Name("OnlMonV1495H2X" );  Title("V1495: H2X" );  break;
+  case H3X:  m_pl0 = 39;  Name("OnlMonV1495H3X" );  Title("V1495: H3X" );  break;
+  case H4X:  m_pl0 = 45;  Name("OnlMonV1495H4X" );  Title("V1495: H4X" );  break;
+  case H1Y:  m_pl0 = 33;  Name("OnlMonV1495H1Y" );  Title("V1495: H1Y" );  break;
+  case H2Y:  m_pl0 = 35;  Name("OnlMonV1495H2Y" );  Title("V1495: H2Y" );  break;
+  case H4Y1: m_pl0 = 41;  Name("OnlMonV1495H4Y1");  Title("V1495: H4Y1");  break;
+  case H4Y2: m_pl0 = 43;  Name("OnlMonV1495H4Y2");  Title("V1495: H4Y2");  break;
   }
 }
 


### PR DESCRIPTION
This pull request contains various types of updates that I implemented during my Fermilab stay in June & July.  I closely looked into the data taken and the behavior of the decoding process.  The updated code can be compiled fine on seaquestdaq01, and is running to auto-decode every run.

Below is the major part of these updates.
* The decoder discards all flush events that come before the 1st BOS event per run, since such events contain no hit by design and thus not useful.
* The OnlMonMainDaq monitor shows a warning message when the error rates of events or hits are high.
* The I/O access of OnlMon histograms is protected by MUTEX. Thus the OnlMon server will no longer crash when accessed frequently.
* The status of the decoder process per run (i.e. started and finished) is recorded to MySQL DB via "DecoStatusDb".
