### PR TITLE
Online bug fix.  Better handling of environmental variables.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,29 +32,27 @@ git clone git@github.com:E1039-Collaboration/e1039-core.git
 
 ## Build and Install
 
-The following commands should succeed on the supported servers.
-You should first try them to learn the overall procedure.
+You can first try the following commands to learn the overall procedure.
+They should succeed on the supported servers.
 ```
 cd /path/to/directory_where_you_download_e1039-core
-source e1039-core/script/setup-install.sh auto
-source $DIR_INST/this-e1039.sh
-mkdir e1039-core-build
-cd    e1039-core-build
-../e1039-core/build.sh
+./script/setup-install.sh auto
+source ../core-inst/this-e1039.sh
+./build.sh
 ```
 
 It takes 5-10 minutes.
-Lots of installed files appear in "e1039-core-inst".
+Lots of installed files appear in "../core-inst".
 
 ### Details
 
-When you open a new shell environment (i.e. text terminal), you have to source "this-e1039.sh", where DIR_INST is no longer available and thus you type a real path (in either relative or absolute).
+When you open a new shell environment (i.e. text terminal), you have to source "this-e1039.sh".
 
 The script "setup-install.sh" sets up the environment to install, build and run this package.
 It warns you if your computer is not supported for the automated setup.
 
-The argument "auto" of "setup-install.sh" means that the installation directory is selected automatically ("e1039-core-inst").
-If you like to select it, you can type it instead of "auto".
+The argument "auto" of "setup-install.sh" means that the installation directory is selected automatically, which is "../core-inst".
+If you like to manually select it (such as `~/e1039/inst/core`), you can type it instead of "auto".
 
 A directory that includes 'CMakeLists.txt' under "e1039-core" forms a sub-package.
 The script "build.sh" builds all the sub-packages in the right order.

--- a/build.sh
+++ b/build.sh
@@ -75,17 +75,18 @@ do
 	fi
 done
 
