### PR TITLE
Updates for better stability of MainDAQ decoder.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -75,9 +75,12 @@ do
 done
 
 
-( ## Install all macro files.
+(
+    echo "================================================================"
+    echo "Install all macros to $install/macros/."
     cd $src
     find . -type d -regex '.*/macros*' | while read DIR_SRC ; do
+	echo "  $DIR_SRC"
 	DIR_DEST=$install/macros/$(dirname $DIR_SRC)
 	mkdir -p $DIR_DEST
 	cp -p $DIR_SRC/* $DIR_DEST

--- a/build.sh
+++ b/build.sh
@@ -74,4 +74,14 @@ do
 	fi
 done
 
+
+( ## Install all macro files.
+    cd $src
+    find . -type d -regex '.*/macros*' | while read DIR_SRC ; do
+	DIR_DEST=$install/macros/$(dirname $DIR_SRC)
+	mkdir -p $DIR_DEST
+	cp -p $DIR_SRC/* $DIR_DEST
+    done
+)
+
 cd $build

--- a/online/decoder_maindaq/CodaInputManager.cc
+++ b/online/decoder_maindaq/CodaInputManager.cc
@@ -47,7 +47,7 @@ int CodaInputManager::OpenFile(const std::string fname, const int file_size_min,
   }
   
   if (m_verb) {
-    cout << "Loading " << fname << "...\n";
+    cout << "Loading " << fname << "..." << endl;
   }
   CloseFile();
   int ret = evOpen((char*)fname.c_str(), (char*)"r", &m_handle);

--- a/online/decoder_maindaq/CodaInputManager.h
+++ b/online/decoder_maindaq/CodaInputManager.h
@@ -16,7 +16,7 @@ class CodaInputManager {
   std::string m_fname;
   long int m_file_size;
   int m_event_count;
-  int event_words[buflen];
+  int m_event_words[buflen];
 
  public:
   CodaInputManager();
@@ -28,8 +28,9 @@ class CodaInputManager {
   void ForceEnd () { m_go_end = true; }
   bool IsEnded  () { return m_go_end; }
 
-  int OpenFile(const std::string fname, const int file_size_min=0, const int sec_wait=10, const int n_wait=0, const int n_evt_pre_read=0);
+  int OpenFile(const std::string fname, const int file_size_min=0, const int sec_wait=10, const int n_wait=0);
   int CloseFile();
+  bool JumpCodaEvent(unsigned int& coda_id, int*& event_words, const int n_evt);
   bool NextCodaEvent(unsigned int& coda_id, int*& event_words);
 
  private:

--- a/online/decoder_maindaq/DbUpSpill.h
+++ b/online/decoder_maindaq/DbUpSpill.h
@@ -13,6 +13,7 @@ class DbUpSpill: public SubsysReco {
   int End(PHCompositeNode *topNode);
 
  private:
+  void ClearTable(const char* table_name, const int run_id);
   void UploadToSpillTable(SQSpill* spi);
   void UploadToScalerTable(SQSpill* spi, const std::string boseos);
   void UploadToSlowContTable(SQSpill* spi);

--- a/online/decoder_maindaq/MainDaqParser.cc
+++ b/online/decoder_maindaq/MainDaqParser.cc
@@ -88,7 +88,7 @@ int MainDaqParser::ParseOneSpill()
         coda->ForceEnd(); //if (dec_par.verbose) printf ("End Event Processed\n");
         break;
       default:
-        cerr << "!!ERROR!! Uncovered Coda event type: " << evt_type_id << ".  Exit.\n";
+        cerr << "!!ERROR!! Uncovered Coda event type: " << evt_type_id << ".  Exit." << endl;
         return false;
       }
       break;
@@ -103,7 +103,7 @@ int MainDaqParser::ParseOneSpill()
       }
       break;
     default: // If no match to any given case, print it and exit.
-      cerr << "!!ERROR!!  Uncovered Coda event type: " << evt_type_id << ".  Exit\n";
+      cerr << "!!ERROR!!  Uncovered Coda event type: " << evt_type_id << ".  Exit." << endl;
       return false;
     }
     if (ret != 0) {
@@ -130,7 +130,7 @@ int MainDaqParser::End()
          << "  Real  events:  all = " << run_data.n_evt_all << ", decoded = " << run_data.n_evt_dec << "\n"
          << "  TDC   hits: total = " << run_data.n_hit   << ", bad = " << run_data.n_hit_bad << "\n"
          << "  v1495 hits: total = " << run_data.n_t_hit << ", bad = " << run_data.n_t_hit_bad << "\n"
-         << "  Real decoding time: " << (dec_par.timeEnd - dec_par.timeStart) << "\n";
+         << "  Real decoding time: " << (dec_par.timeEnd - dec_par.timeStart) << endl;
   }
   return 0;
 }
@@ -148,7 +148,7 @@ int MainDaqParser::ProcessCodaPrestart(int* words)
     dec_par.runID = run_data.run_id = words[3];
     // int runType = words[4];
 
-    cout << "  ProcessCodaPrestart " << dec_par.runID << " " << run_data.utime_b << " " << dec_par.sampling << "\n";
+    cout << "  ProcessCodaPrestart " << dec_par.runID << " " << run_data.utime_b << " " << dec_par.sampling << endl;
 
     dec_par.InitMapper();
     coda->SetRunNumber(dec_par.runID);
@@ -159,7 +159,7 @@ int MainDaqParser::ProcessCodaPrestart(int* words)
 int MainDaqParser::ProcessCodaFee(int* words)
 {
   if (words[1] != FEE_EVENT) {
-    cerr << "!!ERROR!!  Not FEE_EVENT in case of FEE_PREFIX: " << words[1] << ".  Exit.\n";
+    cerr << "!!ERROR!!  Not FEE_EVENT in case of FEE_PREFIX: " << words[1] << ".  Exit." << endl;
     return 1;
   }
   if (words[0] > 8) { // Process only if there is content
@@ -219,7 +219,7 @@ int MainDaqParser::ProcessCodaFeeBoard(int* words)
 	       << " " << data.falling_enabled << " " << data.segmentation
 	       << " " << data.multihit_elim_enabled << " " << data.updating_enabled
 	       << " " << data.elim_window << " " << data.selectWindow << " "
-	       << data.lowLimit << " " << data.highLimit << "\n";
+	       << data.lowLimit << " " << data.highLimit << endl;
 	}
     }
 
@@ -251,7 +251,7 @@ int MainDaqParser::ProcessCodaFeePrescale(int* words)
     for (int ii = 0; ii < 10; ii++) cout << " " << run_data.trig_bit[ii];
     cout << "\n  feeP ";
     for (int ii = 0; ii <  8; ii++) cout << " " << run_data.prescale[ii];
-    cout << "\n";
+    cout << endl;
   }
   return 0;
 }
@@ -309,7 +309,7 @@ int MainDaqParser::ProcessCodaPhysics(int* words)
     break;
   default: // Awaiting further event types
     ret = -1;
-    cout << "Unknown event code: " << eventCode << ".  Ignore.\n";
+    cout << "Unknown event code: " << eventCode << ".  Ignore." << endl;
     break;
   }
   if (ret != 0 || dec_par.coda_phys_evt_status != 0) run_data.n_phys_evt_bad++;
@@ -332,7 +332,7 @@ int MainDaqParser::ProcessPhysRunDesc(int* words)
   }
   run_data.run_desc = desc;
   run_data.n_run_desc++;
-  cout << "  run desc: " << desc.length() << " chars.\n";
+  cout << "  run desc: " << desc.length() << " chars." << endl;
   return 0;
 }
 
@@ -357,7 +357,7 @@ int MainDaqParser::ProcessPhysPrestart(int* words)
       }
     }
     if (line.length() > 0) list_line.push_back(line);
-    else cerr << "Unexpectedly line.length() == 0.\n";
+    else cerr << "Unexpectedly line.length() == 0." << endl;
     for (unsigned int ii = 0; ii < list_line.size(); ii++) {
       cout << "  pre " << list_line[ii] << endl;
     }
@@ -400,7 +400,7 @@ int MainDaqParser::ProcessPhysSlow(int* words)
     }
   }
   if (line.length() > 0) list_line.push_back(line);
-  else cout << "WARNING: Unexpectedly line.length() == 0.\n";
+  else cout << "WARNING: Unexpectedly line.length() == 0." << endl;
   
   std::vector<SlowControlData> list_data; //< temporary list
   for (unsigned int ii = 0; ii < list_line.size(); ii++) {
@@ -434,7 +434,7 @@ int MainDaqParser::ProcessPhysSlow(int* words)
     spill_data->list_slow_cont.push_back(*data); // put into the global list
     spill_data->n_slow++;
   }
-  if (dec_par.verbose) cout << "  spill " << dec_par.spillID_slow << ", target " << (short)dec_par.targPos_slow << "\n";
+  if (dec_par.verbose) cout << "  spill " << dec_par.spillID_slow << ", target " << (short)dec_par.targPos_slow << endl;
   // In the past decoder, almost all variables obtained here are inserted into
   // the Beam, HV, Environment and Target tables according to "type".
   return 0;
@@ -465,7 +465,7 @@ int MainDaqParser::ProcessPhysSpillCounter(int* words)
   /// Replace spillID with spillID_cntr at BOS.
   dec_par.spillID_cntr = atoi(spillNum) + 1;
   if (dec_par.verbose) {
-    cout << "Spill Counter @ coda = " << dec_par.codaID << ":  spill = " << dec_par.spillID_cntr << "\n";
+    cout << "Spill Counter @ coda = " << dec_par.codaID << ":  spill = " << dec_par.spillID_cntr << endl;
   }
   run_data.n_spill++;
   return 0;
@@ -478,7 +478,7 @@ int MainDaqParser::ProcessPhysBOSEOS(int* words, const int type)
     dec_par.has_1st_bos = true;
     dec_par.at_bos      = true;
     if (PackOneSpillData() != 0) { // if (SubmitEventData() != 0) {
-      cout << "Error submitting data.  Exiting...\n";
+      cout << "Error submitting data.  Exiting..." << endl;
       return 1;
     }
 
@@ -505,7 +505,7 @@ int MainDaqParser::ProcessPhysBOSEOS(int* words, const int type)
   }
 
   if (dec_par.verbose) {
-    cout << type_str << " @ coda " << dec_par.codaID << ": spill " << dec_par.spillID << ".\n";
+    cout << type_str << " @ coda " << dec_par.codaID << ": spill " << dec_par.spillID << "." << endl;
   }
   dec_par.spillType = type;
 
@@ -515,7 +515,7 @@ int MainDaqParser::ProcessPhysBOSEOS(int* words, const int type)
     int rocEvLength = words[idx];
     int idx_roc_end = idx + rocEvLength; // inclusive endpoint
     if ( (rocEvLength + idx) > evLength) {
-      cout << "Word limit error: " << rocEvLength << " + " << idx << " > " << evLength <<"\n";
+      cout << "Word limit error: " << rocEvLength << " + " << idx << " > " << evLength << endl;
       return 1;
     }
     idx++;
@@ -535,7 +535,7 @@ int MainDaqParser::ProcessPhysBOSEOS(int* words, const int type)
 	data->eos_vme_time = codaEvVmeTime;
 	data->n_eos_spill++;
       }
-      if (dec_par.verbose > 2) cout << "  " << type_str << " spill: " << dec_par.spillID << " " << dec_par.runID << " " << dec_par.codaID << " " << (short)dec_par.targPos << " " << codaEvVmeTime << "\n";
+      if (dec_par.verbose > 2) cout << "  " << type_str << " spill: " << dec_par.spillID << " " << dec_par.runID << " " << dec_par.codaID << " " << (short)dec_par.targPos << " " << codaEvVmeTime << endl;
     }
     /// Skip ROC 25 in END_SPILL since unknown words are placed for debug by Xinkun(?).
     if (type != TYPE_BOS && rocID == 25) idx = idx_roc_end + 1;

--- a/online/macros/Daemon4MainDaq.C
+++ b/online/macros/Daemon4MainDaq.C
@@ -33,9 +33,21 @@ void StartDecoder(const int run, const int n_evt=0, const bool is_online=true)
   gSystem->mkdir(oss.str().c_str(), true);
   oss << "/log_" << setfill('0') << setw(6) << run << ".txt";
   string fn_log = oss.str();
+  if (! gSystem->AccessPathName(fn_log.c_str())) { // if exists
+    for (int ii = 1; true; ii++) {
+      oss.str("");
+      oss << fn_log << "." << ii;
+      if (gSystem->AccessPathName(oss.str().c_str())) {
+        cout << "Rename the existing log file with suffix=" << ii << "." << endl;
+        gSystem->Rename(fn_log.c_str(), oss.str().c_str());
+        break;
+      }
+    }
+  }
+
   oss.str("");
   oss << "root.exe -b -q '" << gSystem->Getenv("E1039_CORE")
-      << "/macros/Fun4MainDaq.C(" << run << ", " << n_evt << ", " << is_online << ")' &>" << fn_log << " &";
+      << "/macros/online/Fun4MainDaq.C(" << run << ", " << n_evt << ", " << is_online << ")' &>" << fn_log << " &";
 
   cout << "Start the decoder for run " << run << ":\n"
        << "  Log file = " << fn_log << "\n"

--- a/online/macros/Fun4MainDaq.C
+++ b/online/macros/Fun4MainDaq.C
@@ -7,6 +7,7 @@ R__LOAD_LIBRARY(libdecoder_maindaq)
 
 int Fun4MainDaq(const int run=46, const int nevent=0, const bool is_online=false)
 {
+  gSystem->Umask(0002);
   gSystem->Load("libinterface_main.so");
   gSystem->Load("libdecoder_maindaq.so");
   gSystem->Load("libonlmonserver.so");

--- a/online/onlmonserver/OnlMonClient.cc
+++ b/online/onlmonserver/OnlMonClient.cc
@@ -114,8 +114,10 @@ int OnlMonClient::End(PHCompositeNode* topNode)
   ostringstream oss;
   oss << OnlMonServer::GetOutDir() << "/" << setfill('0') << setw(6) << run_id;
   gSystem->mkdir(oss.str().c_str(), true);
+  gSystem->Chmod(oss.str().c_str(), 0775);
   oss << "/" << Name() << ".root";
   m_hm->dumpHistos(oss.str());
+  gSystem->Chmod(oss.str().c_str(), 0664);
 
   return EndOnlMon(topNode);
 }

--- a/online/onlmonserver/OnlMonClient.cc
+++ b/online/onlmonserver/OnlMonClient.cc
@@ -77,16 +77,17 @@ int OnlMonClient::process_event(PHCompositeNode* topNode)
   SQEvent* event = findNode::getClass<SQEvent>(topNode, "SQEvent");
   if (!event) return Fun4AllReturnCodes::ABORTEVENT;
 
-  pthread_mutex_t mutex;
-  OnlMonServer::instance()->GetMutex(mutex);
-  pthread_mutex_lock(&mutex);
+  pthread_mutex_t* mutex = OnlMonServer::instance()->GetMutex();
+  int ret_mutex = pthread_mutex_lock(mutex); // got stuck here, n = 1
+  if (ret_mutex != 0) cout << "WARNING:  mutex_lock returned " << ret_mutex << "." << endl;
 
   m_h1_basic_info->SetBinContent(BIN_SPILL, event->get_spill_id());
   m_h1_basic_info->SetBinContent(BIN_EVENT, event->get_event_id());
   m_h1_basic_info->AddBinContent(BIN_N_EVT, 1);
 
   int ret = ProcessEventOnlMon(topNode);
-  pthread_mutex_unlock(&mutex);
+  ret_mutex = pthread_mutex_unlock(mutex);
+  if (ret_mutex != 0) cout << "WARNING:  mutex_unlock returned " << ret_mutex << "." << endl;
   return ret;
 }
 

--- a/online/onlmonserver/OnlMonServer.cc
+++ b/online/onlmonserver/OnlMonServer.cc
@@ -42,7 +42,14 @@ OnlMonServer *OnlMonServer::instance()
 OnlMonServer::OnlMonServer(const std::string &name)
   : Fun4AllServer(name), m_go_end(false)
 {
-  pthread_mutex_unlock(&mutex);
+  pthread_mutexattr_t mutex_attr;
+  pthread_mutexattr_init(&mutex_attr);
+  pthread_mutexattr_settype(&mutex_attr, PTHREAD_MUTEX_ERRORCHECK);
+
+  int ret = pthread_mutex_init(&mutex, &mutex_attr);
+  if (ret != 0) {
+    cout << "WARNING:  pthread_mutex_init() returned " << ret << "." << endl;
+  }
   return;
 }
 

--- a/online/onlmonserver/OnlMonServer.h
+++ b/online/onlmonserver/OnlMonServer.h
@@ -38,6 +38,7 @@ class OnlMonServer : public Fun4AllServer
   bool GetGoEnd()        { return m_go_end; }
 
 #ifndef __CINT__
+  pthread_mutex_t* GetMutex() { return &mutex; }
   void GetMutex(pthread_mutex_t &lock) {lock = mutex;}
   void SetThreadId(pthread_t &id) {serverthreadid = id;}
 #endif

--- a/packages/geom_svc/macros/CheckChanMap.C
+++ b/packages/geom_svc/macros/CheckChanMap.C
@@ -1,9 +1,9 @@
 /// CheckChanMap.C:  Macro to check one of the channel mappings on MySQL DB.
-R__LOAD_LIBRARY(libchan_map)
+R__LOAD_LIBRARY(libgeom_svc)
 
 int CheckChanMap()
 {
-  gSystem->Load("libchan_map.so");
+  gSystem->Load("libgeom_svc.so");
 
   /// Select one of the classes.
   //ChanMapTaiwan map;

--- a/packages/geom_svc/macros/MakeChanMap.C
+++ b/packages/geom_svc/macros/MakeChanMap.C
@@ -1,9 +1,9 @@
 /// MakeChanMap.C:  Macro to create a channel mapping.
-R__LOAD_LIBRARY(libchan_map)
+R__LOAD_LIBRARY(libgeom_svc)
 
 int MakeChanMap()
 {
-  gSystem->Load("libchan_map.so");
+  gSystem->Load("libgeom_svc.so");
   ChanMapTaiwan map;
 
   /// roc, board chan, det, ele

--- a/packages/geom_svc/macros/UploadChanMap.C
+++ b/packages/geom_svc/macros/UploadChanMap.C
@@ -1,9 +1,9 @@
 /// UploadChanMap.C:  Macro to upload the channel mapping from tsv file to MySQL DB.
-R__LOAD_LIBRARY(libchan_map)
+R__LOAD_LIBRARY(libgeom_svc)
 
 int UploadChanMap()
 {
-  gSystem->Load("libchan_map.so");
+  gSystem->Load("libgeom_svc.so");
 
   /// Select one of the classes.
   ChanMapTaiwan map;
@@ -15,7 +15,8 @@ int UploadChanMap()
   //GeomParamPlane map;
 
   /// Set a map ID.
-  const std::string map_id="e906run28740";
+  const std::string map_id="2019091301";
+//  const std::string map_id="e906run28740";
 //  const std::string map_id="G9_run5_2";
 
   map.SetMapIDbyFile(map_id);

--- a/script/setup-install.sh
+++ b/script/setup-install.sh
@@ -11,13 +11,18 @@
 ## One need not use this script but can set up everything by oneself.  But 
 ## this script should be helpful in preparing for an easily-reproducible 
 ## environment.  Any questions/requests can be sent to Kenichi.
-DIR_SCRIPT=$(dirname $(readlink -f $BASH_SOURCE))
+if [ $0 != $BASH_SOURCE ] ; then
+    echo "!!ERROR!!  The usage of this script has changed recently."
+    echo "Now you have execute (not source) it.  Sorry for the inconvenience."
+    return
+fi
+DIR_SCRIPT=$(dirname $(readlink -f $0))
 
 if [ -z "$1" ] ; then
     echo "The 1st argument must be an installation directory,"
     echo "or 'auto' to auto-select it."
     echo "Abort."
-    return
+    exit 1
 elif [ "X$1" = 'Xauto' ] ; then
     DIR_INST=$(readlink -f $DIR_SCRIPT/../../e1039-core-inst)
 else
@@ -49,7 +54,7 @@ if [ -z "$E1039_ROOT" ] ; then
     echo "Your host is not supported by this script."
     echo "You can ask the manager (Kenichi) how to proceed, or"
     echo "try to set E1039_RESOURCE and E1039_SHARE properly by yourself."
-    return
+    exit 1
 fi
 {
     echo "source $E1039_ROOT/resource/this-resource.sh"
@@ -63,6 +68,9 @@ fi
 echo
 echo "A setup script was created;"
 echo "  $DIR_INST/this-e1039.sh"
-echo "You should source it when you start building or executing this e1039-core "
-echo "package.  Next you likely source the script, move to a build directory "
+echo "Next you likely source this script, move to a build directory "
 echo "and execute 'build.sh'."
+echo
+echo "Note that You should source the setup script when you use a new "
+echo "shell environment (i.e. text terminal) to build or execute this "
+echo "e1039-core package."


### PR DESCRIPTION
A big issue about the MainDAQ decoder is that a decoder process sometimes (once per day) gets stuck and never ends.  I made several small updates, and here I request a pull because this new version is running without problem in the past few days.

I would expect this version doesn't conflict with PL 57.  But if it is found conflicting after PL 57 is merged, please just let me know it so that I resolve it.

I think the last update did fix the issue.  The Mutex variable in `OnlMonServer` had not been initialized well (although it was how the original example did), which sometimes caused a never-ending wait when `OnlMonClient::process_event()` called `pthread_mutex_lock()`.

Below are the other updates included in this request, which are likely not related to the issue but are helpful anyway.
1.  `build.sh` now copies all macro files to the installation directory.
1. A wrong handling of coda ID in the online decoding mode has been fixed in `CodaInputManager.cc`.
1. Now a temporary spill ID is given in `MainDaqParser.cc` when no spill-ID info is provided by the spill counter nor the slow control.  Should be helpful during the cosmic-ray commissioning.
1. Old log file written by the decoder is no longer overwritten but renamed by `Daemon4MainDaq.C` before a new log file is opened.
1.  Now `setup-install.sh` has to be executed, not sourced.  This usage should be more natural with respect to its present behavior, namely it does not set any shell variable but creates setup scripts.