### PR TITLE
Updates on the online code in Aug 2019

### DIFF
--- a/online/decoder_maindaq/CodaInputManager.cc
+++ b/online/decoder_maindaq/CodaInputManager.cc
@@ -42,7 +42,7 @@ int CodaInputManager::OpenFile(const std::string fname, const int file_size_min,
     sleep (sec_wait);
   }
   if (! size_ok) {
-    cout << "File size not enough (<" << file_size_min << ").  Wait timeout.  Exiting..." << endl;
+    cout << "File size not enough (" << m_file_size << " < " << file_size_min << ").  Wait timeout.  Exiting..." << endl;
     return 2;
   }
   

--- a/online/macros/Fun4MainDaq.C
+++ b/online/macros/Fun4MainDaq.C
@@ -74,3 +74,11 @@ int Fun4MainDaq(const int run=46, const int nevent=0, const bool is_online=false
   cout << "Fun4MainDaq Done!" << endl;
   return 0;
 }
+
+void TestOnlMonServer()
+{
+  gSystem->Load("libonlmonserver.so");
+  OnlMonServer* se = OnlMonServer::instance();
+  //se->Verbosity(1);
+  se->StartServer();
+}

--- a/online/onlmonserver/OnlMonMainDaq.cc
+++ b/online/onlmonserver/OnlMonMainDaq.cc
@@ -11,6 +11,7 @@
 #include <phool/getClass.h>
 #include "OnlMonServer.h"
 #include "OnlMonMainDaq.h"
+#include "UtilHist.h"
 using namespace std;
 
 OnlMonMainDaq::OnlMonMainDaq()