-
-(
+if [ ${#packages[@]} -gt 1 ] ; then
     echo "================================================================"
     echo "Install all macros to $install/macros/."
-    cd $src
-    find . -type d -regex '.*/macros*' | while read DIR_SRC ; do
-	echo "  $DIR_SRC"
-	DIR_DEST=$install/macros/$(dirname $DIR_SRC)
-	mkdir -p $DIR_DEST
-	cp -p $DIR_SRC/* $DIR_DEST
-    done
-)
+    ( 
+	cd $src
+	find . -type d -regex '.*/macros*' | while read DIR_SRC ; do
+	    echo "  $DIR_SRC"
+	    DIR_DEST=$install/macros/$(dirname $DIR_SRC)
+	    mkdir -p $DIR_DEST
+	    cp -p $DIR_SRC/* $DIR_DEST
+	done
+    )
+fi
 
 cd $build

--- a/generators/phhepmc/CMakeLists.txt
+++ b/generators/phhepmc/CMakeLists.txt
@@ -76,7 +76,7 @@ add_library(phhepmc_io SHARED
 target_link_libraries(phhepmc_io -lphool -lHepMC)
 
 add_dependencies(phhepmc phhepmc_io)
-target_link_libraries(phhepmc -lphhepmc_io -lphool -lSubsysReco -lboost_iostreams -lfun4all -lgsl -lgslcblas)
+target_link_libraries(phhepmc phhepmc_io -lphool -lSubsysReco -lboost_iostreams -lfun4all -lgsl -lgslcblas)
 
 install(TARGETS phhepmc_io  DESTINATION ${CMAKE_INSTALL_PREFIX}/lib)
 install(TARGETS phhepmc     DESTINATION ${CMAKE_INSTALL_PREFIX}/lib)

--- a/interface_main/CMakeLists.txt
+++ b/interface_main/CMakeLists.txt
@@ -32,7 +32,7 @@ execute_process(COMMAND root-config --prefix OUTPUT_VARIABLE ROOT_PREFIX  OUTPUT
 execute_process(COMMAND root-config --cflags OUTPUT_VARIABLE ROOT_CFLAGS  OUTPUT_STRIP_TRAILING_WHITESPACE)
 execute_process(COMMAND root-config --libs   OUTPUT_VARIABLE ROOT_LINK    OUTPUT_STRIP_TRAILING_WHITESPACE)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x -I$ENV{MY_INSTALL}/include/ -I$ENV{OFFLINE_MAIN}/include/ ${ROOT_CFLAGS}")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -g -O2 -std=c++0x -I$ENV{MY_INSTALL}/include/ -I$ENV{OFFLINE_MAIN}/include/ ${ROOT_CFLAGS}")
 #set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -L$ENV{OFFLINE_MAIN}/lib -lphool")
 
 add_library(interface_main SHARED ${sources} ${dicts})

--- a/interface_main/SQParamDeco.h
+++ b/interface_main/SQParamDeco.h
@@ -28,6 +28,7 @@ public:
 
   virtual ParamConstIter begin() const = 0;
   virtual ParamConstIter   end() const = 0;
+  virtual unsigned int    size() const = 0;
   
 protected:
   SQParamDeco() {}

--- a/interface_main/SQParamDeco_v1.h
+++ b/interface_main/SQParamDeco_v1.h
@@ -19,6 +19,7 @@ public:
 
   ParamConstIter begin() const { return m_map.begin(); }
   ParamConstIter   end() const { return m_map.end(); }
+  unsigned int    size() const { return m_map.size(); }
   
 private:
   ParamMap m_map;

--- a/online/decoder_maindaq/CodaInputManager.cc
+++ b/online/decoder_maindaq/CodaInputManager.cc
@@ -127,32 +127,6 @@ bool CodaInputManager::NextCodaEvent(unsigned int& coda_id, int*& words)
   cout << "CodaInputManager::NextCodaEvent():  Bad end." << endl;
   ForceEnd();
   return false;
-
-
-
-//  if (ret != 0 && m_online && m_run > 0) { // try to recover
-//    cout << "No new event seems available for now.  Try to recover." << endl;
-//    if (file_exists(UtilOnline::GetEndFilePath(m_run))) {
-//      cout << "Exiting since the END file exists." << endl;
-//      ForceEnd();
-//      return false;
-//    }
-//
-//    if (file_exists(UtilOnline::GetCodaFilePath(m_run+1))) {
-//      cout << "Exiting since the next run file exists." << endl;
-//      ForceEnd();
-//      return false;
-//    }
-//    // Re-open the file, requring a larger file size
-//    ret = OpenFile(m_fname, m_file_size + 32768, 10, 20, m_event_count);
-//  }
-//  if (ret != 0) {
-//    ForceEnd();
-//    return false;
-//  }
-//  coda_id = m_event_count++;
-//  words   = event_words;
-//  return true;
 }
 
 bool CodaInputManager::file_exists(const std::string fname)

--- a/online/decoder_maindaq/CodaInputManager.h
+++ b/online/decoder_maindaq/CodaInputManager.h
@@ -9,7 +9,7 @@
 class CodaInputManager {
   static const int buflen = 500000;
   int  m_verb;
-  bool m_online; //< Always 'true' for now
+  bool m_online; //< True if the decoder runs in the online mode.
   bool m_go_end;
   int  m_handle; //< Handler for evio
   int  m_run;

--- a/online/decoder_maindaq/DbUpRun.cc
+++ b/online/decoder_maindaq/DbUpRun.cc
@@ -142,6 +142,8 @@ void DbUpRun::UploadParam(const int run, const SQParamDeco* sq)
     db.CreateTable(table_name, list);
   }
 
+  if (sq->size() == 0) return;
+
   ostringstream oss;
   oss << "delete from " << table_name << " where run_id = " << run;
   if (! db.Con()->Exec(oss.str().c_str())) {
@@ -156,7 +158,7 @@ void DbUpRun::UploadParam(const int run, const SQParamDeco* sq)
   string query = oss.str();
   query.erase(query.length()-1, 1); // Remove the last ',' char.
   if (! db.Con()->Exec(query.c_str())) {
-    cerr << "!!ERROR!!  DbUpSpill::UploadToSpillTable()." << endl;
+    cerr << "!!ERROR!!  DbUpRun::UploadParam()." << endl;
     return;
   }
 }

--- a/online/decoder_maindaq/Fun4AllEVIOInputManager.cc
+++ b/online/decoder_maindaq/Fun4AllEVIOInputManager.cc
@@ -124,14 +124,10 @@ int Fun4AllEVIOInputManager::fileopen(const string &filenam)
     }
 
   events_thisfile = 0;
-  //parser = new MainDaqParser();
   parser->dec_par.verbose = Verbosity();
   int status = parser->OpenCodaFile(fname);
   if (status!=0) {
-    cerr << "!!ERROR!! Failed at file open (" << status << ").  Exit.\n";
-    //delete parser;
-    //parser = NULL;
-    cout << PHWHERE << ThisName << ": could not open file " << fname << endl;
+    cout << PHWHERE << ThisName << ": could not open file " << fname << " with status = " << status << "." << endl;
     return -1;
   }
   //pair<int, int> runseg = Fun4AllUtils::GetRunSegment(fname);

--- a/online/decoder_maindaq/MainDaqParser.cc
+++ b/online/decoder_maindaq/MainDaqParser.cc
@@ -7,6 +7,7 @@ using namespace std;
 // In the current design, all event-word handlers (i.e. functions) should print out all error messages needed, so that their caller should print nothing but just check the returned value.
 
 MainDaqParser::MainDaqParser()
+  : m_file_size_min(32768), m_sec_wait(15), m_n_wait(40)
 {
   coda = new CodaInputManager();
   list_sd = new SpillDataMap();
@@ -25,6 +26,9 @@ MainDaqParser::~MainDaqParser()
 
 int MainDaqParser::OpenCodaFile(const std::string fname, const int file_size_min, const int sec_wait, const int n_wait)
 {
+  m_file_size_min = file_size_min;
+  m_sec_wait      = sec_wait;
+  m_n_wait        = n_wait;
   dec_par.timeStart = time(NULL);
   dec_par.fn_in = fname;
   return coda->OpenFile(fname, file_size_min, sec_wait, n_wait);
@@ -97,7 +101,7 @@ int MainDaqParser::ParseOneSpill()
       break;
     case 0: // Special case which requires waiting and retrying.  Purpose??  Still needed??
       cout << "Case '0' @ coda " << dec_par.codaID << "." << endl;
-      ret = coda->OpenFile(dec_par.fn_in, file_size_min, sec_wait, n_wait);
+      ret = coda->OpenFile(dec_par.fn_in, m_file_size_min, m_sec_wait, m_n_wait);
       if (ret == 0) {
         ret = coda->JumpCodaEvent(dec_par.codaID, event_words, dec_par.codaID - 1) ? 0 : 2;
       }

--- a/online/decoder_maindaq/MainDaqParser.h
+++ b/online/decoder_maindaq/MainDaqParser.h
@@ -5,10 +5,9 @@
 class CodaInputManager;
 
 class MainDaqParser {
-  static const int file_size_min = 32768;
-  static const int sec_wait      = 15;
-  static const int n_wait        = 40;
-
+  int m_file_size_min;
+  int m_sec_wait;
+  int m_n_wait;
   CodaInputManager* coda;
 
   /// Variables for data storage

--- a/online/onlmonserver/OnlMonClient.cc
+++ b/online/onlmonserver/OnlMonClient.cc
@@ -94,6 +94,7 @@ int OnlMonClient::process_event(PHCompositeNode* topNode)
 
 int OnlMonClient::End(PHCompositeNode* topNode)
 {
+  if (! m_hm) return Fun4AllReturnCodes::EVENT_OK;
   int run_id;
   GetBasicInfo(&run_id);
 

--- a/online/onlmonserver/OnlMonHodo.cc
+++ b/online/onlmonserver/OnlMonHodo.cc
@@ -175,6 +175,7 @@ int OnlMonHodo::DrawMonitor()
   for (int pl = 0; pl < m_n_pl; pl++) {
     pad1->cd(pl+1);
     UtilHist::AutoSetRange(h1_time[pl]);
+    //h1_time[pl]->GetXaxis()->SetRangeUser(400, 1050);
     h1_time[pl]->SetLineColor(kBlack);
     h1_time[pl]->Draw();
     h1_time_in[pl]->SetLineColor(kBlue);

--- a/packages/PHField/CMakeLists.txt
+++ b/packages/PHField/CMakeLists.txt
@@ -74,7 +74,7 @@ add_library(phfield SHARED
 add_dependencies(phfield phfield_io)
 
 target_link_libraries(phfield_io -lphool)
-target_link_libraries(phfield    -lfun4all -lphfield_io )
+target_link_libraries(phfield    phfield_io -lfun4all)
 
 install(TARGETS phfield_io 				DESTINATION ${CMAKE_INSTALL_PREFIX}/lib)
 install(TARGETS phfield 					DESTINATION ${CMAKE_INSTALL_PREFIX}/lib)

--- a/script/setup-install.sh
+++ b/script/setup-install.sh
@@ -24,7 +24,7 @@ if [ -z "$1" ] ; then
     echo "Abort."
     exit 1
 elif [ "X$1" = 'Xauto' ] ; then
-    DIR_INST=$(readlink -f $DIR_SCRIPT/../../e1039-core-inst)
+    DIR_INST=$(readlink -f $DIR_SCRIPT/../../core-inst)
 else
     DIR_INST=$(readlink -m "$1")
 fi
@@ -68,8 +68,9 @@ fi
 echo
 echo "A setup script was created;"
 echo "  $DIR_INST/this-e1039.sh"
-echo "Next you likely source this script, move to a build directory "
-echo "and execute 'build.sh'."
+echo "Next you likely source this script and execute 'build.sh';"
+echo "  source $DIR_INST/this-e1039.sh"
+echo "  ./build.sh"
 echo
 echo "Note that You should source the setup script when you use a new "
 echo "shell environment (i.e. text terminal) to build or execute this "

--- a/script/this-core-org.sh
+++ b/script/this-core-org.sh
@@ -1,9 +1,16 @@
 
 if [ $E1039_CORE ] ; then # Clean up the old components
-    PATH=${PATH//"$E1039_CORE/bin:"}
-    CPATH=${CPATH//"$E1039_CORE/include:"}
-    LIBRARY_PATH=${LIBRARY_PATH//"$E1039_CORE/lib:"}
-    LD_LIBRARY_PATH=${LD_LIBRARY_PATH//"$E1039_CORE/lib:"}
+    function DropEleFromPath {
+	local -r NAME=$1
+	local -r  ELE=$2
+	local -r CONT=$(eval "echo :\$$NAME:" | sed -e 's/:/::/g' -e "s%:$ELE:%%g" -e 's/:\+/:/g' -e 's/^://' -e 's/:$//')
+	eval "$NAME=$CONT"
+    }
+    DropEleFromPath PATH            $E1039_CORE/bin
+    DropEleFromPath CPATH           $E1039_CORE/include
+    DropEleFromPath LIBRARY_PATH    $E1039_CORE/lib
+    DropEleFromPath LD_LIBRARY_PATH $E1039_CORE/lib
+    unset -f DropEleFromPath
 fi
 
 export E1039_CORE=$(dirname $(readlink -f $BASH_SOURCE))

--- a/script/this-core-org.sh
+++ b/script/this-core-org.sh
@@ -1,3 +1,11 @@
+
+if [ $E1039_CORE ] ; then # Clean up the old components
+    PATH=${PATH//"$E1039_CORE/bin:"}
+    CPATH=${CPATH//"$E1039_CORE/include:"}
+    LIBRARY_PATH=${LIBRARY_PATH//"$E1039_CORE/lib:"}
+    LD_LIBRARY_PATH=${LD_LIBRARY_PATH//"$E1039_CORE/lib:"}
+fi
+
 export E1039_CORE=$(dirname $(readlink -f $BASH_SOURCE))
 export OFFLINE_MAIN=$E1039_CORE
 export   MY_INSTALL=$E1039_CORE
@@ -15,5 +23,5 @@ export    LIBRARY_PATH=$E1039_CORE/lib:$LIBRARY_PATH
 export LD_LIBRARY_PATH=$E1039_CORE/lib:$LD_LIBRARY_PATH
 
 if [ -d $E1039_CORE/include ] ; then
-    export ROOT_INCLUDE_PATH=$(find $E1039_CORE/include -type d -printf '%p:')$ROOT_INCLUDE_PATH
+    export ROOT_INCLUDE_PATH=$(find $E1039_CORE/include -type d -printf '%p:')$ROOT_INCLUDE_PATH_E1039_SHARE
 fi


### PR DESCRIPTION
I first fixed a problem (bug) that happens when a run fails at starting. It happened in runs 1065, 1067 and 1069.  This updated version is already running on seaquestdaq01, and the problem never happens since then.

I updated `script/this-core-org.sh`.  It now cleans up the environmental variables (like `PATH` and `ROOT_INCLUDE_PATH`) when `E1039_CORE` is already defined.  The similar change has been made on `this-share.sh` in the e1039-share package.  As a result, we can change the E1039_* environment at any time, by executing `this-core.sh` or `this-e1039.sh`.  This update will help Abi and me to test PR 63 (and future updates).

