### PR TITLE
New SQ interface classes and SubsysReco modules for simulated variables.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -23,7 +23,6 @@ else
     framework/fun4all
     interface_main
     packages/UtilAna
-    packages/evt_filter
     online/decoder_maindaq
     packages/Half
     packages/vararray
@@ -40,6 +39,7 @@ else
     simulation/g4dst
     simulation/g4eval
     generators/E906LegacyGen
+    packages/evt_filter
     packages/dptrigger
     #packages/db2g4
     packages/PHGenFitPkg/GenFitExp

--- a/interface_main/SQDimuon.cxx
+++ b/interface_main/SQDimuon.cxx
@@ -1,0 +1,9 @@
+#include "SQDimuon.h"
+using namespace std;
+ClassImp(SQDimuon)
+
+//void SQDimuon::identify(std::ostream& os = std::cout) const
+//{
+//  cout << "---SQDimuon::identify: abstract base-------------------" << endl;
+//}
+

--- a/interface_main/SQDimuon.h
+++ b/interface_main/SQDimuon.h
@@ -1,0 +1,46 @@
+#ifndef _SQ_DIMUON__H_
+#define _SQ_DIMUON__H_
+#include <iostream>
+#include <phool/PHObject.h>
+#include <TLorentzVector.h>
+
+class SQDimuon: public PHObject {
+ public:
+  virtual ~SQDimuon() {}
+
+  virtual void identify(std::ostream& os = std::cout) const = 0;
+  virtual void Reset() = 0;
+  virtual int isValid() const = 0;
+  virtual SQDimuon* Clone() const = 0;
+
+  virtual int  get_dimuon_id() const = 0;
+  virtual void set_dimuon_id(const int a) = 0;
+
+  virtual int  get_pdg_id() const = 0;
+  virtual void set_pdg_id(const int a) = 0;
+
+  virtual int  get_track_id_pos() const = 0;
+  virtual void set_track_id_pos(const int a) = 0;
+
+  virtual int  get_track_id_neg() const = 0;
+  virtual void set_track_id_neg(const int a) = 0;
+
+  virtual TVector3 get_pos() const = 0;
+  virtual void     set_pos(const TVector3 a) = 0;
+
+  virtual TLorentzVector get_mom() const = 0;
+  virtual void           set_mom(const TLorentzVector a) = 0;
+
+  virtual TLorentzVector get_mom_pos() const = 0;
+  virtual void           set_mom_pos(const TLorentzVector a) = 0;
+
+  virtual TLorentzVector get_mom_neg() const = 0;
+  virtual void           set_mom_neg(const TLorentzVector a) = 0;
+
+ protected:
+  SQDimuon() {}
+
+  ClassDef(SQDimuon, 1);
+};
+
+#endif // _SQ_DIMUON__H_

--- a/interface_main/SQDimuonLinkDef.h
+++ b/interface_main/SQDimuonLinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class SQDimuon+;
+
+#endif /* __CINT__ */

--- a/interface_main/SQDimuonVector.cxx
+++ b/interface_main/SQDimuonVector.cxx
@@ -1,0 +1,3 @@
+#include "SQDimuonVector.h"
+//using namespace std;
+ClassImp(SQDimuonVector)

--- a/interface_main/SQDimuonVector.h
+++ b/interface_main/SQDimuonVector.h
@@ -1,0 +1,40 @@
+#ifndef _SQ_DIMUON_VECTOR__H_
+#define _SQ_DIMUON_VECTOR__H_
+#include <iostream>
+#include <vector>
+#include <phool/PHObject.h>
+#include "SQDimuon.h"
+
+class SQDimuonVector: public PHObject {
+ public:
+  typedef std::vector<SQDimuon*>                    Vector;
+  typedef std::vector<SQDimuon*>::const_iterator ConstIter;
+  typedef std::vector<SQDimuon*>::iterator            Iter;
+
+  virtual ~SQDimuonVector() {}
+
+  virtual void identify(std::ostream& os = std::cout) const = 0;
+  virtual void Reset() = 0;
+  virtual int  isValid() const = 0;
+  virtual SQDimuonVector* Clone() const = 0;
+
+  virtual ConstIter begin() const = 0;
+  virtual ConstIter end  () const = 0;
+  virtual      Iter begin() = 0;
+  virtual      Iter end  () = 0;
+  virtual bool      empty() const = 0;
+  virtual size_t    size () const = 0;
+  virtual void      clear() = 0;
+
+  virtual const SQDimuon* at(const size_t id) const = 0;
+  virtual       SQDimuon* at(const size_t id) = 0;
+  virtual       void   push_back(const SQDimuon *dim) = 0;
+  virtual       size_t erase(const size_t id) = 0;
+
+ protected:
+  SQDimuonVector() {}
+
+  ClassDef(SQDimuonVector, 1);
+};
+
+#endif // _SQ_DIMUON_VECTOR__H_

--- a/interface_main/SQDimuonVectorLinkDef.h
+++ b/interface_main/SQDimuonVectorLinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class SQDimuonVector+;
+
+#endif /* __CINT__ */

--- a/interface_main/SQDimuonVector_v1.cxx
+++ b/interface_main/SQDimuonVector_v1.cxx
@@ -1,0 +1,64 @@
+#include "SQDimuonVector_v1.h"
+using namespace std;
+ClassImp(SQDimuonVector_v1)
+
+SQDimuonVector_v1::SQDimuonVector_v1()
+{
+  ;
+}
+
+SQDimuonVector_v1::SQDimuonVector_v1(const SQDimuonVector_v1& obj)
+{
+  for (ConstIter iter = obj.begin(); iter != obj.end(); ++iter) {
+    _vector.push_back((*iter)->Clone());
+  }
+}
+
+SQDimuonVector_v1& SQDimuonVector_v1::operator=(const SQDimuonVector_v1& obj)
+{
+  Reset();
+  for (ConstIter iter = obj.begin(); iter != obj.end(); ++iter) {
+    _vector.push_back((*iter)->Clone());
+  }
+  return *this;
+}
+
+SQDimuonVector_v1::~SQDimuonVector_v1()
+{
+  Reset();
+}
+
+void SQDimuonVector_v1::Reset() 
+{
+  for (Iter iter = _vector.begin(); iter != _vector.end(); ++iter) delete *iter;
+  _vector.clear();
+}
+
+void SQDimuonVector_v1::identify(ostream& os) const
+{
+  os << "SQDimuonVector_v1: size = " << _vector.size() << endl;
+}
+
+const SQDimuon* SQDimuonVector_v1::at(const size_t id) const
+{
+  if (id >= _vector.size()) return nullptr;
+  return _vector[id];
+}
+
+SQDimuon* SQDimuonVector_v1::at(const size_t id)
+{
+  if (id >= _vector.size()) return nullptr;
+  return _vector[id];
+}
+
+void SQDimuonVector_v1::push_back(const SQDimuon *dim)
+{
+  _vector.push_back(dim->Clone());
+}
+
+size_t SQDimuonVector_v1::erase(const size_t id)
+{
+  delete _vector[id];
+  _vector.erase(_vector.begin() + id);
+  return _vector.size();
+}