@@ -28,6 +29,7 @@ int OnlMonMainDaq::InitOnlMon(PHCompositeNode* topNode)
 int OnlMonMainDaq::InitRunOnlMon(PHCompositeNode* topNode)
 {
   h1_trig = new TH1D("h1_trig", "Trigger Status;Trigger;N of events", 10, 0.5, 10.5);
+  h1_n_taiwan = new TH1D("h1_n_taiwan", "Taiwan TDC Status;N of boards/event;N of events", 200, -0.5, 199.5);
   h1_evt_qual = new TH1D("h1_evt_qual", "Event Status;Event-quality bit;N of events", 33, -0.5, 32.5);
   h1_flag_v1495 = new TH1D("h1_flag_v1495", "V1495 Status;v1495 status bit; N of v1495 events", 5, -0.5, 4.5);
   h1_cnt = new TH1D("h1_cnt", ";Type;Count", 15, 0.5, 15.5);
@@ -57,6 +59,7 @@ int OnlMonMainDaq::InitRunOnlMon(PHCompositeNode* topNode)
   h1_flag_v1495->GetXaxis()->SetBinLabel(5, "Other");
 
   RegisterHist(h1_trig);
+  RegisterHist(h1_n_taiwan);
   RegisterHist(h1_evt_qual);
   RegisterHist(h1_flag_v1495);
   RegisterHist(h1_cnt);
@@ -97,6 +100,8 @@ int OnlMonMainDaq::ProcessEventOnlMon(PHCompositeNode* topNode)
   h1_cnt->SetBinContent(14, run->get_n_v1495_d2ad   ());
   h1_cnt->SetBinContent(15, run->get_n_v1495_d3ad   ());
 
+  h1_n_taiwan->Fill(event->get_n_board_taiwan());
+
   int dq = event->get_data_quality();
   if (dq == 0) h1_evt_qual->Fill(0);
   for (int bit = 0; bit < 32; bit++) {
@@ -120,6 +125,7 @@ int OnlMonMainDaq::EndOnlMon(PHCompositeNode* topNode)
 int OnlMonMainDaq::FindAllMonHist()
 {
   h1_trig       = (TH1*)FindMonObj("h1_trig");
+  h1_n_taiwan   = (TH1*)FindMonObj("h1_n_taiwan");
   h1_evt_qual   = (TH1*)FindMonObj("h1_evt_qual");
   h1_flag_v1495 = (TH1*)FindMonObj("h1_flag_v1495");
   h1_cnt        = (TH1*)FindMonObj("h1_cnt");
@@ -128,6 +134,8 @@ int OnlMonMainDaq::FindAllMonHist()
 
 int OnlMonMainDaq::DrawMonitor()
 {
+  UtilHist::AutoSetRange(h1_n_taiwan);
+
   OnlMonCanvas* can = GetCanvas();
   can->SetStatus(OnlMonCanvas::OK);
 
@@ -144,7 +152,12 @@ int OnlMonMainDaq::DrawMonitor()
   pad12->cd();  h1_flag_v1495->Draw();
 
   pad->cd(2);
-  h1_evt_qual->Draw();
+  TPad* pad21 = new TPad("pad21", "", 0.0, 0.0, 0.7, 1.0);
+  TPad* pad22 = new TPad("pad22", "", 0.7, 0.0, 1.0, 1.0);
+  pad21->Draw();
+  pad22->Draw();
+  pad21->cd();  h1_evt_qual->Draw();
+  pad22->cd();  h1_n_taiwan->Draw();
 
   pad->cd(3);
   TPaveText* pate = new TPaveText(.02, .02, .98, .98);

--- a/online/onlmonserver/OnlMonMainDaq.h
+++ b/online/onlmonserver/OnlMonMainDaq.h
@@ -5,6 +5,7 @@
 
 class OnlMonMainDaq: public OnlMonClient {
   TH1* h1_trig;
+  TH1* h1_n_taiwan;
   TH1* h1_evt_qual;
   TH1* h1_flag_v1495;
   TH1* h1_cnt;

--- a/online/onlmonserver/OnlMonServer.cc
+++ b/online/onlmonserver/OnlMonServer.cc
@@ -150,10 +150,11 @@ void* OnlMonServer::FuncServer(void* arg)
     adr.Print();
   }
   UInt_t ip0 = adr.GetAddress();
-  if ((ip0 >> 24) == (192 << 8) + 168) {
+  if ((ip0 >> 16) == (192 << 8) + 168) {
     se->HandleConnection(s0);
   } else {
-    cout << "OnlMonServer::FuncServer():  Ignore a connection from WAN." << endl;
+    cout << "OnlMonServer::FuncServer():  Ignore a connection from WAN.\n  ";
+    adr.Print();
   }
   
   delete s0;

--- a/online/onlmonserver/OnlMonServer.cc
+++ b/online/onlmonserver/OnlMonServer.cc
@@ -144,12 +144,18 @@ void* OnlMonServer::FuncServer(void* arg)
   // mutex protected since writing of histo
   // to outgoing buffer and updating by other thread do not
   // go well together
+  TInetAddress adr = s0->GetInetAddress();
   if (se->Verbosity() > 2) {
-    TInetAddress adr = s0->GetInetAddress();
-    cout << "got connection from " << endl;
+    cout << "got connection from\n  ";
     adr.Print();
   }
-  se->HandleConnection(s0);
+  UInt_t ip0 = adr.GetAddress();
+  if ((ip0 >> 24) == (192 << 8) + 168) {
+    se->HandleConnection(s0);
+  } else {
+    cout << "OnlMonServer::FuncServer():  Ignore a connection from WAN." << endl;
+  }
+  
   delete s0;
   //s0->Close();
   if (se->GetGoEnd()) {

--- a/online/onlmonserver/OnlMonServer.cc
+++ b/online/onlmonserver/OnlMonServer.cc
@@ -150,7 +150,7 @@ void* OnlMonServer::FuncServer(void* arg)
     adr.Print();
   }
   UInt_t ip0 = adr.GetAddress();
-  if ((ip0 >> 16) == (192 << 8) + 168) {
+  if ((ip0 >> 16) == (192 << 8) + 168 || ip0 == (127 << 24) + 1) {
     se->HandleConnection(s0);
   } else {
     cout << "OnlMonServer::FuncServer():  Ignore a connection from WAN.\n  ";

--- a/script/setup-install.sh
+++ b/script/setup-install.sh
@@ -8,7 +8,7 @@ if [ -z "$1" ] ; then
 elif [ "X$1" = 'Xauto' ] ; then
     DIR_INST=$(readlink -f $DIR_SCRIPT/../../e1039-core-inst)
 else
-    DIR_INST=$(readlink -f "$1")
+    DIR_INST=$(readlink -m "$1")
 fi
 echo "Use this installation directory:"
 echo "  $DIR_INST"


### PR DESCRIPTION
The online code (decoder & online monitor) was updated as follows in Aug 2019.  It is running fine on seaquestdaq01 as the online-version library (/data2/e1039/core-online).  It is not urgent but now I like to merge the updates.
 
1. Daemon4MainDaq.C, which starts a decoding process per run, now checks and waits until the Coda file directory is mounted.
2. The online monitor for Main DAQ (OnlMonMainDaq) shows the number of Taiwan TDC boards per event.  A deviation of this number tells us a problem on board(s).
3. The OnlMon server (OnlMonServer) rejects all client connections that come from WAN.  It has improved the security and the stability (where the server process died due to port scans multiple times in the past), although such connections should be blocked first by the firewall.