--- a/interface_main/SQDimuonVector_v1.h
+++ b/interface_main/SQDimuonVector_v1.h
@@ -1,0 +1,36 @@
+#ifndef _SQ_DIMUON_VECTOR_V1__H_
+#define _SQ_DIMUON_VECTOR_V1__H_
+#include "SQDimuonVector.h"
+
+class SQDimuonVector_v1: public SQDimuonVector {
+ public:
+  SQDimuonVector_v1();
+  SQDimuonVector_v1(const SQDimuonVector_v1& obj);
+  SQDimuonVector_v1& operator=(const SQDimuonVector_v1& obj);
+  virtual ~SQDimuonVector_v1();
+
+  void identify(std::ostream& os = std::cout) const;
+  void Reset();
+  int  isValid() const { return 1; }
+  SQDimuonVector* Clone() const { return new SQDimuonVector_v1(*this); }
+
+  ConstIter begin() const { return _vector.begin(); }
+  ConstIter end  () const { return _vector.end  (); }
+  Iter      begin()       { return _vector.begin(); }
+  Iter      end  ()       { return _vector.end  (); }
+  bool      empty() const { return _vector.empty(); }
+  size_t    size () const { return _vector.size (); }
+  void      clear() { Reset(); }
+
+  const SQDimuon* at(const size_t id) const;
+  SQDimuon*       at(const size_t id);
+  void   push_back(const SQDimuon *dim);
+  size_t erase(const size_t id);
+
+ protected:
+  Vector _vector;
+
+  ClassDef(SQDimuonVector_v1, 1);
+};
+
+#endif // _SQ_DIMUON_VECTOR_V1__H_

--- a/interface_main/SQDimuonVector_v1LinkDef.h
+++ b/interface_main/SQDimuonVector_v1LinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class SQDimuonVector_v1+;
+
+#endif /* __CINT__ */

--- a/interface_main/SQDimuon_v1.cxx
+++ b/interface_main/SQDimuon_v1.cxx
@@ -1,0 +1,31 @@
+#include "SQDimuon_v1.h"
+using namespace std;
+
+SQDimuon_v1::SQDimuon_v1()
+  : _id(-1)
+  , _pdg_id(0)
+  , _track_id_pos(0)
+  , _track_id_neg(0)
+  , _pos(0,0,0)
+  , _mom(0,0,0,0)
+  , _mom_pos(0,0,0,0)
+  , _mom_neg(0,0,0,0)
+{
+  ;
+}
+
+SQDimuon_v1::~SQDimuon_v1()
+{
+  ;
+}
+
+void SQDimuon_v1::identify(std::ostream& os) const
+{
+  ;
+}
+
+void SQDimuon_v1::Reset()
+{
+  ;
+}
+

--- a/interface_main/SQDimuon_v1.h
+++ b/interface_main/SQDimuon_v1.h
@@ -1,0 +1,64 @@
+#ifndef _SQ_DIMUON_V1__H_
+#define _SQ_DIMUON_V1__H_
+#include "SQDimuon.h"
+
+class SQDimuon_v1 : public SQDimuon {
+ public:
+  SQDimuon_v1();
+  virtual ~SQDimuon_v1();
+
+  void identify(std::ostream& os = std::cout) const;
+  void Reset();
+  int isValid() const { return 1; }
+  SQDimuon* Clone() const { return new SQDimuon_v1(*this); }
+
+  int  get_dimuon_id() const { return _id; }
+  void set_dimuon_id(const int a)   { _id = a; }
+
+  int  get_pdg_id() const { return _pdg_id; }
+  void set_pdg_id(const int a)   { _pdg_id = a; }
+
+  int  get_track_id_pos() const { return _track_id_pos; }
+  void set_track_id_pos(const int a)   { _track_id_pos = a; }
+
+  int  get_track_id_neg() const { return _track_id_neg; }
+  void set_track_id_neg(const int a)   { _track_id_neg = a; }
+
+  TVector3 get_pos() const    { return _pos; }
+  void     set_pos(const TVector3 a) { _pos = a; }
+
+  TLorentzVector get_mom() const          { return _mom; }
+  void           set_mom(const TLorentzVector a) { _mom = a; }
+
+  TLorentzVector get_mom_pos() const          { return _mom_pos; }
+  void           set_mom_pos(const TLorentzVector a) { _mom_pos = a; }
+
+  TLorentzVector get_mom_neg() const          { return _mom_neg; }
+  void           set_mom_neg(const TLorentzVector a) { _mom_neg = a; }
+
+ protected:
+  int _id;
+  int _pdg_id;
+  int _track_id_pos;
+  int _track_id_neg;
+  TVector3 _pos;
+  TLorentzVector _mom;
+  TLorentzVector _mom_pos;
+  TLorentzVector _mom_neg;
+
+  ClassDef(SQDimuon_v1, 1);
+};
+
+//struct SQDimuonVector : public PHObject, public std::vector<SQDimuon> {
+//  SQDimuonVector() {;}
+//  virtual ~SQDimuonVector() {;}
+//
+//  void identify(std::ostream& os = std::cout) const {;}
+//  void Reset() { *this = SQDimuonVector(); }
+//  int isValid() const { return 1; }
+//  SQDimuonVector* Clone() const { return new SQDimuonVector(*this); }
+//
+//  ClassDef(SQDimuonVector, 1);
+//};
+
+#endif // _SQ_DIMUON_V1__H_

--- a/interface_main/SQDimuon_v1LinkDef.h
+++ b/interface_main/SQDimuon_v1LinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class SQDimuon_v1+;
+
+#endif /* __CINT__ */

--- a/interface_main/SQMCEvent.cxx
+++ b/interface_main/SQMCEvent.cxx
@@ -1,0 +1,9 @@
+#include "SQMCEvent.h"
+using namespace std;
+ClassImp(SQMCEvent)
+
+//void SQMCEvent::identify(std::ostream& os = std::cout) const
+//{
+//  cout << "---SQMCEvent::identify: abstract base-------------------" << endl;
+//}
+

--- a/interface_main/SQMCEvent.h
+++ b/interface_main/SQMCEvent.h
@@ -1,0 +1,34 @@
+#ifndef _SQ_MC_EVENT__H_
+#define _SQ_MC_EVENT__H_
+#include <iostream>
+#include <phool/PHObject.h>
+#include <TLorentzVector.h>
+
+class SQMCEvent: public PHObject {
+ public:
+  virtual ~SQMCEvent() {}
+
+  virtual void identify(std::ostream& os = std::cout) const = 0;
+  virtual void Reset() = 0;
+  virtual int isValid() const = 0;
+  virtual SQMCEvent* Clone() const = 0;
+
+  virtual int  get_process_id() const = 0;
+  virtual void set_process_id(const int a) = 0;
+
+  virtual double get_cross_section() const = 0;
+  virtual void   set_cross_section(const double a) = 0;
+
+  virtual int  get_particle_id(const int i) const = 0;
+  virtual void set_particle_id(const int i, const int a) = 0;
+
+  virtual TLorentzVector get_particle_momentum(const int i) const = 0;
+  virtual void           set_particle_momentum(const int i, const TLorentzVector a) = 0;
+
+ protected:
+  SQMCEvent() {}
+
+  ClassDef(SQMCEvent, 1);
+};
+
+#endif // _SQ_MC_EVENT__H_

--- a/interface_main/SQMCEvent.h
+++ b/interface_main/SQMCEvent.h
@@ -19,6 +19,9 @@ class SQMCEvent: public PHObject {
   virtual double get_cross_section() const = 0;
   virtual void   set_cross_section(const double a) = 0;
 
+  virtual double get_weight() const = 0;
+  virtual void   set_weight(const double a) = 0;
+
   virtual int  get_particle_id(const int i) const = 0;
   virtual void set_particle_id(const int i, const int a) = 0;
 

--- a/interface_main/SQMCEventLinkDef.h
+++ b/interface_main/SQMCEventLinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class SQMCEvent+;
+
+#endif /* __CINT__ */

--- a/interface_main/SQMCEvent_v1.cxx
+++ b/interface_main/SQMCEvent_v1.cxx
@@ -1,0 +1,64 @@
+#include <phool/phool.h>
+#include "SQMCEvent_v1.h"
+using namespace std;
+
+SQMCEvent_v1::SQMCEvent_v1()
+  : _proc_id(0)
+  , _xsec(.0)
+{
+  for (int ii = 0; ii < 4; ii++) {
+    _par_id [ii] = 0;
+    _par_mom[ii].SetXYZT(0,0,0,0);
+  }
+}
+
+SQMCEvent_v1::~SQMCEvent_v1()
+{
+  ;
+}
+
+void SQMCEvent_v1::identify(std::ostream& os) const
+{
+  ;
+}
+
+void SQMCEvent_v1::Reset()
+{
+  ;
+}
+
+int SQMCEvent_v1::get_particle_id(const int i) const
+{
+  if (i < 0 || i >= _N_PAR) {
+    cerr << PHWHERE << " Invalid index:" << i << endl;
+    return 0;
+  }
+  return _par_id[i];
+}
+
+void SQMCEvent_v1::set_particle_id(const int i, const int a)
+{
+  if (i < 0 || i >= _N_PAR) {
+    cerr << PHWHERE << " Invalid index:" << i << endl;
+    return;
+  }
+  _par_id[i] = a;
+}
+
+TLorentzVector SQMCEvent_v1::get_particle_momentum(const int i) const
+{
+  if (i < 0 || i >= _N_PAR) {
+    cerr << PHWHERE << " Invalid index:" << i << endl;
+    return TLorentzVector(0,0,0,0);
+  }
+  return _par_mom[i];
+}
+
+void SQMCEvent_v1::set_particle_momentum(const int i, const TLorentzVector a)
+{
+  if (i < 0 || i >= _N_PAR) {
+    cerr << PHWHERE << " Invalid index:" << i << endl;
+    return;
+  }
+  _par_mom[i] = a;
+}

--- a/interface_main/SQMCEvent_v1.cxx
+++ b/interface_main/SQMCEvent_v1.cxx
@@ -5,6 +5,7 @@ using namespace std;
 SQMCEvent_v1::SQMCEvent_v1()
   : _proc_id(0)
   , _xsec(.0)
+  , _weight(.0)
 {
   for (int ii = 0; ii < 4; ii++) {
     _par_id [ii] = 0;

--- a/interface_main/SQMCEvent_v1.h
+++ b/interface_main/SQMCEvent_v1.h
@@ -18,6 +18,10 @@ class SQMCEvent_v1 : public SQMCEvent {
   double get_cross_section() const  { return _xsec; }
   void   set_cross_section(const double a) { _xsec = a; }
 
+  double get_weight() const  { return _weight; }
+  void   set_weight(const double a) { _weight = a; }
+
+
   int  get_particle_id(const int i) const;
   void set_particle_id(const int i, const int a);
 
@@ -28,6 +32,7 @@ class SQMCEvent_v1 : public SQMCEvent {
   static const int _N_PAR = 4; // 2 -> 2
   int _proc_id;
   double _xsec;
+  double _weight;
   int _par_id[_N_PAR];
   TLorentzVector _par_mom[_N_PAR];
 

--- a/interface_main/SQMCEvent_v1.h
+++ b/interface_main/SQMCEvent_v1.h
@@ -1,0 +1,37 @@
+#ifndef _SQ_MC_EVENT_V1__H_
+#define _SQ_MC_EVENT_V1__H_
+#include "SQMCEvent.h"
+
+class SQMCEvent_v1 : public SQMCEvent {
+ public:
+  SQMCEvent_v1();
+  virtual ~SQMCEvent_v1();
+
+  void identify(std::ostream& os = std::cout) const;
+  void Reset();
+  int isValid() const { return 1; }
+  SQMCEvent* Clone() const { return new SQMCEvent_v1(*this); }
+
+  int  get_process_id() const { return _proc_id; }
+  void set_process_id(const int a)   { _proc_id = a; }
+
+  double get_cross_section() const  { return _xsec; }
+  void   set_cross_section(const double a) { _xsec = a; }
+
+  int  get_particle_id(const int i) const;
+  void set_particle_id(const int i, const int a);
+
+  TLorentzVector get_particle_momentum(const int i) const;
+  void           set_particle_momentum(const int i, const TLorentzVector a);
+
+ protected:
+  static const int _N_PAR = 4; // 2 -> 2
+  int _proc_id;
+  double _xsec;
+  int _par_id[_N_PAR];
+  TLorentzVector _par_mom[_N_PAR];
+
+  ClassDef(SQMCEvent_v1, 1)
+};
+
+#endif // _SQ_MC_EVENT_V1__H_

--- a/interface_main/SQMCEvent_v1LinkDef.h
+++ b/interface_main/SQMCEvent_v1LinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class SQMCEvent_v1+;
+
+#endif /* __CINT__ */

--- a/interface_main/SQTrack.cxx
+++ b/interface_main/SQTrack.cxx
@@ -1,0 +1,9 @@
+#include "SQTrack.h"
+using namespace std;
+ClassImp(SQTrack)
+
+//void SQTrack::identify(std::ostream& os = std::cout) const
+//{
+//  cout << "---SQTrack::identify: abstract base-------------------" << endl;
+//}
+

--- a/interface_main/SQTrack.h
+++ b/interface_main/SQTrack.h
@@ -1,0 +1,49 @@
+#ifndef _SQ_TRACK__H_
+#define _SQ_TRACK__H_
+#include <iostream>
+#include <phool/PHObject.h>
+#include <TLorentzVector.h>
+
+class SQTrack: public PHObject {
+ public:
+  virtual ~SQTrack() {}
+
+  virtual void identify(std::ostream& os = std::cout) const = 0;
+  virtual void Reset() = 0;
+  virtual int isValid() const = 0;
+  virtual SQTrack* Clone() const = 0;
+
+  virtual int  get_track_id() const = 0;
+  virtual void set_track_id(const int a) = 0;
+
+  virtual int  get_charge() const = 0;
+  virtual void set_charge(const int a) = 0;
+
+  virtual int  get_num_hits() const = 0;
+  virtual void set_num_hits(const int a) = 0;
+
+  virtual TVector3 get_pos_vtx() const = 0;
+  virtual void     set_pos_vtx(const TVector3 a) = 0;
+
+  virtual TVector3 get_pos_st1() const = 0;
+  virtual void     set_pos_st1(const TVector3 a) = 0;
+
+  virtual TVector3 get_pos_st3() const = 0;
+  virtual void     set_pos_st3(const TVector3 a) = 0;
+
+  virtual TLorentzVector get_mom_vtx() const = 0;
+  virtual void           set_mom_vtx(const TLorentzVector a) = 0;
+
+  virtual TLorentzVector get_mom_st1() const = 0;
+  virtual void           set_mom_st1(const TLorentzVector a) = 0;
+
+  virtual TLorentzVector get_mom_st3() const = 0;
+  virtual void           set_mom_st3(const TLorentzVector a) = 0;
+
+ protected:
+  SQTrack() {}
+
+  ClassDef(SQTrack, 1);
+};
+
+#endif // _SQ_TRACK__H_

--- a/interface_main/SQTrackLinkDef.h
+++ b/interface_main/SQTrackLinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class SQTrack+;
+
+#endif /* __CINT__ */

--- a/interface_main/SQTrackVector.cxx
+++ b/interface_main/SQTrackVector.cxx
@@ -1,0 +1,2 @@
+#include "SQTrackVector.h"
+ClassImp(SQTrackVector)

--- a/interface_main/SQTrackVector.h
+++ b/interface_main/SQTrackVector.h
@@ -1,0 +1,40 @@
+#ifndef _SQ_TRACK_VECTOR__H_
+#define _SQ_TRACK_VECTOR__H_
+#include <iostream>
+#include <vector>
+#include <phool/PHObject.h>
+#include "SQTrack.h"
+
+class SQTrackVector: public PHObject {
+ public:
+  typedef std::vector<SQTrack*>                    Vector;
+  typedef std::vector<SQTrack*>::const_iterator ConstIter;
+  typedef std::vector<SQTrack*>::iterator            Iter;
+
+  virtual ~SQTrackVector() {}
+
+  virtual void identify(std::ostream& os = std::cout) const = 0;
+  virtual void Reset() = 0;
+  virtual int  isValid() const = 0;
+  virtual SQTrackVector* Clone() const = 0;
+
+  virtual ConstIter begin() const = 0;
+  virtual ConstIter end  () const = 0;
+  virtual      Iter begin() = 0;
+  virtual      Iter end  () = 0;
+  virtual bool      empty() const = 0;
+  virtual size_t    size () const = 0;
+  virtual void      clear() = 0;
+
+  virtual const SQTrack* at(const size_t id) const = 0;
+  virtual       SQTrack* at(const size_t id) = 0;
+  virtual       void   push_back(const SQTrack *trk) = 0;
+  virtual       size_t erase(const size_t id) = 0;
+
+ protected:
+  SQTrackVector() {}
+
+  ClassDef(SQTrackVector, 1);
+};
+
+#endif // _SQ_TRACK_VECTOR__H_

--- a/interface_main/SQTrackVectorLinkDef.h
+++ b/interface_main/SQTrackVectorLinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class SQTrackVector+;
+
+#endif /* __CINT__ */

--- a/interface_main/SQTrackVector_v1.cxx
+++ b/interface_main/SQTrackVector_v1.cxx
@@ -1,0 +1,64 @@
+#include "SQTrackVector_v1.h"
+using namespace std;
+ClassImp(SQTrackVector_v1)
+
+SQTrackVector_v1::SQTrackVector_v1()
+{
+  ;
+}
+
+SQTrackVector_v1::SQTrackVector_v1(const SQTrackVector_v1& obj)
+{
+  for (ConstIter iter = obj.begin(); iter != obj.end(); ++iter) {
+    _vector.push_back((*iter)->Clone());
+  }
+}
+
+SQTrackVector_v1& SQTrackVector_v1::operator=(const SQTrackVector_v1& obj)
+{
+  Reset();
+  for (ConstIter iter = obj.begin(); iter != obj.end(); ++iter) {
+    _vector.push_back((*iter)->Clone());
+  }
+  return *this;
+}
+
+SQTrackVector_v1::~SQTrackVector_v1()
+{
+  Reset();
+}
+
+void SQTrackVector_v1::Reset() 
+{
+  for (Iter iter = _vector.begin(); iter != _vector.end(); ++iter) delete *iter;
+  _vector.clear();
+}
+
+void SQTrackVector_v1::identify(ostream& os) const
+{
+  os << "SQTrackVector_v1: size = " << _vector.size() << endl;
+}
+
+const SQTrack* SQTrackVector_v1::at(const size_t id) const
+{
+  if (id >= _vector.size()) return nullptr;
+  return _vector[id];
+}
+
+SQTrack* SQTrackVector_v1::at(const size_t id)
+{
+  if (id >= _vector.size()) return nullptr;
+  return _vector[id];
+}
+
+void SQTrackVector_v1::push_back(const SQTrack *trk)
+{
+  _vector.push_back(trk->Clone());
+}
+
+size_t SQTrackVector_v1::erase(const size_t id)
+{
+  delete _vector[id];
+  _vector.erase(_vector.begin() + id);
+  return _vector.size();
+}

--- a/interface_main/SQTrackVector_v1.h
+++ b/interface_main/SQTrackVector_v1.h
@@ -1,0 +1,36 @@
+#ifndef _SQ_TRACK_VECTOR_V1__H_
+#define _SQ_TRACK_VECTOR_V1__H_
+#include "SQTrackVector.h"
+
+class SQTrackVector_v1: public SQTrackVector {
+ public:
+  SQTrackVector_v1();
+  SQTrackVector_v1(const SQTrackVector_v1& obj);
+  SQTrackVector_v1& operator=(const SQTrackVector_v1& obj);
+  virtual ~SQTrackVector_v1();
+
+  void identify(std::ostream& os = std::cout) const;
+  void Reset();
+  int  isValid() const { return 1; }
+  SQTrackVector* Clone() const { return new SQTrackVector_v1(*this); }
+
+  ConstIter begin() const { return _vector.begin(); }
+  ConstIter end  () const { return _vector.end  (); }
+  Iter      begin()       { return _vector.begin(); }
+  Iter      end  ()       { return _vector.end  (); }
+  bool      empty() const { return _vector.empty(); }
+  size_t    size () const { return _vector.size (); }
+  void      clear() { Reset(); }
+
+  const SQTrack* at(const size_t id) const;
+  SQTrack*       at(const size_t id);
+  void   push_back(const SQTrack *trk);
+  size_t erase(const size_t id);
+
+ protected:
+  Vector _vector;
+
+  ClassDef(SQTrackVector_v1, 1);
+};
+
+#endif // _SQ_TRACK_VECTOR_V1__H_

--- a/interface_main/SQTrackVector_v1LinkDef.h
+++ b/interface_main/SQTrackVector_v1LinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class SQTrackVector_v1+;
+
+#endif /* __CINT__ */

--- a/interface_main/SQTrack_v1.cxx
+++ b/interface_main/SQTrack_v1.cxx
@@ -1,0 +1,31 @@
+#include "SQTrack_v1.h"
+using namespace std;
+
+SQTrack_v1::SQTrack_v1() 
+  : _id(0)
+  , _charge(0)
+  , _n_hits(0)
+  , _pos_vtx(0,0,0)
+  , _pos_st1(0,0,0)
+  , _pos_st3(0,0,0)
+  , _mom_vtx(0,0,0,0)
+  , _mom_st1(0,0,0,0)
+  , _mom_st3(0,0,0,0)
+{
+  ;
+}
+
+SQTrack_v1::~SQTrack_v1()
+{
+  ;
+}
+
+void SQTrack_v1::identify(std::ostream& os) const
+{
+  ;
+}
+
+void SQTrack_v1::Reset()
+{
+  ;
+}

--- a/interface_main/SQTrack_v1.h
+++ b/interface_main/SQTrack_v1.h
@@ -1,0 +1,68 @@
+#ifndef _SQ_TRACK_V1__H_
+#define _SQ_TRACK_V1__H_
+#include "SQTrack.h"
+
+class SQTrack_v1 : public SQTrack {
+ public:
+  SQTrack_v1();
+  virtual ~SQTrack_v1();
+
+  void identify(std::ostream& os = std::cout) const;
+  void Reset();
+  int isValid() const { return 1; }
+  SQTrack* Clone() const { return new SQTrack_v1(*this); }
+
+  virtual int  get_track_id() const { return _id; }
+  virtual void set_track_id(const int a)   { _id = a; }
+
+  virtual int  get_charge() const { return _charge; }
+  virtual void set_charge(const int a)   { _charge = a; }
+
+  virtual int  get_num_hits() const { return _n_hits; }
+  virtual void set_num_hits(const int a)   { _n_hits = a; }
+
+  virtual TVector3 get_pos_vtx() const    { return _pos_vtx; }
+  virtual void     set_pos_vtx(const TVector3 a) { _pos_vtx = a; }
+
+  virtual TVector3 get_pos_st1() const    { return _pos_st1; }
+  virtual void     set_pos_st1(const TVector3 a) { _pos_st1 = a; }
+
+  virtual TVector3 get_pos_st3() const    { return _pos_st3; }
+  virtual void     set_pos_st3(const TVector3 a) { _pos_st3 = a; }
+
+  virtual TLorentzVector get_mom_vtx() const          { return _mom_vtx; }
+  virtual void           set_mom_vtx(const TLorentzVector a) { _mom_vtx = a; }
+
+  virtual TLorentzVector get_mom_st1() const          { return _mom_st1; }
+  virtual void           set_mom_st1(const TLorentzVector a) { _mom_st1 = a; }
+
+  virtual TLorentzVector get_mom_st3() const          { return _mom_st3; }
+  virtual void           set_mom_st3(const TLorentzVector a) { _mom_st3 = a; }
+
+ protected:
+  int _id;
+  int _charge;
+  int _n_hits;
+  TVector3 _pos_vtx;
+  TVector3 _pos_st1;
+  TVector3 _pos_st3;
+  TLorentzVector _mom_vtx;
+  TLorentzVector _mom_st1;
+  TLorentzVector _mom_st3;
+
+  ClassDef(SQTrack_v1, 1);
+};
+
+//struct SQTrackVector : public PHObject, public std::vector<SQTrack> {
+//  SQTrackVector() {;}
+//  virtual ~SQTrackVector() {;}
+//
+//  void identify(std::ostream& os = std::cout) const {;}
+//  void Reset() { *this = SQTrackVector(); }
+//  int isValid() const { return 1; }
+//  SQTrackVector* Clone() const { return new SQTrackVector(*this); }
+//
+//  ClassDef(SQTrackVector, 1);
+//};
+
+#endif // _SQ_TRACK_V1__H_

--- a/interface_main/SQTrack_v1LinkDef.h
+++ b/interface_main/SQTrack_v1LinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class SQTrack_v1+;
+
+#endif /* __CINT__ */

--- a/packages/UtilAna/UtilDimuon.cc
+++ b/packages/UtilAna/UtilDimuon.cc
@@ -1,0 +1,38 @@
+#include <TLorentzVector.h>
+#include <interface_main/SQDimuon.h>
+#include "UtilDimuon.h"
+using namespace std;
+
+void UtilDimuon::GetX1X2(const SQDimuon* dim, double& x1, double& x2)
+{
+  const double M_P    = 0.938;
+  const double E_BEAM = 120.0;
+  const TLorentzVector p_beam  (0, 0, sqrt(E_BEAM*E_BEAM - M_P*M_P), E_BEAM);
+  const TLorentzVector p_target(0, 0, 0, M_P);
+  const TLorentzVector p_cms = p_beam + p_target;
+  TLorentzVector p_sum = dim->get_mom_pos() + dim->get_mom_neg();
+  x1 = (p_target*p_sum)/(p_target*p_cms);
+  x2 = (p_beam  *p_sum)/(p_beam  *p_cms);
+}
+
+void UtilDimuon::GetX1X2(const SQDimuon* dim, float& x1, float& x2)
+{
+  double x1d, x2d;
+  GetX1X2(dim, x1d, x2d);
+  x1 = x1d;
+  x2 = x2d;
+}
+
+double UtilDimuon::GetX1(const SQDimuon* dim)
+{
+  double x1, x2;
+  GetX1X2(dim, x1, x2);
+  return x1;
+}
+
+double UtilDimuon::GetX2(const SQDimuon* dim)
+{
+  double x1, x2;
+  GetX1X2(dim, x1, x2);
+  return x2;
+}

--- a/packages/UtilAna/UtilDimuon.h
+++ b/packages/UtilAna/UtilDimuon.h
@@ -1,0 +1,12 @@
+#ifndef _UTIL_DIMUON__H_
+#define _UTIL_DIMUON__H_
+class SQDimuon;
+
+namespace UtilDimuon {
+  void GetX1X2(const SQDimuon* dim, double& x1, double& x2);
+  void GetX1X2(const SQDimuon* dim,  float& x1,  float& x2);
+  double GetX1(const SQDimuon* dim);
+  double GetX2(const SQDimuon* dim);
+}
+
+#endif /* _UTIL_DIMUON__H_ */

--- a/packages/evt_filter/SimDstTrimmer.cxx
+++ b/packages/evt_filter/SimDstTrimmer.cxx
@@ -1,0 +1,63 @@
+#include <iomanip>
+#include <fun4all/Fun4AllBase.h>
+#include <fun4all/Fun4AllReturnCodes.h>
+#include <phool/PHNodeIterator.h>
+#include <phool/PHCompositeNode.h>
+#include <phool/PHIODataNode.h>
+#include <phool/getClass.h>
+#include <g4main/PHG4TruthInfoContainer.h>
+#include "SimDstTrimmer.h"
+
+#define LogInfo(message) std::cout << "DEBUG: " << __FILE__ << "  " << __LINE__ << "  " << __FUNCTION__ << " :::  " << message << std::endl
+
+using namespace std;
+
+SimDstTrimmer::SimDstTrimmer(const std::string& name)
+  : SubsysReco(name), _truth(0)
+{
+  ;
+}
+
+SimDstTrimmer::~SimDstTrimmer()
+{
+  ;
+}
+
+int SimDstTrimmer::Init(PHCompositeNode *topNode)
+{
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int SimDstTrimmer::InitRun(PHCompositeNode* topNode)
+{
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int SimDstTrimmer::process_event(PHCompositeNode* topNode)
+{
+  int ret = GetNodes(topNode);
+  if (ret != Fun4AllReturnCodes::EVENT_OK) return ret;
+
+  PHG4TruthInfoContainer::ShowerRange range = _truth->GetShowerRange();
+  for (PHG4TruthInfoContainer::ShowerIterator it = range.first; it != range.second; ) {
+    _truth->delete_shower(it++);
+  }
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int SimDstTrimmer::End(PHCompositeNode* topNode)
+{
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int SimDstTrimmer::GetNodes(PHCompositeNode* topNode)
+{
+  _truth = findNode::getClass<PHG4TruthInfoContainer>(topNode, "G4TruthInfo");
+  if (!_truth) {
+    LogInfo("!_truth");
+    return Fun4AllReturnCodes::ABORTEVENT;
+  }
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+

--- a/packages/evt_filter/SimDstTrimmer.h
+++ b/packages/evt_filter/SimDstTrimmer.h
@@ -1,0 +1,29 @@
+#ifndef SimDstTrimmer_H
+#define SimDstTrimmer_H
+//#include <vector>
+//#include <string>
+//#include <iostream>
+//#include <set>
+//#include <list>
+//#include <map>
+#include <fun4all/SubsysReco.h>
+class PHG4TruthInfoContainer;
+
+class SimDstTrimmer : public SubsysReco {
+ public:
+  SimDstTrimmer(const std::string &name = "SimDstTrimmer");
+  virtual ~SimDstTrimmer();
+
+  int Init(PHCompositeNode *topNode);
+  int InitRun(PHCompositeNode *topNode);
+  int process_event(PHCompositeNode *topNode);
+  int End(PHCompositeNode *topNode);
+    
+ private:
+  PHG4TruthInfoContainer* _truth;
+
+  int GetNodes(PHCompositeNode *topNode);
+};
+
+
+#endif

--- a/packages/evt_filter/SimDstTrimmerLinkDef.h
+++ b/packages/evt_filter/SimDstTrimmerLinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class SimDstTrimmer-!;
+
+#endif /* __CINT__ */

--- a/script/setup-install.sh
+++ b/script/setup-install.sh
@@ -40,27 +40,35 @@ mkdir -p $DIR_INST
 ##
 ## Check and set up the parent environments.
 ##
-E1039_ROOT=
 if   [ ${HOSTNAME:0:11} = 'seaquestdaq' -o \
        ${HOSTNAME:0:12} = 'spinquestana' ] ; then
-    echo "Use the environment predefined for seaquestdaq/spinquestana."
-    E1039_ROOT=/data2/e1039
+    echo "Use the environment for seaquestdaq/spinquestana."
+    {
+	echo 'export  E1039_ROOT=/data2/e1039'
+	echo 'source $E1039_ROOT/resource/this-resource.sh'
+	echo 'source $E1039_ROOT/share/this-share.sh'
+	echo 'source $(dirname $(readlink -f $BASH_SOURCE))/this-core.sh'
+    } >$DIR_INST/this-e1039.sh
+    
 elif [ ${HOSTNAME:0:12} = 'seaquestgpvm' -o \
        ${HOSTNAME:0:13} = 'spinquestgpvm' ] ; then
-    echo "Use the environment predefined for seaquestgpvm/spinquestgpvm."
-    E1039_ROOT=/e906/app/software/osg/software/e1039
-fi
-if [ -z "$E1039_ROOT" ] ; then
+    echo "Use the environment for seaquestgpvm/spinquestgpvm."
+    {
+	echo 'export E1039_ROOT=/e906/app/software/osg/software/e1039'
+	echo 'if [ ! -d $E1039_ROOT ] ; then '
+	echo '    E1039_ROOT=/cvmfs/seaquest.opensciencegrid.org/seaquest/software/e1039'
+	echo 'fi'
+	echo 'source $E1039_ROOT/resource/this-resource.sh'
+	echo 'source $E1039_ROOT/share/this-share.sh'
+	echo 'source $(dirname $(readlink -f $BASH_SOURCE))/this-core.sh'
+    } >$DIR_INST/this-e1039.sh
+    
+else
     echo "Your host is not supported by this script."
     echo "You can ask the manager (Kenichi) how to proceed, or"
     echo "try to set E1039_RESOURCE and E1039_SHARE properly by yourself."
     exit 1
 fi
-{
-    echo "source $E1039_ROOT/resource/this-resource.sh"
-    echo "source $E1039_ROOT/share/this-share.sh"
-    echo 'source $(dirname $(readlink -f $BASH_SOURCE))/this-core.sh'
-} >$DIR_INST/this-e1039.sh
 
 ##
 ## Message

--- a/simulation/g4dst/CMakeLists.txt
+++ b/simulation/g4dst/CMakeLists.txt
@@ -2,20 +2,56 @@
 cmake_minimum_required(VERSION 2.6 FATAL_ERROR)
 project(g4dst CXX C)
 
-add_library(g4dst SHARED
-  g4dst.C
+# source code
+file(GLOB          sources ${PROJECT_SOURCE_DIR}/*.cc)
+file(GLOB     dist_headers ${PROJECT_SOURCE_DIR}/*.h)
+file(GLOB non_dist_headers ${PROJECT_SOURCE_DIR}/LinkDef.h)
+list(REMOVE_ITEM dist_headers ${non_dist_headers})
+
+# ROOT dict generation
+add_custom_command (
+  OUTPUT g4dst_Dict.cc
+  COMMAND rootcint
+  ARGS -f g4dst_Dict.cc -noIncludePaths -inlineInputHeader -c -p
+    -I${PROJECT_SOURCE_DIR}/ -I${ROOT_PREFIX}/include/
+    ${dist_headers} ${non_dist_headers}
 )
 
-add_custom_command(
-  OUTPUT g4dst.C
-  COMMAND echo
-  ARGS "//*** this is a generated empty file. Do not commit, do not edit" > g4dst.C
-)
+# ROOT
+find_program(ROOTCONF "root-config")
+if(ROOTCONF)
+  message("-- Detecting ROOT:    found at ${ROOTCONF}")
+else()
+  message(FATAL_ERROR "-- Detecting ROOT:    not found")
+endif()
+execute_process(COMMAND root-config --prefix OUTPUT_VARIABLE ROOT_PREFIX  OUTPUT_STRIP_TRAILING_WHITESPACE)
+execute_process(COMMAND root-config --cflags OUTPUT_VARIABLE ROOT_CFLAGS  OUTPUT_STRIP_TRAILING_WHITESPACE)
+execute_process(COMMAND root-config --libs   OUTPUT_VARIABLE ROOT_LINK    OUTPUT_STRIP_TRAILING_WHITESPACE)
 
-target_link_libraries(g4dst -lphg4hit -lg4detectors_io -lphgeom_io -lphhepmc_io -lphfield_io)
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x ${ROOT_CFLAGS}")
 
-install(TARGETS g4dst	DESTINATION ${CMAKE_INSTALL_PREFIX}/lib)
+add_library(g4dst SHARED  ${sources} g4dst_Dict.cc)
+target_link_libraries(g4dst  -lfun4all -linterface_main -lphg4hit -lPHPythia8 -lg4detectors)
 
-message(${CMAKE_PROJECT_NAME} " will be installed to " ${CMAKE_INSTALL_PREFIX})
-
+install(TARGETS g4dst         DESTINATION ${CMAKE_INSTALL_PREFIX}/lib)
 install(FILES ${dist_headers} DESTINATION ${CMAKE_INSTALL_PREFIX}/include/${CMAKE_PROJECT_NAME}/)
+
+# Install the pcm files in case of ROOT 6.
+execute_process(COMMAND root-config --version OUTPUT_VARIABLE ROOT_VER)
+string(SUBSTRING ${ROOT_VER} 0 1 ROOT_VER)
+if (ROOT_VER GREATER 5)
+   add_custom_target(install_pcm ALL COMMAND mkdir -p ${CMAKE_INSTALL_PREFIX}/lib COMMAND cp -up *_rdict.pcm ${CMAKE_INSTALL_PREFIX}/lib)
+   add_dependencies(install_pcm g4dst)
+endif()
+
+#add_library(g4dst SHARED
+#  g4dst.C
+#)
+#
+#add_custom_command(
+#  OUTPUT g4dst.C
+#  COMMAND echo
+#  ARGS "//*** this is a generated empty file. Do not commit, do not edit" > g4dst.C
+#)
+#
+#target_link_libraries(g4dst -lphg4hit -lg4detectors_io -lphgeom_io -lphhepmc_io -lphfield_io)

--- a/simulation/g4dst/LinkDef.h
+++ b/simulation/g4dst/LinkDef.h
@@ -3,8 +3,6 @@
 #pragma link off all function;
 #pragma link off all global;
 
-#pragma link C++ class UtilOnline-!;
-#pragma link C++ class UtilSQHit-!;
-#pragma link C++ class UtilDimuon-!;
+#pragma link C++ class TruthNodeMaker-!;
 
 #endif

--- a/simulation/g4dst/TruthNodeMaker.cc
+++ b/simulation/g4dst/TruthNodeMaker.cc
@@ -229,8 +229,8 @@ int TruthNodeMaker::MakeNodes(PHCompositeNode* topNode)
   m_vec_dim = new SQDimuonVector_v1();
 
   node_dst->addNode(new PHIODataNode<PHObject>(m_evt    , "SQMCEvent"         , "PHObject"));
-  node_dst->addNode(new PHIODataNode<PHObject>(m_vec_trk, "SQTrueTrackVector" , "PHObject"));
-  node_dst->addNode(new PHIODataNode<PHObject>(m_vec_dim, "SQTrueDimuonVector", "PHObject"));
+  node_dst->addNode(new PHIODataNode<PHObject>(m_vec_trk, "SQTruthTrackVector" , "PHObject"));
+  node_dst->addNode(new PHIODataNode<PHObject>(m_vec_dim, "SQTruthDimuonVector", "PHObject"));
 
   return Fun4AllReturnCodes::EVENT_OK;
 }

--- a/simulation/g4dst/TruthNodeMaker.cc
+++ b/simulation/g4dst/TruthNodeMaker.cc
@@ -1,0 +1,247 @@
+#include <iomanip>
+#include <phhepmc/PHHepMCGenEventMap.h>
+#include <g4main/PHG4TruthInfoContainer.h>
+#include <g4main/PHG4HitContainer.h>
+#include <g4main/PHG4Hit.h>
+#include <g4main/PHG4Particle.h>
+//#include <g4main/PHG4HitDefs.h>
+#include <g4main/PHG4VtxPoint.h>
+//#include <HepMC/GenRanges.h>
+//#include <interface_main/SQRun.h>
+//#include <interface_main/SQEvent.h>
+//#include <interface_main/SQHitVector.h>
+//#include <ktracker/SRecEvent.h>
+#include <interface_main/SQMCEvent_v1.h>
+#include <interface_main/SQTrack_v1.h>
+#include <interface_main/SQDimuon_v1.h>
+#include <interface_main/SQTrackVector_v1.h>
+#include <interface_main/SQDimuonVector_v1.h>
+#include <fun4all/Fun4AllReturnCodes.h>
+#include <phool/PHNodeIterator.h>
+#include <phool/PHIODataNode.h>
+#include <phool/getClass.h>
+//#include <geom_svc/GeomSvc.h>
+//#include <UtilAna/UtilSQHit.h>
+#include "TruthNodeMaker.h"
+using namespace std;
+
+TruthNodeMaker::TruthNodeMaker()
+  : m_evt(0)
+  , m_vec_trk(0)
+  , m_vec_dim(0)
+{
+  ;
+}
+
+TruthNodeMaker::~TruthNodeMaker()
+{
+  if (! m_evt    ) delete m_evt;
+  if (! m_vec_trk) delete m_vec_trk;
+  if (! m_vec_dim) delete m_vec_dim;
+}
+
+int TruthNodeMaker::Init(PHCompositeNode* topNode)
+{
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int TruthNodeMaker::InitRun(PHCompositeNode* topNode)
+{
+  int ret = GetNodes(topNode);
+  if (ret != Fun4AllReturnCodes::EVENT_OK) return ret;
+  ret = MakeNodes(topNode);
+  if (ret != Fun4AllReturnCodes::EVENT_OK) return ret;
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int TruthNodeMaker::process_event(PHCompositeNode* topNode)
+{
+  //const double M_MU = 0.1056583745; // GeV
+
+  typedef std::map<const HepMC::GenParticle*, int> ParPtr2Id_t;
+  ParPtr2Id_t map_par_ptr;
+
+  m_vec_trk->clear();
+  m_vec_dim->clear();
+  int id_trk = 0; // to be incremented
+  int id_dim = 0; // to be incremented
+
+  if (genevtmap->size() != 1) {
+    cout << "TruthNodeMaker::process_event(): size != 1 unexpectedly." << endl;
+  }
+  for (PHHepMCGenEventMap::Iter iter = genevtmap->begin(); iter != genevtmap->end(); ++iter) {
+    PHHepMCGenEvent *genevt = iter->second;
+    if (! genevt) {
+      cout << "No PHHepMCGenEvent object." << endl;
+      return Fun4AllReturnCodes::ABORTEVENT;
+    }
+    HepMC::GenEvent *evt = genevt->getEvent();
+    if (! evt) {
+      cout << "No HepMC::GenEvent object." << endl;
+      return Fun4AllReturnCodes::ABORTEVENT;
+    }
+    m_evt->set_process_id(evt->signal_process_id());
+
+    /// Extract the hard process.
+    //HepMC::GenVertex* vtx = evt->signal_process_vertex(); // Return 0 as of 2019-11-19.
+    HepMC::GenEvent::particle_const_iterator it = evt->particles_begin();
+    it++; // Skip the 1st beam particle.
+    for (int iii = 0; iii < 4; iii++) {
+      it++;
+      const HepMC::GenParticle* par = *it;
+      const HepMC::FourVector * mom = &par->momentum();
+      TLorentzVector lvec;
+      lvec.SetPxPyPzE(mom->px(), mom->py(), mom->pz(), mom->e());
+      m_evt->set_particle_id(iii, par->pdg_id());
+      m_evt->set_particle_momentum(iii, lvec);
+    }
+
+    /// Extract muons.
+    while (++it != evt->particles_end()) {
+      const HepMC::GenParticle* par = *it;
+      int pid = par->pdg_id();
+      if (abs(pid) != 13) continue;
+      HepMC::FourVector pos = par->production_vertex()->position();
+      HepMC::FourVector mom = par->momentum();
+
+      SQTrack_v1 trk;
+      trk.set_track_id(id_trk++);
+      trk.set_charge(pid < 0 ? +1: -1); // -13 = mu+
+      trk.set_pos_vtx(TVector3      (pos.x(), pos.y(), pos.z()         ));
+      trk.set_mom_vtx(TLorentzVector(mom.x(), mom.y(), mom.z(), mom.t()));
+      //SetTrackParamUsingHits(par, &trk);
+      m_vec_trk->push_back(&trk);
+
+      map_par_ptr[par] = trk.get_track_id();
+    }
+
+    /// Extract dimuon vertecies.
+    for (HepMC::GenEvent::vertex_const_iterator it = evt->vertices_begin(); it != evt->vertices_end(); it++) {
+      HepMC::GenVertex* vtx = *it;
+      if (   vtx->particles_in_size () != 1
+          || vtx->particles_out_size() != 2) continue;
+      HepMC::GenParticle* par_mup = 0;
+      HepMC::GenParticle* par_mum = 0;
+      for (HepMC::GenVertex::particles_out_const_iterator it_par = vtx->particles_out_const_begin(); it_par != vtx->particles_out_const_end(); it_par++) {
+        HepMC::GenParticle* par = *it_par;
+        int pdg_id = par->pdg_id();
+        if      (pdg_id == -13) par_mup = par;
+        else if (pdg_id == +13) par_mum = par;
+      }
+      if (! par_mup || ! par_mum) continue;
+      if (   map_par_ptr.find(par_mup) == map_par_ptr.end() 
+          || map_par_ptr.find(par_mum) == map_par_ptr.end()) {
+        cout << "ERROR:  GenVertex points to an invalid GenParticle!?" << endl;
+        return Fun4AllReturnCodes::ABORTEVENT;
+      }
+      int idx_mup = map_par_ptr[par_mup];
+      int idx_mum = map_par_ptr[par_mum];
+      HepMC::GenParticle* par_dim = *(vtx->particles_in_const_begin());
+      HepMC::FourVector pos = par_dim->production_vertex()->position();
+      HepMC::FourVector mom = par_dim->momentum();
+
+      SQDimuon_v1 dim;
+      dim.set_dimuon_id(id_dim++);
+      dim.set_pdg_id(par_dim->pdg_id());
+      dim.set_pos(TVector3      (pos.x(), pos.y(), pos.z()         ));
+      dim.set_mom(TLorentzVector(mom.x(), mom.y(), mom.z(), mom.t()));
+      dim.set_mom_pos(m_vec_trk->at(idx_mup)->get_mom_vtx());
+      dim.set_mom_neg(m_vec_trk->at(idx_mum)->get_mom_vtx());
+      dim.set_track_id_pos(idx_mup);
+      dim.set_track_id_neg(idx_mum);
+      m_vec_dim->push_back(&dim);
+    }
+  }
+
+  ///
+  /// Construct the true track and dimuon info
+  ///
+//  m_vec_trk->clear();
+//  m_vec_dim->clear();
+//  vector<int> vec_vtx_id;
+//  for (auto it = g4true->GetPrimaryParticleRange().first; it != g4true->GetPrimaryParticleRange().second; ++it) {
+//    PHG4Particle* par = it->second;
+//    int pid = par->get_pid();
+//    if (abs(pid) != 13) continue; // not muon
+//    SQTrack trk;
+//    int vtx_id = par->get_vtx_id();
+//    PHG4VtxPoint* vtx = g4true->GetVtx(vtx_id);
+//    trk.charge = pid < 0 ? +1: -1; // -13 = mu+
+//    trk.pos_vtx.SetXYZ(vtx->get_x(), vtx->get_y(), vtx->get_z());
+//    trk.mom_vtx.SetXYZM(par->get_px(), par->get_py(), par->get_pz(), M_MU);
+//    m_vec_trk->push_back(trk);
+//    vec_vtx_id.push_back(vtx_id);
+//  }
+//
+//  unsigned int n_trk = m_vec_trk->size();
+//  for (unsigned int i1 = 0; i1 < n_trk; i1++) {
+//    SQTrack* trk1 = &m_vec_trk->at(i1);
+//    if (trk1->charge <= 0) continue;
+//    for (unsigned int i2 = 0; i2 < n_trk; i2++) {
+//      SQTrack* trk2 = &m_vec_trk->at(i2);
+//      if (trk2->charge >= 0) continue;
+//      if (vec_vtx_id[i1] != vec_vtx_id[i2]) continue;
+//      SQDimuon dim;
+//      dim.pos = trk1->pos_vtx;
+//      dim.mom = trk1->mom_vtx + trk2->mom_vtx;
+//      dim.mom_pos = trk1->mom_vtx;
+//      dim.mom_neg = trk2->mom_vtx;
+//      dim.track_id_pos = i1;
+//      dim.track_id_neg = i2;
+//      m_vec_dim->push_back(dim);
+//    }
+//  }
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int TruthNodeMaker::End(PHCompositeNode* topNode)
+{
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int TruthNodeMaker::GetNodes(PHCompositeNode* topNode)
+{
+  genevtmap = findNode::getClass<PHHepMCGenEventMap    >(topNode, "PHHepMCGenEventMap");
+  g4true    = findNode::getClass<PHG4TruthInfoContainer>(topNode, "G4TruthInfo");
+  g4hc_d1x  = findNode::getClass<PHG4HitContainer      >(topNode, "G4HIT_D1X");
+  //g4hc_d3x  = findNode::getClass<PHG4HitContainer      >(topNode, "G4HIT_D3X");
+  if (! g4hc_d1x) g4hc_d1x = findNode::getClass<PHG4HitContainer>(topNode, "G4HIT_D0X");
+
+  //if (!genevtmap || !g4true || !g4hc_d1x || !g4hc_d3x) {
+  if (!genevtmap || !g4true || !g4hc_d1x) {
+    return Fun4AllReturnCodes::ABORTEVENT;
+  }
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int TruthNodeMaker::MakeNodes(PHCompositeNode* topNode)
+{
+  PHNodeIterator iter(topNode);
+  PHCompositeNode* node_dst = static_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "DST"));
+  if (! node_dst) {
+    cout << "No DST node!?" << endl;
+    return Fun4AllReturnCodes::ABORTEVENT;
+  }
+
+  m_evt     = new SQMCEvent_v1();
+  m_vec_trk = new SQTrackVector_v1();
+  m_vec_dim = new SQDimuonVector_v1();
+
+  node_dst->addNode(new PHIODataNode<PHObject>(m_evt    , "SQMCEvent"         , "PHObject"));
+  node_dst->addNode(new PHIODataNode<PHObject>(m_vec_trk, "SQTrueTrackVector" , "PHObject"));
+  node_dst->addNode(new PHIODataNode<PHObject>(m_vec_dim, "SQTrueDimuonVector", "PHObject"));
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+//void TruthNodeMaker::SetTrackParamUsingHits(const HepMC::GenParticle* par, SQTrack* trk)
+//{
+//  PHG4HitContainer::ConstRange range = g4hc_d1x->getHits();
+//  for (PHG4HitContainer::ConstIterator it = range.first; it != range.second; it++) {
+//    PHG4Hit* hit = it->second;
+//    cout << "d1x " << hit->get_detid() << " " << hit->get_trkid() << endl;
+//  }
+//    
+//  //g4hc_d3x;
+//}

--- a/simulation/g4dst/TruthNodeMaker.h
+++ b/simulation/g4dst/TruthNodeMaker.h
@@ -1,0 +1,39 @@
+#ifndef _TRUTH_NODE_MAKER__H_
+#define _TRUTH_NODE_MAKER__H_
+#include <fun4all/SubsysReco.h>
+namespace HepMC { 
+  class GenParticle; 
+};
+class PHHepMCGenEventMap;
+class PHG4TruthInfoContainer;
+class PHG4HitContainer;
+class SQMCEvent;
+class SQTrackVector;
+class SQDimuonVector;
+
+/// An SubsysReco module to create a set of (compact) nodes for the simulation true info.
+class TruthNodeMaker: public SubsysReco {
+  PHHepMCGenEventMap* genevtmap;
+  PHG4TruthInfoContainer* g4true;
+  PHG4HitContainer *g4hc_d1x;
+  PHG4HitContainer *g4hc_d3x;
+
+  SQMCEvent*      m_evt;
+  SQTrackVector*  m_vec_trk;
+  SQDimuonVector* m_vec_dim;
+
+ public:
+  TruthNodeMaker();
+  virtual ~TruthNodeMaker();
+  int Init(PHCompositeNode *topNode);
+  int InitRun(PHCompositeNode *topNode);
+  int process_event(PHCompositeNode *topNode);
+  int End(PHCompositeNode *topNode);
+
+ private:
+  int  GetNodes(PHCompositeNode *topNode);
+  int MakeNodes(PHCompositeNode *topNode);
+  //void SetTrackParamUsingHits(const HepMC::GenParticle* par, SQTrack* trk);
+};
+
+#endif /* _TRUTH_NODE_MAKER__H_ */


### PR DESCRIPTION
This update includes new SQ interface classes and SubsysReco modules that store and handle simulated variables.  Most of them were taken (imported) from "e1039-share/AnaSimDst" that I explained in DocDB 7056.  I myself have confirmed that this version runs fine on gpvm01 and grid and its output (i.e. DST) is analyzable by the "new_truth_sq_int" version of "e1039-share/AnaSimDst".

SQTrack and SQDimuon are to store the truth info on track and dimuon (and possibly the reconstructed info also).  Their vector classes and the class inheritances are similar to the existing ones like SQHit (and SQHitVector).  SQMCEvent is to store the event info such as the ID and cross section of  elementary process ID.  These classes will be able to be unified with "generators/E906LegacyGen/SQ*".

TruthNodeMaker is a SubsysReco module to create data nodes of SQTrack, SQDimuon and SQMCEvent.

UtilDimuon is a collection of functions about the dimuon variables.  We can add more functions that, for example, compute the CS angles.