### PR TITLE
Addition of spill selector to OnlMon

### DIFF
--- a/online/decoder_maindaq/DecoData.cc
+++ b/online/decoder_maindaq/DecoData.cc
@@ -55,7 +55,7 @@ ScalerData::ScalerData() :
 }
 
 SpillData::SpillData() : 
-  spill_id(0), spill_id_cntr(0), run_id(0), targ_pos(0), 
+  spill_id(0), spill_id_slow(0), run_id(0), targ_pos(0), 
   bos_coda_id(0), bos_vme_time(0), eos_coda_id(0), eos_vme_time(0), 
   n_bos_spill(0), n_eos_spill(0), n_slow(0), n_scaler(0)
 {

--- a/online/decoder_maindaq/DecoData.h
+++ b/online/decoder_maindaq/DecoData.h
@@ -138,8 +138,8 @@ struct ScalerData {
 typedef std::vector<ScalerData> ScalerDataList;
 
 struct SpillData {
-  unsigned int spill_id;
-  unsigned int spill_id_cntr; //< spill ID in Spill Counter
+  unsigned int spill_id; //< spill ID in Spill Counter
+  unsigned int spill_id_slow; //< spill ID in slow control
   unsigned int run_id;
   unsigned int targ_pos;
   unsigned int bos_coda_id;

--- a/online/decoder_maindaq/MainDaqParser.cc
+++ b/online/decoder_maindaq/MainDaqParser.cc
@@ -486,20 +486,18 @@ int MainDaqParser::ProcessPhysBOSEOS(int* words, const int type)
       return 1;
     }
 
-    /// Temporary adjustment (added on 2019-09-25).
-    /// Since spill ID is not available in the cosmic-ray commissioning,
+    /// Temporary adjustment (modified on 2020-01-15).
+    /// Since spill ID is not always available in the cosmic-ray commissioning,
     /// a temporary ID is given here.
-    if (dec_par.spillID_slow == 0 && dec_par.spillID_cntr == 0) {
-      static int spillID_local = 0;
-      dec_par.spillID_slow = dec_par.spillID_cntr = ++spillID_local;
-    }
+    static int spillID_local = 0;
+    dec_par.spillID_cntr = ++spillID_local;
 
     /// Regard the Slow Control info as primary (rather than Spill Counter)
-    dec_par.spillID     = dec_par.spillID_slow;
+    dec_par.spillID     = dec_par.spillID_cntr;
     dec_par.targPos     = dec_par.targPos_slow;
     SpillData* data     = &(*list_sd)[dec_par.spillID];
     data->spill_id      = dec_par.spillID;
-    data->spill_id_cntr = dec_par.spillID_cntr;
+    data->spill_id_slow = dec_par.spillID_slow;
     data->run_id        = dec_par.runID;
     data->targ_pos      = dec_par.targPos;
 

--- a/online/decoder_maindaq/MainDaqParser.cc
+++ b/online/decoder_maindaq/MainDaqParser.cc
@@ -598,8 +598,8 @@ int MainDaqParser::ProcessPhysFlush(int* words)
     
     idx++; // go to next position to get ROCID
     int rocID = get_hex_bits (words[idx], 5, 2);
-    if (rocID > 30) {
-      cerr << "ERROR: rocID > 30." << endl;
+    if (rocID > 64) { // "64" is a rough number, not strict limit.
+      cerr << "ERROR: rocID > 64." << endl;
       return -1;
     }
     dec_par.rocID = rocID;

--- a/online/macros/TestOnlMon4MainDaq.C
+++ b/online/macros/TestOnlMon4MainDaq.C
@@ -1,0 +1,75 @@
+/// TestOnlMon4MainDaq.C
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6,00,0)
+R__LOAD_LIBRARY(libinterface_main)
+R__LOAD_LIBRARY(libonlmonserver)
+#endif
+
+int TestOnlMon4MainDaq()
+{
+  return 0;
+}
+
+void ConfigServer()
+{
+  OnlMonServer::SetPort (9086);
+  OnlMonServer::SetPort0(9086);
+  OnlMonServer::SetNumPorts(1);
+}
+
+int OnlMon4MainDaq()
+{
+  if (gROOT->IsBatch()) {
+    cout << "ERROR: This macro cannot run in the batch mode (-b).  Abort.\n";
+    exit(1);
+  }
+  gSystem->Load("libdecoder_maindaq.so");
+  gSystem->Load("libonlmonserver.so");
+
+  ConfigServer();
+  //OnlMonServer::SetHost("192.168.24.211");
+
+  OnlMonClientList_t list_omc;
+  list_omc.push_back(new OnlMonMainDaq());
+  list_omc.push_back(new OnlMonTrigNim());
+  OnlMonUI* ui = new OnlMonUI(&list_omc);
+  //ui->SetCycleInterval(5); // default = 10 sec
+  //ui->SetAutoCycleFlag(true); // default = false
+  ui->Run();
+  
+  return 0;
+}
+
+int Fun4MainDaq(const int run=1330, const int nevent=0)
+{
+  gSystem->Umask(0002);
+  gSystem->Load("libinterface_main.so");
+  gSystem->Load("libdecoder_maindaq.so");
+  gSystem->Load("libonlmonserver.so");
+
+  ConfigServer();
+  UtilOnline::UseOutputLocationForDevel();
+
+  //DecoStatusDb deco_stat;
+  //deco_stat.RunStarted(run);
+
+  string fn_in = "/data2/e1039/dst/" + UtilOnline::RunNum2DstFile(run);
+
+  OnlMonServer* se = OnlMonServer::instance();
+  //se->Verbosity(1);
+  se->StartServer();
+  se->registerSubsystem(new OnlMonMainDaq());
+  se->registerSubsystem(new OnlMonTrigNim());
+  se->registerSubsystem(new AnaWait(1, 0)); // (spill, event)
+
+  Fun4AllInputManager *in = new Fun4AllDstInputManager("MainDaq");
+  in->fileopen(fn_in);
+  se->registerInputManager(in);
+
+  se->run(nevent);
+  se->End();
+  //deco_stat.RunFinished(run, 0); // always "result = 0" for now.
+  
+  delete se;
+  cout << "Fun4MainDaq Done!" << endl;
+  return 0;
+}

--- a/online/macros/TestOnlMon4MainDaq.C
+++ b/online/macros/TestOnlMon4MainDaq.C
@@ -26,7 +26,6 @@ int OnlMon4MainDaq()
   gSystem->Load("libonlmonserver.so");
 
   ConfigServer();
-  //OnlMonServer::SetHost("192.168.24.211");
 
   OnlMonClientList_t list_omc;
   list_omc.push_back(new OnlMonMainDaq());
@@ -49,9 +48,6 @@ int Fun4MainDaq(const int run=1330, const int nevent=0)
   ConfigServer();
   UtilOnline::UseOutputLocationForDevel();
 
-  //DecoStatusDb deco_stat;
-  //deco_stat.RunStarted(run);
-
   string fn_in = "/data2/e1039/dst/" + UtilOnline::RunNum2DstFile(run);
 
   OnlMonServer* se = OnlMonServer::instance();
@@ -67,7 +63,6 @@ int Fun4MainDaq(const int run=1330, const int nevent=0)
 
   se->run(nevent);
   se->End();
-  //deco_stat.RunFinished(run, 0); // always "result = 0" for now.
   
   delete se;
   cout << "Fun4MainDaq Done!" << endl;

--- a/online/onlmonserver/AnaWait.cc
+++ b/online/onlmonserver/AnaWait.cc
@@ -1,9 +1,5 @@
-//#include <iomanip>
-//#include <TSystem.h>
 #include <interface_main/SQEvent.h>
 #include <fun4all/Fun4AllReturnCodes.h>
-//#include <phool/PHNodeIterator.h>
-//#include <phool/PHIODataNode.h>
 #include <phool/getClass.h>
 #include "AnaWait.h"
 using namespace std;

--- a/online/onlmonserver/AnaWait.cc
+++ b/online/onlmonserver/AnaWait.cc
@@ -1,0 +1,60 @@
+//#include <iomanip>
+//#include <TSystem.h>
+#include <interface_main/SQEvent.h>
+#include <fun4all/Fun4AllReturnCodes.h>
+//#include <phool/PHNodeIterator.h>
+//#include <phool/PHIODataNode.h>
+#include <phool/getClass.h>
+#include "AnaWait.h"
+using namespace std;
+
+AnaWait::AnaWait(const int sec_spill, const int sec_event)
+  : m_wait_spill(sec_spill), m_wait_event(sec_event)
+{
+  ;
+}
+
+AnaWait::~AnaWait()
+{
+  ;
+}
+
+int AnaWait::Init(PHCompositeNode* topNode)
+{
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int AnaWait::InitRun(PHCompositeNode* topNode)
+{
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int AnaWait::process_event(PHCompositeNode* topNode)
+{
+  SQEvent* event = findNode::getClass<SQEvent>(topNode, "SQEvent");
+  if (!event) return Fun4AllReturnCodes::ABORTEVENT;
+
+  static int id_pre = -1;
+  int id = event->get_spill_id();
+  if (id_pre < 0) {
+    id_pre = id;
+  } else if (id != id_pre) {
+    id_pre = id;
+    cout << "  AnaWait: " << m_wait_spill << " sec." << endl;
+    DoWait(m_wait_spill);
+  } else {
+    DoWait(m_wait_event);
+  }
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int AnaWait::End(PHCompositeNode* topNode)
+{
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+void AnaWait::DoWait(int sec)
+{
+  while (sec-- > 0) sleep(1);
+}

--- a/online/onlmonserver/AnaWait.h
+++ b/online/onlmonserver/AnaWait.h
@@ -1,0 +1,25 @@
+#ifndef _ANA_WAIT__H_
+#define _ANA_WAIT__H_
+#include <fun4all/SubsysReco.h>
+
+class AnaWait: public SubsysReco {
+  int m_wait_spill;
+  int m_wait_event;
+
+ public:
+  AnaWait(const int sec_spill=30, const int sec_event=0);
+  virtual ~AnaWait();
+
+  void SetWaitPerSpill(const int sec) { m_wait_spill = sec; }
+  void SetWaitPerEvent(const int sec) { m_wait_event = sec; }
+
+  int Init(PHCompositeNode *topNode);
+  int InitRun(PHCompositeNode *topNode);
+  int process_event(PHCompositeNode *topNode);
+  int End(PHCompositeNode *topNode);
+
+ protected:
+  void DoWait(int sec);
+};
+
+#endif /* _ANA_WAIT__H_ */

--- a/online/onlmonserver/CMakeLists.txt
+++ b/online/onlmonserver/CMakeLists.txt
@@ -9,6 +9,7 @@ add_custom_command (
   ARGS -f onlmonserver_Dict.cc -noIncludePaths -inlineInputHeader -c -p
     -I${PROJECT_SOURCE_DIR}/
     -I${ROOT_PREFIX}/include/
+    ${PROJECT_SOURCE_DIR}/AnaWait.h
     ${PROJECT_SOURCE_DIR}/OnlMon*.h
     ${PROJECT_SOURCE_DIR}/LinkDef.h
 )

--- a/online/onlmonserver/LinkDef.h
+++ b/online/onlmonserver/LinkDef.h
@@ -8,6 +8,8 @@
 #pragma link C++ class OnlMonUI-!;
 #pragma link C++ typedef OnlMonClientList_t;
 
+#pragma link C++ class AnaWait-!;
+
 #pragma link C++ class OnlMonMainDaq-!;
 #pragma link C++ class OnlMonTrigSig-!;
 #pragma link C++ class OnlMonTrigNim-!;

--- a/online/onlmonserver/OnlMonCanvas.cc
+++ b/online/onlmonserver/OnlMonCanvas.cc
@@ -32,14 +32,6 @@ OnlMonCanvas::~OnlMonCanvas()
   ;
 }
 
-//void OnlMonCanvas::SetBasicInfo(const int run_id, const int spill_id, const int event_id, const int n_evt)
-//{
-//  m_run   = run_id;
-//  m_spill = spill_id;
-//  m_event = event_id;
-//  m_n_evt = n_evt;
-//}
-
 void OnlMonCanvas::SetBasicID(const int run_id, const int spill_id, const int event_id, const int spill_id_min, const int spill_id_max)
 {
   m_run       = run_id;
@@ -107,7 +99,7 @@ void OnlMonCanvas::PreDraw(const bool at_end)
 
   oss.str("");
   oss << "Run " << m_run << ", Spill " << m_spill_min << "-" << m_spill_max
-      << "(N=" << m_n_sp << "), Event " << m_event
+      << " (N=" << m_n_sp << "), Event " << m_event
       << " (N=" << m_n_evt << ")";
   //if (! at_end) oss << ", " << m_spill;
   pate2->AddText(oss.str().c_str());

--- a/online/onlmonserver/OnlMonCanvas.cc
+++ b/online/onlmonserver/OnlMonCanvas.cc
@@ -101,7 +101,6 @@ void OnlMonCanvas::PreDraw(const bool at_end)
   oss << "Run " << m_run << ", Spill " << m_spill_min << "-" << m_spill_max
       << " (N=" << m_n_sp << "), Event " << m_event
       << " (N=" << m_n_evt << ")";
-  //if (! at_end) oss << ", " << m_spill;
   pate2->AddText(oss.str().c_str());
 
   time_t utime = time(0);

--- a/online/onlmonserver/OnlMonCanvas.cc
+++ b/online/onlmonserver/OnlMonCanvas.cc
@@ -21,7 +21,8 @@ OnlMonCanvas::OnlMonCanvas(const std::string name, const std::string title, cons
   m_pad_msg  ("msg"  , "", 0.0, 0.0, 1.0, 0.1),
   m_pate_msg(.02, .02, .98, .98),
   m_mon_status(UNDEF),
-  m_run(0), m_spill(0), m_event(0), m_n_evt(0)
+  m_run(0), m_spill(0), m_event(0), m_spill_min(0), m_spill_max(0), 
+  m_n_evt(0), m_n_sp(0)
 {
   //m_can.SetWindowPosition(5+600*num, 5);
 }
@@ -31,12 +32,27 @@ OnlMonCanvas::~OnlMonCanvas()
   ;
 }
 
-void OnlMonCanvas::SetBasicInfo(const int run_id, const int spill_id, const int event_id, const int n_evt)
+//void OnlMonCanvas::SetBasicInfo(const int run_id, const int spill_id, const int event_id, const int n_evt)
+//{
+//  m_run   = run_id;
+//  m_spill = spill_id;
+//  m_event = event_id;
+//  m_n_evt = n_evt;
+//}
+
+void OnlMonCanvas::SetBasicID(const int run_id, const int spill_id, const int event_id, const int spill_id_min, const int spill_id_max)
 {
-  m_run   = run_id;
-  m_spill = spill_id;
-  m_event = event_id;
+  m_run       = run_id;
+  m_spill     = spill_id;
+  m_event     = event_id;
+  m_spill_min = spill_id_min;
+  m_spill_max = spill_id_max;
+}
+
+void OnlMonCanvas::SetBasicCount(const int n_evt, const int n_sp)
+{
   m_n_evt = n_evt;
+  m_n_sp  = n_sp ;
 }
 
 void OnlMonCanvas::AddMessage(const char* msg)
@@ -90,8 +106,10 @@ void OnlMonCanvas::PreDraw(const bool at_end)
   pate2->SetFillColor(kWhite);
 
   oss.str("");
-  oss << "Run #" << m_run;
-  if (! at_end) oss << ", Spill #" << m_spill << ", Event #" << m_event << ", " << m_n_evt << " events";
+  oss << "Run " << m_run << ", Spill " << m_spill_min << "-" << m_spill_max
+      << "(N=" << m_n_sp << "), Event " << m_event
+      << " (N=" << m_n_evt << ")";
+  //if (! at_end) oss << ", " << m_spill;
   pate2->AddText(oss.str().c_str());
 
   time_t utime = time(0);

--- a/online/onlmonserver/OnlMonCanvas.h
+++ b/online/onlmonserver/OnlMonCanvas.h
@@ -26,13 +26,18 @@ class OnlMonCanvas {
   int         m_run;
   int         m_spill;
   int         m_event;
+  int         m_spill_min;
+  int         m_spill_max;
   int         m_n_evt;
+  int         m_n_sp;
 
  public:
   OnlMonCanvas(const std::string name, const std::string title, const int num);
   virtual ~OnlMonCanvas();
 
-  void SetBasicInfo(const int run_id, const int spill_id=0, const int event_id=0, const int n_evt=0);
+  //void SetBasicInfo(const int run_id, const int spill_id=0, const int event_id=0, const int n_evt=0);
+  void SetBasicID(const int run_id, const int spill_id=0, const int event_id=0, const int spill_id_min=0, const int spill_id_max=0);
+  void SetBasicCount(const int n_evt=0, const int n_sp=0);
   void AddMessage(const char* msg);
   MonStatus_t GetStatus() { return m_mon_status; }
   void SetStatus(const MonStatus_t stat) { m_mon_status = stat; }

--- a/online/onlmonserver/OnlMonCanvas.h
+++ b/online/onlmonserver/OnlMonCanvas.h
@@ -35,7 +35,6 @@ class OnlMonCanvas {
   OnlMonCanvas(const std::string name, const std::string title, const int num);
   virtual ~OnlMonCanvas();
 
-  //void SetBasicInfo(const int run_id, const int spill_id=0, const int event_id=0, const int n_evt=0);
   void SetBasicID(const int run_id, const int spill_id=0, const int event_id=0, const int spill_id_min=0, const int spill_id_max=0);
   void SetBasicCount(const int n_evt=0, const int n_sp=0);
   void AddMessage(const char* msg);

--- a/online/onlmonserver/OnlMonCham.cc
+++ b/online/onlmonserver/OnlMonCham.cc
@@ -103,11 +103,11 @@ int OnlMonCham::FindAllMonHist()
   for (int pl = 0; pl < N_PL; pl++) {
     oss.str("");
     oss << "h1_ele_" << pl;
-    h1_ele[pl] = (TH1*)FindMonObj(oss.str().c_str());
+    h1_ele[pl] = FindMonHist(oss.str().c_str());
     if (! h1_ele[pl]) return 1;
     oss.str("");
     oss << "h1_time_" << pl;
-    h1_time[pl] = (TH1*)FindMonObj(oss.str().c_str());
+    h1_time[pl] = FindMonHist(oss.str().c_str());
     if (! h1_time[pl]) return 1;
   }
   return 0;

--- a/online/onlmonserver/OnlMonCham.cc
+++ b/online/onlmonserver/OnlMonCham.cc
@@ -53,10 +53,10 @@ int OnlMonCham::InitRunOnlMon(PHCompositeNode* topNode)
     oss << name << ";Element ID;Hit count";
     h1_ele[pl]->SetTitle(oss.str().c_str());
 
-    const double DT = 20/9.0; // 4/9 ns per single count of Taiwan TDC
-    const int NT = 1000;
-    const double T0 = 0.5*DT;
-    const double T1 = (NT+0.5)*DT;
+    const double DT = 40/9.0; // 4/9 ns per single count of Taiwan TDC
+    const int    NT = 150;
+    const double T0 = 100.5*DT;
+    const double T1 = 250.5*DT;
 
     //double center, width;
     //calib.Find(m_pl0 + pl, 1, center, width);

--- a/online/onlmonserver/OnlMonClient.cc
+++ b/online/onlmonserver/OnlMonClient.cc
@@ -16,14 +16,22 @@
 #include <UtilAna/UtilOnline.h>
 #include "OnlMonServer.h"
 #include "OnlMonCanvas.h"
+#include "OnlMonComm.h"
 #include "OnlMonClient.h"
 using namespace std;
 
 std::vector<OnlMonClient*> OnlMonClient::m_list_us;
 bool OnlMonClient::m_bl_clear_us = true;
 
-OnlMonClient::OnlMonClient() :
-  SubsysReco("OnlMonClient"), m_title("Client Title"), m_hm(0), m_n_can(1), m_h1_basic_info(0)
+OnlMonClient::OnlMonClient()
+  : SubsysReco("OnlMonClient")
+  , m_title("Client Title")
+  , m_hm(0)
+  , m_n_can(1)
+//, m_h1_basic_info(0)
+  , m_h1_basic_id(0)
+  , m_h1_basic_cnt(0)
+  , m_spill_id_pre(-1)
 {
   memset(m_list_can, 0, sizeof(m_list_can));
   m_list_us.push_back(this);
@@ -63,12 +71,17 @@ int OnlMonClient::InitRun(PHCompositeNode* topNode)
 
   m_hm = new Fun4AllHistoManager(Name());
   OnlMonServer::instance()->registerHistoManager(m_hm);
-  m_h1_basic_info = new TH1D("h1_basic_info", "", 10, 0.5, 10.5);
-  m_hm->registerHisto(m_h1_basic_info);
+  //m_h1_basic_info = new TH1D("h1_basic_info", "", 10, 0.5, 10.5);
+  m_h1_basic_id  = new TH1D("h1_basic_id" , "", 10, 0.5, 10.5);
+  m_h1_basic_cnt = new TH1D("h1_basic_cnt", "", 10, 0.5, 10.5);
+  //m_hm->registerHisto(m_h1_basic_info);
+  m_hm->registerHisto(m_h1_basic_id);
+  m_hm->registerHisto(m_h1_basic_cnt);
 
   SQRun* run_header = findNode::getClass<SQRun>(topNode, "SQRun");
   if (!run_header) return Fun4AllReturnCodes::ABORTEVENT;
-  m_h1_basic_info->SetBinContent(BIN_RUN, run_header->get_run_id());
+  //m_h1_basic_info->SetBinContent(BIN_RUN, run_header->get_run_id());
+  m_h1_basic_id->SetBinContent(BIN_RUN, run_header->get_run_id());
 
   return InitRunOnlMon(topNode);
 }
@@ -82,9 +95,30 @@ int OnlMonClient::process_event(PHCompositeNode* topNode)
   int ret_mutex = pthread_mutex_lock(mutex); // got stuck here, n = 1
   if (ret_mutex != 0) cout << "WARNING:  mutex_lock returned " << ret_mutex << "." << endl;
 
-  m_h1_basic_info->SetBinContent(BIN_SPILL, event->get_spill_id());
-  m_h1_basic_info->SetBinContent(BIN_EVENT, event->get_event_id());
-  m_h1_basic_info->AddBinContent(BIN_N_EVT, 1);
+  int sp_id = event->get_spill_id();
+  if (m_spill_id_pre < 0) { // First call
+    m_spill_id_pre = sp_id;
+  } else if (sp_id != m_spill_id_pre) {
+    m_h1_basic_cnt->AddBinContent(BIN_N_SP, 1);
+    for (unsigned int ih = 0; ih < m_hm->nHistos(); ih++) {
+      TH1* h1 = (TH1*)m_hm->getHisto(ih);
+      string name = h1->GetName();
+      ostringstream oss;
+      oss << name << "_sp" << m_spill_id_pre;
+      m_map_hist_sp[name][m_spill_id_pre] = (TH1*)h1->Clone(oss.str().c_str());
+      h1->Reset("M");
+    }
+    OnlMonComm::instance()->AddSpill(m_spill_id_pre);
+    m_spill_id_pre = sp_id;
+  }
+
+  //m_h1_basic_info->SetBinContent(BIN_SPILL, event->get_spill_id());
+  //m_h1_basic_info->SetBinContent(BIN_EVENT, event->get_event_id());
+  //m_h1_basic_info->AddBinContent(BIN_N_EVT, 1);
+  m_h1_basic_id ->SetBinContent(BIN_RUN  , event->get_run_id());
+  m_h1_basic_id ->SetBinContent(BIN_SPILL, sp_id);
+  m_h1_basic_id ->SetBinContent(BIN_EVENT, event->get_event_id());
+  m_h1_basic_cnt->AddBinContent(BIN_N_EVT, 1);
 
   int ret = ProcessEventOnlMon(topNode);
   ret_mutex = pthread_mutex_unlock(mutex);
@@ -95,13 +129,15 @@ int OnlMonClient::process_event(PHCompositeNode* topNode)
 int OnlMonClient::End(PHCompositeNode* topNode)
 {
   if (! m_hm) return Fun4AllReturnCodes::EVENT_OK;
-  int run_id;
-  GetBasicInfo(&run_id);
+  int run_id, spill_id, event_id;
+  //GetBasicInfo(&run_id);
+  GetBasicID(&run_id, &spill_id, &event_id);
 
   ClearCanvasList();
   for (int ii = 0; ii < m_n_can; ii++) {
     m_list_can[ii] = new OnlMonCanvas(Name(), Title(), ii);
-    m_list_can[ii]->SetBasicInfo(run_id);
+    //m_list_can[ii]->SetBasicInfo(run_id);
+    m_list_can[ii]->SetBasicID(run_id, spill_id, event_id);
     m_list_can[ii]->PreDraw(true);
   }
 
@@ -125,24 +161,27 @@ int OnlMonClient::End(PHCompositeNode* topNode)
   return EndOnlMon(topNode);
 }
 
-void OnlMonClient::GetBasicInfo(int* run_id, int* spill_id, int* event_id, int* n_evt)
+//void OnlMonClient::GetBasicInfo(int* run_id, int* spill_id, int* event_id, int* n_evt)
+//{
+//  if (run_id  ) *run_id   = (int)m_h1_basic_info->GetBinContent(BIN_RUN);
+//  if (spill_id) *spill_id = (int)m_h1_basic_info->GetBinContent(BIN_SPILL);
+//  if (event_id) *event_id = (int)m_h1_basic_info->GetBinContent(BIN_EVENT);
+//  if (n_evt   ) *n_evt    = (int)m_h1_basic_info->GetBinContent(BIN_N_EVT);
+//}
+
+void OnlMonClient::GetBasicID(int* run_id, int* spill_id, int* event_id, int* spill_id_min, int* spill_id_max)
 {
-  if (run_id  ) *run_id   = (int)m_h1_basic_info->GetBinContent(BIN_RUN);
-  if (spill_id) *spill_id = (int)m_h1_basic_info->GetBinContent(BIN_SPILL);
-  if (event_id) *event_id = (int)m_h1_basic_info->GetBinContent(BIN_EVENT);
-  if (n_evt   ) *n_evt    = (int)m_h1_basic_info->GetBinContent(BIN_N_EVT);
+  if (run_id      ) *run_id       = (int)m_h1_basic_id->GetBinContent(BIN_RUN);
+  if (spill_id    ) *spill_id     = (int)m_h1_basic_id->GetBinContent(BIN_SPILL);
+  if (event_id    ) *event_id     = (int)m_h1_basic_id->GetBinContent(BIN_EVENT);
+  if (spill_id_min) *spill_id_min = (int)m_h1_basic_id->GetBinContent(BIN_SPILL_MIN);
+  if (spill_id_max) *spill_id_max = (int)m_h1_basic_id->GetBinContent(BIN_SPILL_MAX);
 }
 
-TH1* OnlMonClient::FindMonHist(const std::string name, const bool non_null)
+void OnlMonClient::GetBasicCount(int* n_evt, int* n_sp)
 {
-  for (HistList_t::iterator it = m_list_h1.begin(); it != m_list_h1.end(); it++) {
-    if (name == (*it)->GetName()) return *it;
-  }
-  if (non_null) {
-    cerr << "!!ERROR!!  OnlMonClient::FindMonHist() cannot find '" << name << "'.  Abort." << endl;
-    exit(1);
-  }
-  return 0;
+  if (n_evt) *n_evt = (int)m_h1_basic_cnt->GetBinContent(BIN_N_EVT);
+  if (n_sp ) *n_sp  = (int)m_h1_basic_cnt->GetBinContent(BIN_N_SP );
 }
 
 TObject* OnlMonClient::FindMonObj(const std::string name, const bool non_null)
@@ -214,18 +253,26 @@ int OnlMonClient::StartMonitor()
     return 1;
   }
 
-  m_h1_basic_info = (TH1*)FindMonObj("h1_basic_info");
+  //m_h1_basic_info = (TH1*)FindMonObj("h1_basic_info");
+  m_h1_basic_id  = (TH1*)FindMonObj("h1_basic_id");
+  m_h1_basic_cnt = (TH1*)FindMonObj("h1_basic_cnt");
   ret = FindAllMonHist();
-  if (m_h1_basic_info == 0 || ret != 0) {
+  //if (m_h1_basic_info == 0 || ret != 0) {
+  if (m_h1_basic_id == 0 || m_h1_basic_cnt == 0 || ret != 0) {
     cout << "WARNING: Cannot find OnlMon histogram(s)." << endl;
     return 2;
   }
 
-  int run_id, spill_id, event_id, n_evt;
-  GetBasicInfo(&run_id, &spill_id, &event_id, &n_evt);
+  int run_id, spill_id, event_id, spill_id_min, spill_id_max;
+  //GetBasicInfo(&run_id, &spill_id, &event_id, &n_evt);
+  GetBasicID(&run_id, &spill_id, &event_id, &spill_id_min, &spill_id_max);
+  int n_evt, n_sp;
+  GetBasicCount(&n_evt, &n_sp);
   for (int ii = 0; ii < m_n_can; ii++) {
     m_list_can[ii] = new OnlMonCanvas(Name(), Title(), ii);
-    m_list_can[ii]->SetBasicInfo(run_id, spill_id, event_id, n_evt);
+    //m_list_can[ii]->SetBasicInfo(run_id, spill_id, event_id, n_evt);
+    m_list_can[ii]->SetBasicID(run_id, spill_id, event_id, spill_id_min, spill_id_max);
+    m_list_can[ii]->SetBasicCount(n_evt, n_sp);
     m_list_can[ii]->PreDraw();
   }
 
@@ -247,45 +294,95 @@ void OnlMonClient::RegisterHist(TH1* h1)
   }
 }
 
-int OnlMonClient::ReceiveHist()
+int OnlMonClient::SendHist(TSocket* sock, int sp_min, int sp_max)
 {
-  string host = OnlMonServer::GetHost();
-  int   port  = OnlMonServer::GetPort();
-  int   port0 = OnlMonServer::GetPort0();
-  int n_port  = OnlMonServer::GetNumPorts();
+  if (! m_hm) {
+    //if (Verbosity() > 2) cout << "  HM not ready." << endl;
+    sock->Send("NotReady");
+    return 1; // Not ready
+  }
+  cout << "  spill: " << sp_min << "-" << sp_max << endl;
+  if (sp_min > 0 && sp_max == 0) { // "sp_min" means N of spills
+    int min0, max0;
+    OnlMonComm::instance()->GetFullSpillRange(min0, max0);
+    sp_max = max0;
+    sp_min = max0 - sp_min + 1;
+  }
 
-  TSocket* sock = 0;
-  for (int ip = 0; ip < n_port; ip++) {
-    bool port_ok = false;
-    sock = new TSocket(host.c_str(), port);
-    if (sock->IsValid()) {
-      sock->Send("Ping");
-      if (sock->Select(TSocket::kRead, 2000) > 0) { // 2000 msec
-        TMessage* mess = 0;
-        sock->Recv(mess);
-        if (mess->What() == kMESS_STRING) {
-          char str[200];
-          mess->ReadString(str, 200);
-          if (strcmp(str, "Pong") == 0) port_ok = true;
-        }
-        delete mess;
+  TMessage outgoing(kMESS_OBJECT);
+  //if (Verbosity() > 2) cout << "  SUBSYS: " << name_subsys << " " << hm->nHistos() << endl;
+  pthread_mutex_t* mutex = OnlMonServer::instance()->GetMutex();
+  pthread_mutex_lock(mutex);
+  for (unsigned int ih = 0; ih < m_hm->nHistos(); ih++) {
+    TH1* h1_org = (TH1*)m_hm->getHisto(ih);
+    string name = h1_org->GetName();
+    TH1* h1 = (TH1*)h1_org->Clone(name.c_str());
+    h1->Reset("M");
+    SpillHistMap_t* map_hist = &m_map_hist_sp[name];
+    for (SpillHistMap_t::iterator it = map_hist->begin(); it != map_hist->end(); it++) {
+      int sp_id = it->first;
+      if (sp_min > 0 && sp_id < sp_min) continue;
+      if (sp_max > 0 && sp_id > sp_max) continue;
+      if (name == "h1_basic_id") {
+        h1->SetBinContent(BIN_RUN  , TMath::Max(h1->GetBinContent(BIN_RUN  ), it->second->GetBinContent(BIN_RUN  )));
+        h1->SetBinContent(BIN_SPILL, TMath::Max(h1->GetBinContent(BIN_SPILL), it->second->GetBinContent(BIN_SPILL)));
+        h1->SetBinContent(BIN_EVENT, TMath::Max(h1->GetBinContent(BIN_EVENT), it->second->GetBinContent(BIN_EVENT)));
+        int sp_curr = h1->GetBinContent(BIN_SPILL_MIN);
+        if (sp_curr <= 0 || sp_curr > sp_id) h1->SetBinContent(BIN_SPILL_MIN, sp_id);
+        sp_curr = h1->GetBinContent(BIN_SPILL_MAX);
+        if (sp_curr < sp_id) h1->SetBinContent(BIN_SPILL_MAX, sp_id);
+      } else {
+        h1->Add(it->second);
       }
     }
-    if (port_ok) {
-      cout << "OnlMonClient::ReceiveHist(): " << host << ":" << port << " " << Name() << endl;
-      break;
-    }
-    delete sock;
-    sock = 0;
-    port++;
-    if (port >= port0 + n_port) port -= n_port;
+    outgoing.Reset();
+    outgoing.WriteObject(h1);
+    sock->Send(outgoing);
+    outgoing.Reset();
+    TMessage* mess = 0;
+    sock->Recv(mess); // Just check a response.
+    delete mess;
+    if (h1 != h1_org) delete h1;
   }
+
+  //for (unsigned int i = 0; i < m_hm->nHistos(); i++) {
+  //  TH1 *histo = (TH1 *) m_hm->getHisto(i);
+  //  if (! histo) continue;
+  //  outgoing.Reset();
+  //  outgoing.WriteObject(histo);
+  //  sock->Send(outgoing);
+  //  outgoing.Reset();
+  //  sock->Recv(mess); // Just check a response.
+  //  delete mess;
+  //  mess = 0;
+  //}
+  pthread_mutex_unlock(mutex);
+  sock->Send("Finished");
+  return 0;
+}
+
+int OnlMonClient::ReceiveHist()
+{
+  TSocket* sock = OnlMonComm::instance()->ConnectServer();
   if (! sock) return 1;
-  OnlMonServer::SetPort(port);
-  
-  string comm = "SUBSYS:";
-  comm += Name();
-  sock->Send(comm.c_str());
+
+  int sp_lo, sp_hi;
+  switch (OnlMonComm::instance()->GetSpillMode()) {
+  case OnlMonComm::SP_ALL:
+    sp_lo = sp_hi = 0;
+    break;
+  case OnlMonComm::SP_LAST:
+    sp_lo = OnlMonComm::instance()->GetSpillNum();
+    sp_hi = 0;
+    break;
+  case OnlMonComm::SP_RANGE:
+    OnlMonComm::instance()->GetSpillRange(sp_lo, sp_hi);
+    break;
+  }
+
+  ostringstream oss;
+  oss << "SUBSYS:" << Name() << " " << sp_lo << " " << sp_hi;
+  sock->Send(oss.str().c_str());
 
   ClearHistList();
 
@@ -310,10 +407,6 @@ int OnlMonClient::ReceiveHist()
       TObject* obj = mess->ReadObject(cla);
       cout << "  Receive: " << cla->GetName() << " " << obj->GetName() << endl;
       m_list_obj.push_back( obj->Clone() ); // copy
-
-      //TH1*    obj = (TH1*)mess->ReadObject(cla);
-      //cout << "  Receive: " << cla->GetName() << " " << obj->GetName() << endl;
-      //m_list_h1.push_back( (TH1*)obj->Clone() ); // copy
       delete mess;
       mess = 0;
       sock->Send("NEXT"); // Any text is ok for now
@@ -326,11 +419,6 @@ int OnlMonClient::ReceiveHist()
 
 void OnlMonClient::ClearHistList()
 {
-  for (HistList_t::iterator it = m_list_h1.begin(); it != m_list_h1.end(); it++) {
-    delete *it;
-  }
-  m_list_h1.clear();
-
   for (ObjList_t::iterator it = m_list_obj.begin(); it != m_list_obj.end(); it++) {
     delete *it;
   }

--- a/online/onlmonserver/OnlMonClient.h
+++ b/online/onlmonserver/OnlMonClient.h
@@ -78,6 +78,7 @@ class OnlMonClient: public SubsysReco {
   OnlMonCanvas* GetCanvas(const int num=0);
 
  private:
+  void MakeSpillHist();
   void MakeMergedHist(HistList_t& list_h1, const int sp_min=0, const int sp_max=0);
   int  ReceiveHist();
   void ClearHistList();

--- a/online/onlmonserver/OnlMonClient.h
+++ b/online/onlmonserver/OnlMonClient.h
@@ -3,6 +3,7 @@
 #include <fun4all/SubsysReco.h>
 #include "OnlMonCanvas.h"
 class Fun4AllHistoManager;
+class TSocket;
 class TH1;
 class TH2;
 class TH3;
@@ -13,12 +14,20 @@ class OnlMonClient: public SubsysReco {
   int m_n_can;
   OnlMonCanvas* m_list_can[9];
 
-  typedef enum { BIN_RUN = 1, BIN_SPILL = 2, BIN_EVENT = 3, BIN_N_EVT = 4 } BasicInfoBin_t;
-  TH1* m_h1_basic_info;
-  typedef std::vector<TH1*> HistList_t;
-  HistList_t m_list_h1;
+  //typedef enum { BIN_RUN = 1, BIN_SPILL = 2, BIN_EVENT = 3, BIN_N_EVT = 4 } BasicInfoBin_t;
+  typedef enum { BIN_RUN = 1, BIN_SPILL = 2, BIN_EVENT = 3, BIN_SPILL_MIN = 4, BIN_SPILL_MAX = 5 } BasicIdBin_t;
+  typedef enum { BIN_N_EVT = 1, BIN_N_SP = 2 } BasicInfoBin_t;
+  //TH1* m_h1_basic_info;
+  TH1* m_h1_basic_id;
+  TH1* m_h1_basic_cnt;
+
   typedef std::vector<TObject*> ObjList_t;
-  ObjList_t m_list_obj; ///< Need this or m_list_h1 at end...
+  ObjList_t m_list_obj;
+
+  typedef std::map<int, TH1*> SpillHistMap_t; // [spill] -> TH1*
+  typedef std::map<std::string, SpillHistMap_t> Name2SpillHistMap_t; // [hist name] 
+  Name2SpillHistMap_t m_map_hist_sp;
+  int m_spill_id_pre;
 
   /// List of OnlMonClient objects created.  Used to clear all canvases opened by all objects.
   typedef std::vector<OnlMonClient*> SelfList_t;
@@ -38,9 +47,10 @@ class OnlMonClient: public SubsysReco {
   int process_event(PHCompositeNode *topNode);
   int End(PHCompositeNode *topNode);
 
-  void GetBasicInfo(int* run_id=0, int* spill_id=0, int* event_id=0, int* n_evt=0);
+  //void GetBasicInfo(int* run_id=0, int* spill_id=0, int* event_id=0, int* n_evt=0);
+  void GetBasicID(int* run_id=0, int* spill_id=0, int* event_id=0, int* spill_id_min=0, int* spill_id_max=0);
+  void GetBasicCount(int* n_evt=0, int* n_sp=0);
   int StartMonitor();
-  TH1* FindMonHist(const std::string name, const bool non_null=true);
   TObject* FindMonObj(const std::string name, const bool non_null=true);
 
   virtual int InitOnlMon(PHCompositeNode *topNode);
@@ -52,6 +62,8 @@ class OnlMonClient: public SubsysReco {
 
   static void SetClearUsFlag(const bool val) { m_bl_clear_us = val; }
   static bool GetClearUsFlag() { return m_bl_clear_us; }
+
+  int SendHist(TSocket* sock, int sp_min, int sp_max);
 
  protected:  
   void RegisterHist(TH1* h1);

--- a/online/onlmonserver/OnlMonClient.h
+++ b/online/onlmonserver/OnlMonClient.h
@@ -9,20 +9,26 @@ class TH2;
 class TH3;
 
 class OnlMonClient: public SubsysReco {
+ protected:
+  typedef enum { MODE_ADD, MODE_UPDATE } HistMode_t;
+
+ private:
   std::string m_title;
   Fun4AllHistoManager* m_hm;
   int m_n_can;
   OnlMonCanvas* m_list_can[9];
 
-  //typedef enum { BIN_RUN = 1, BIN_SPILL = 2, BIN_EVENT = 3, BIN_N_EVT = 4 } BasicInfoBin_t;
+  typedef std::map<std::string, HistMode_t> HistModeMap_t;
+  HistModeMap_t m_hist_mode;
+
   typedef enum { BIN_RUN = 1, BIN_SPILL = 2, BIN_EVENT = 3, BIN_SPILL_MIN = 4, BIN_SPILL_MAX = 5 } BasicIdBin_t;
   typedef enum { BIN_N_EVT = 1, BIN_N_SP = 2 } BasicInfoBin_t;
-  //TH1* m_h1_basic_info;
   TH1* m_h1_basic_id;
   TH1* m_h1_basic_cnt;
 
+  typedef std::vector<TH1*> HistList_t;
   typedef std::vector<TObject*> ObjList_t;
-  ObjList_t m_list_obj;
+  HistList_t m_list_h1;
 
   typedef std::map<int, TH1*> SpillHistMap_t; // [spill] -> TH1*
   typedef std::map<std::string, SpillHistMap_t> Name2SpillHistMap_t; // [hist name] 
@@ -47,11 +53,10 @@ class OnlMonClient: public SubsysReco {
   int process_event(PHCompositeNode *topNode);
   int End(PHCompositeNode *topNode);
 
-  //void GetBasicInfo(int* run_id=0, int* spill_id=0, int* event_id=0, int* n_evt=0);
   void GetBasicID(int* run_id=0, int* spill_id=0, int* event_id=0, int* spill_id_min=0, int* spill_id_max=0);
   void GetBasicCount(int* n_evt=0, int* n_sp=0);
   int StartMonitor();
-  TObject* FindMonObj(const std::string name, const bool non_null=true);
+  TH1* FindMonHist(const std::string name, const bool non_null=true);
 
   virtual int InitOnlMon(PHCompositeNode *topNode);
   virtual int InitRunOnlMon(PHCompositeNode *topNode);
@@ -66,15 +71,18 @@ class OnlMonClient: public SubsysReco {
   int SendHist(TSocket* sock, int sp_min, int sp_max);
 
  protected:  
-  void RegisterHist(TH1* h1);
-
-  int ReceiveHist();
-  void ClearHistList();
+  void RegisterHist(TH1* h1, const HistMode_t mode=MODE_ADD);
 
   void NumCanvases(const int num) { m_n_can = num; }
   int  NumCanvases() { return m_n_can; }
   OnlMonCanvas* GetCanvas(const int num=0);
+
+ private:
+  void MakeMergedHist(HistList_t& list_h1, const int sp_min=0, const int sp_max=0);
+  int  ReceiveHist();
+  void ClearHistList();
   void ClearCanvasList();
+  int  DrawCanvas(const bool at_end=false);
 };
 
 #endif /* _ONL_MON_CLIENT__H_ */

--- a/online/onlmonserver/OnlMonComm.cc
+++ b/online/onlmonserver/OnlMonComm.cc
@@ -73,11 +73,6 @@ void OnlMonComm::FindFullSpillRange(int& id_min, int& id_max)
   }
 }
 
-//void OnlMonComm::AddClient(OnlMonClient* cli)
-//{
-//  m_map_cli[cli->Name()] = cli;
-//}
-
 int OnlMonComm::ReceiveFullSpillRange()
 {
   TSocket* sock = ConnectServer();

--- a/online/onlmonserver/OnlMonComm.cc
+++ b/online/onlmonserver/OnlMonComm.cc
@@ -1,0 +1,138 @@
+#include <string>
+#include <sstream>
+#include <pthread.h>
+#include <TMessage.h>
+#include <TServerSocket.h>
+#include <TSocket.h>
+#include <TROOT.h>
+#include <TH1.h>
+#include "OnlMonServer.h"
+#include "OnlMonClient.h"
+#include "OnlMonComm.h"
+using namespace std;
+
+OnlMonComm* OnlMonComm::m_inst = 0;
+
+OnlMonComm* OnlMonComm::instance()
+{
+  if (! m_inst) m_inst = new OnlMonComm();
+  return m_inst;
+}
+
+OnlMonComm::OnlMonComm()
+  : m_sp_mode(SP_ALL)
+  , m_sp_num(1)
+  , m_sp_lo(0)
+  , m_sp_hi(0)
+{
+  ;
+}
+
+OnlMonComm::~OnlMonComm()
+{
+  ;
+}
+
+void OnlMonComm::SetSpillRangeLow(const int sp)
+{
+  m_sp_lo = sp;
+}
+
+void OnlMonComm::SetSpillRangeHigh(const int sp)
+{
+  m_sp_hi = sp;
+}
+
+void OnlMonComm::SetSpillRange(const int sp_lo, const int sp_hi)
+{
+  m_sp_lo = sp_lo;
+  m_sp_hi = sp_hi;
+}
+
+void OnlMonComm::GetSpillRange(int& sp_lo, int& sp_hi)
+{
+  sp_lo = m_sp_lo;
+  sp_hi = m_sp_hi;
+}
+
+void OnlMonComm::AddSpill(const int id)
+{
+  if (find(m_list_sp.begin(), m_list_sp.end(), id) == m_list_sp.end()) m_list_sp.push_back(id);
+}
+
+void OnlMonComm::GetFullSpillRange(int& id_min, int& id_max)
+{
+  if (m_list_sp.size() == 0) {
+    id_min = id_max = 0;
+  } else {
+    sort(m_list_sp.begin(), m_list_sp.end());
+    id_min = m_list_sp[0];
+    id_max = m_list_sp[m_list_sp.size()-1];
+  }
+}
+
+//void OnlMonComm::AddClient(OnlMonClient* cli)
+//{
+//  m_map_cli[cli->Name()] = cli;
+//}
+
+int OnlMonComm::ReceiveSpillRange(int& sp_min, int& sp_max)
+{
+  TSocket* sock = ConnectServer();
+  if (! sock) return 1;
+  sock->Send("Spill");
+
+  TMessage *mess = 0;
+  sock->Recv(mess);
+  int ret = 0;
+  if (mess && mess->What() == kMESS_STRING) {
+    char str[200];
+    mess->ReadString(str, 200);
+    istringstream iss(str);
+    if (! (iss >> sp_min >> sp_max)) sp_min = sp_max = 0;
+    delete mess;
+  } else {
+    ret = 1;
+  }
+
+  sock->Close();
+  delete sock;
+  return ret;
+}
+
+TSocket* OnlMonComm::ConnectServer()
+{
+  string host = OnlMonServer::GetHost();
+  int   port  = OnlMonServer::GetPort();
+  int   port0 = OnlMonServer::GetPort0();
+  int n_port  = OnlMonServer::GetNumPorts();
+
+  TSocket* sock = 0;
+  for (int ip = 0; ip < n_port; ip++) {
+    bool port_ok = false;
+    sock = new TSocket(host.c_str(), port);
+    if (sock->IsValid()) {
+      sock->Send("Ping");
+      if (sock->Select(TSocket::kRead, 2000) > 0) { // 2000 msec
+        TMessage* mess = 0;
+        sock->Recv(mess);
+        if (mess->What() == kMESS_STRING) {
+          char str[200];
+          mess->ReadString(str, 200);
+          if (strcmp(str, "Pong") == 0) port_ok = true;
+        }
+        delete mess;
+      }
+    }
+    if (port_ok) {
+      cout << "OnlMonComm::ConnectServer(): " << host << ":" << port << endl;
+      break;
+    }
+    delete sock;
+    sock = 0;
+    port++;
+    if (port >= port0 + n_port) port -= n_port;
+  }
+  if (sock) OnlMonServer::SetPort(port);
+  return sock;
+}

--- a/online/onlmonserver/OnlMonComm.cc
+++ b/online/onlmonserver/OnlMonComm.cc
@@ -24,6 +24,8 @@ OnlMonComm::OnlMonComm()
   , m_sp_num(1)
   , m_sp_lo(0)
   , m_sp_hi(0)
+  , m_sp_min(0)
+  , m_sp_max(0)
 {
   ;
 }
@@ -60,7 +62,7 @@ void OnlMonComm::AddSpill(const int id)
   if (find(m_list_sp.begin(), m_list_sp.end(), id) == m_list_sp.end()) m_list_sp.push_back(id);
 }
 
-void OnlMonComm::GetFullSpillRange(int& id_min, int& id_max)
+void OnlMonComm::FindFullSpillRange(int& id_min, int& id_max)
 {
   if (m_list_sp.size() == 0) {
     id_min = id_max = 0;
@@ -76,7 +78,7 @@ void OnlMonComm::GetFullSpillRange(int& id_min, int& id_max)
 //  m_map_cli[cli->Name()] = cli;
 //}
 
-int OnlMonComm::ReceiveSpillRange(int& sp_min, int& sp_max)
+int OnlMonComm::ReceiveFullSpillRange()
 {
   TSocket* sock = ConnectServer();
   if (! sock) return 1;
@@ -89,7 +91,7 @@ int OnlMonComm::ReceiveSpillRange(int& sp_min, int& sp_max)
     char str[200];
     mess->ReadString(str, 200);
     istringstream iss(str);
-    if (! (iss >> sp_min >> sp_max)) sp_min = sp_max = 0;
+    if (! (iss >> m_sp_min >> m_sp_max)) m_sp_min = m_sp_max = 0;
     delete mess;
   } else {
     ret = 1;
@@ -98,6 +100,12 @@ int OnlMonComm::ReceiveSpillRange(int& sp_min, int& sp_max)
   sock->Close();
   delete sock;
   return ret;
+}
+
+void OnlMonComm::GetFullSpillRange(int& id_min, int& id_max)
+{
+  id_min = m_sp_min;
+  id_max = m_sp_max;
 }
 
 TSocket* OnlMonComm::ConnectServer()

--- a/online/onlmonserver/OnlMonComm.h
+++ b/online/onlmonserver/OnlMonComm.h
@@ -1,10 +1,7 @@
 #ifndef _ONL_MON_COMM__H__
 #define _ONL_MON_COMM__H__
-#include <map>
-#include <string>
-//#include <pthread.h>
+#include <vector>
 class TSocket;
-class OnlMonClient;
 
 class OnlMonComm {
  public:
@@ -15,8 +12,10 @@ class OnlMonComm {
 
   SpillMode_t m_sp_mode;
   int m_sp_num; 
-  int m_sp_lo;
-  int m_sp_hi;
+  int m_sp_lo; //< Low  of selected range
+  int m_sp_hi; //< High of selected range
+  int m_sp_min; //< Min of full (not selected) range
+  int m_sp_max; //< Max of full scale
 
   typedef std::vector<int> SpillList_t;
   SpillList_t m_list_sp;
@@ -36,10 +35,12 @@ class OnlMonComm {
   void SetSpillRange(const int sp_lo, const int sp_hi);
   void GetSpillRange(int& sp_lo, int& sp_hi);
 
-  void AddSpill(const int id);
-  void GetFullSpillRange(int& id_min, int& id_max);
+  void AddSpill(const int id); //< Used in the server process
+  void FindFullSpillRange(int& id_min, int& id_max); //< Used in the server process
 
-  int ReceiveSpillRange(int& sp_min, int& sp_max);
+  int ReceiveFullSpillRange(); //< Used in the viewer process
+  void GetFullSpillRange(int& id_min, int& id_max); //< Used in the viewer process
+
   TSocket* ConnectServer();
 
  protected:

--- a/online/onlmonserver/OnlMonComm.h
+++ b/online/onlmonserver/OnlMonComm.h
@@ -1,0 +1,49 @@
+#ifndef _ONL_MON_COMM__H__
+#define _ONL_MON_COMM__H__
+#include <map>
+#include <string>
+//#include <pthread.h>
+class TSocket;
+class OnlMonClient;
+
+class OnlMonComm {
+ public:
+  typedef enum { SP_ALL, SP_LAST, SP_RANGE } SpillMode_t;
+
+ private:
+  static OnlMonComm* m_inst;
+
+  SpillMode_t m_sp_mode;
+  int m_sp_num; 
+  int m_sp_lo;
+  int m_sp_hi;
+
+  typedef std::vector<int> SpillList_t;
+  SpillList_t m_list_sp;
+
+ public:
+  static OnlMonComm *instance();
+  virtual ~OnlMonComm();
+
+  void SetSpillMode(const SpillMode_t mode) { m_sp_mode = mode; }
+  SpillMode_t GetSpillMode() { return m_sp_mode; } 
+
+  void SetSpillNum(const int num) { m_sp_num = num; }
+  int  GetSpillNum()       { return m_sp_num; }
+
+  void SetSpillRangeLow (const int sp);
+  void SetSpillRangeHigh(const int sp);
+  void SetSpillRange(const int sp_lo, const int sp_hi);
+  void GetSpillRange(int& sp_lo, int& sp_hi);
+
+  void AddSpill(const int id);
+  void GetFullSpillRange(int& id_min, int& id_max);
+
+  int ReceiveSpillRange(int& sp_min, int& sp_max);
+  TSocket* ConnectServer();
+
+ protected:
+  OnlMonComm();
+};
+
+#endif // _ONL_MON_COMM__H__

--- a/online/onlmonserver/OnlMonH4.cc
+++ b/online/onlmonserver/OnlMonH4.cc
@@ -158,15 +158,15 @@ int OnlMonH4::FindAllMonHist()
   for (int pl = 0; pl < N_PL; pl++) {
     oss.str("");
     oss << "h1_ele_" << pl;
-    h1_ele[pl] = (TH1*)FindMonObj(oss.str().c_str());
+    h1_ele[pl] = FindMonHist(oss.str().c_str());
     if (! h1_ele[pl]) return 1;
     oss.str("");
     oss << "h1_time_" << pl;
-    h1_time[pl] = (TH1*)FindMonObj(oss.str().c_str());
+    h1_time[pl] = FindMonHist(oss.str().c_str());
     if (! h1_time[pl]) return 1;
   }
-  h2_ele  = (TH2*)FindMonObj("h2_ele" );
-  h2_time = (TH2*)FindMonObj("h2_time");
+  h2_ele  = FindMonHist("h2_ele" );
+  h2_time = FindMonHist("h2_time");
   if (! h2_ele || ! h2_time) return 1;
   return 0;
 }
@@ -191,8 +191,8 @@ int OnlMonH4::DrawMonitor()
 
   UtilHist::AutoSetRange (h1_time[0]);
   UtilHist::AutoSetRange (h1_time[1]);
-  UtilHist::AutoSetRangeX(h2_time);
-  UtilHist::AutoSetRangeY(h2_time);
+  UtilHist::AutoSetRangeX((TH2*)h2_time);
+  UtilHist::AutoSetRangeY((TH2*)h2_time);
   OnlMonCanvas* can1 = GetCanvas(1);
   can1->SetStatus(OnlMonCanvas::OK);
   TPad* pad1 = can1->GetMainPad();

--- a/online/onlmonserver/OnlMonH4.cc
+++ b/online/onlmonserver/OnlMonH4.cc
@@ -73,10 +73,10 @@ int OnlMonH4::InitOnlMon(PHCompositeNode* topNode)
 
 int OnlMonH4::InitRunOnlMon(PHCompositeNode* topNode)
 {
-  const double DT = 4/9.0; // 4/9 ns per single count of Taiwan TDC
-  const int NT = 4000;
-  const double T0 = 0.5*DT;
-  const double T1 = (NT+0.5)*DT;
+  const double DT = 40/9.0; // 4/9 ns per single count of Taiwan TDC
+  const int NT    = 100;
+  const double T0 = 100.5*DT;
+  const double T1 = 200.5*DT;
 
   GeomSvc* geom = GeomSvc::instance();
   int n_ele = geom->getPlaneNElements( geom->getDetectorID(m_det_name) );

--- a/online/onlmonserver/OnlMonH4.h
+++ b/online/onlmonserver/OnlMonH4.h
@@ -15,8 +15,8 @@ class OnlMonH4: public OnlMonClient {
 
   TH1* h1_ele [N_PL];
   TH1* h1_time[N_PL];
-  TH2* h2_ele ;
-  TH2* h2_time;
+  TH1* h2_ele ;
+  TH1* h2_time;
 
  public:
   OnlMonH4(const HodoType_t type);

--- a/online/onlmonserver/OnlMonHodo.cc
+++ b/online/onlmonserver/OnlMonHodo.cc
@@ -64,10 +64,10 @@ int OnlMonHodo::InitRunOnlMon(PHCompositeNode* topNode)
     oss << name << ";Element ID;In-time hit count";
     h1_ele_in[pl]->SetTitle(oss.str().c_str());
 
-    const double DT = 4/9.0; // 4/9 ns per single count of Taiwan TDC
-    const int NT = 4000;
-    const double T0 = 0.5*DT;
-    const double T1 = (NT+0.5)*DT;
+    const double DT = 20/9.0; // 4/9 ns per single count of Taiwan TDC
+    const int    NT = 200;
+    const double T0 = 200.5*DT;
+    const double T1 = 400.5*DT;
 
     //double center, width;
     //calib.Find(m_pl0 + pl, 1, center, width);

--- a/online/onlmonserver/OnlMonHodo.cc
+++ b/online/onlmonserver/OnlMonHodo.cc
@@ -127,19 +127,19 @@ int OnlMonHodo::FindAllMonHist()
   for (int pl = 0; pl < m_n_pl; pl++) {
     oss.str("");
     oss << "h1_ele_" << pl;
-    h1_ele[pl] = (TH1*)FindMonObj(oss.str().c_str());
+    h1_ele[pl] = FindMonHist(oss.str().c_str());
     if (! h1_ele[pl]) return 1;
     oss.str("");
     oss << "h1_ele_in_" << pl;
-    h1_ele_in[pl] = (TH1*)FindMonObj(oss.str().c_str());
+    h1_ele_in[pl] = FindMonHist(oss.str().c_str());
     if (! h1_ele_in[pl]) return 1;
     oss.str("");
     oss << "h1_time_" << pl;
-    h1_time[pl] = (TH1*)FindMonObj(oss.str().c_str());
+    h1_time[pl] = FindMonHist(oss.str().c_str());
     if (! h1_time[pl]) return 1;
     oss.str("");
     oss << "h1_time_in_" << pl;
-    h1_time_in[pl] = (TH1*)FindMonObj(oss.str().c_str());
+    h1_time_in[pl] = FindMonHist(oss.str().c_str());
     if (! h1_time_in[pl]) return 1;
   }
   return 0;

--- a/online/onlmonserver/OnlMonHodo.h
+++ b/online/onlmonserver/OnlMonHodo.h
@@ -14,6 +14,7 @@ class OnlMonHodo: public OnlMonClient {
   TH1* h1_ele_in [99];
   TH1* h1_time   [99];
   TH1* h1_time_in[99];
+  TH2* h2_time_ele[99];
 
  public:
   OnlMonHodo(const HodoType_t type);

--- a/online/onlmonserver/OnlMonMainDaq.cc
+++ b/online/onlmonserver/OnlMonMainDaq.cc
@@ -62,7 +62,7 @@ int OnlMonMainDaq::InitRunOnlMon(PHCompositeNode* topNode)
   RegisterHist(h1_n_taiwan);
   RegisterHist(h1_evt_qual);
   RegisterHist(h1_flag_v1495);
-  RegisterHist(h1_cnt);
+  RegisterHist(h1_cnt, OnlMonClient::MODE_UPDATE);
 
   return Fun4AllReturnCodes::EVENT_OK;
 }
@@ -124,11 +124,11 @@ int OnlMonMainDaq::EndOnlMon(PHCompositeNode* topNode)
 
 int OnlMonMainDaq::FindAllMonHist()
 {
-  h1_trig       = (TH1*)FindMonObj("h1_trig");
-  h1_n_taiwan   = (TH1*)FindMonObj("h1_n_taiwan");
-  h1_evt_qual   = (TH1*)FindMonObj("h1_evt_qual");
-  h1_flag_v1495 = (TH1*)FindMonObj("h1_flag_v1495");
-  h1_cnt        = (TH1*)FindMonObj("h1_cnt");
+  h1_trig       = FindMonHist("h1_trig");
+  h1_n_taiwan   = FindMonHist("h1_n_taiwan");
+  h1_evt_qual   = FindMonHist("h1_evt_qual");
+  h1_flag_v1495 = FindMonHist("h1_flag_v1495");
+  h1_cnt        = FindMonHist("h1_cnt");
   return (h1_trig && h1_evt_qual && h1_flag_v1495 && h1_cnt  ?  0  :  1);
 }
 

--- a/online/onlmonserver/OnlMonMainDaq.cc
+++ b/online/onlmonserver/OnlMonMainDaq.cc
@@ -162,7 +162,7 @@ int OnlMonMainDaq::DrawMonitor()
   pad->cd(3);
   TPaveText* pate = new TPaveText(.02, .02, .98, .98);
   ostringstream oss;
-  oss << "N of spills = " << h1_cnt->GetBinContent(1);
+  oss << "N of spill-counter events = " << h1_cnt->GetBinContent(1);
   pate->AddText(oss.str().c_str());
   oss.str("");
   oss << "N of triggered events = " << h1_cnt->GetBinContent(2) << " (all), " << h1_cnt->GetBinContent(3) << " (decoded)";

--- a/online/onlmonserver/OnlMonProp.cc
+++ b/online/onlmonserver/OnlMonProp.cc
@@ -50,10 +50,10 @@ int OnlMonProp::InitRunOnlMon(PHCompositeNode* topNode)
     oss << name << ";Element ID;Hit count";
     h1_ele[pl]->SetTitle(oss.str().c_str());
 
-    const double DT = 40/9.0; // 4/9 ns per single count of Taiwan TDC
-    const int NT = 500;
-    const double T0 = 0.5*DT;
-    const double T1 = (NT+0.5)*DT;
+    const double DT = 80/9.0; // 4/9 ns per single count of Taiwan TDC
+    const int NT    = 100;
+    const double T0 =   0.5*DT;
+    const double T1 = 100.5*DT;
 
     //double center, width;
     //calib.Find(m_pl0 + pl, 1, center, width);

--- a/online/onlmonserver/OnlMonProp.cc
+++ b/online/onlmonserver/OnlMonProp.cc
@@ -100,11 +100,11 @@ int OnlMonProp::FindAllMonHist()
   for (int pl = 0; pl < N_PL; pl++) {
     oss.str("");
     oss << "h1_ele_" << pl;
-    h1_ele[pl] = (TH1*)FindMonObj(oss.str().c_str());
+    h1_ele[pl] = FindMonHist(oss.str().c_str());
     if (! h1_ele[pl]) return 1;
     oss.str("");
     oss << "h1_time_" << pl;
-    h1_time[pl] = (TH1*)FindMonObj(oss.str().c_str());
+    h1_time[pl] = FindMonHist(oss.str().c_str());
     if (! h1_time[pl]) return 1;
   }
   return 0;

--- a/online/onlmonserver/OnlMonReco.cc
+++ b/online/onlmonserver/OnlMonReco.cc
@@ -83,13 +83,13 @@ int OnlMonReco::EndOnlMon(PHCompositeNode* topNode)
 
 int OnlMonReco::FindAllMonHist()
 {
-  h1_rec_stats = (TH1*)FindMonObj("h1_rec_stats");
+  h1_rec_stats = FindMonHist("h1_rec_stats");
   if (!h1_rec_stats) return 1;
 
-  h1_sgmu_pt = (TH1*)FindMonObj("h1_sgmu_pt");
+  h1_sgmu_pt = FindMonHist("h1_sgmu_pt");
   if (!h1_sgmu_pt) return 1;
 
-  h1_dimu_mass = (TH1*)FindMonObj("h1_dimu_mass");
+  h1_dimu_mass = FindMonHist("h1_dimu_mass");
   if (!h1_dimu_mass) return 1;
 
   return 0;

--- a/online/onlmonserver/OnlMonServer.cc
+++ b/online/onlmonserver/OnlMonServer.cc
@@ -263,12 +263,14 @@ void OnlMonServer::HandleConnection(TSocket* sock)
       } else {
         //if (Verbosity() > 2) 
         cout << "  Unexpected string message (" << msg_str << ").  Ignore it." << endl;
+        break;
       }
     } else {
       cerr << "OnlMonServer::HandleConnection():  Unexpected message ("
            << mess->What() << ").  Ignore it." << endl;
       delete mess;
       mess = 0;
+      break;
     }
   }
   

--- a/online/onlmonserver/OnlMonServer.cc
+++ b/online/onlmonserver/OnlMonServer.cc
@@ -183,8 +183,7 @@ void* OnlMonServer::FuncServer(void* arg)
   // go well together
   TInetAddress adr = s0->GetInetAddress();
   if (se->Verbosity() >= 0) {
-    cout << "Got connection from\n  ";
-    adr.Print();
+    cout << "Connection from " << adr.GetHostName() << "/" << adr.GetHostAddress() << ":" << adr.GetPort() << endl;
   }
   UInt_t ip0 = adr.GetAddress();
   if ((ip0 >> 16) == (192 << 8) + 168 || ip0 == (127 << 24) + 1) {

--- a/online/onlmonserver/OnlMonServer.cc
+++ b/online/onlmonserver/OnlMonServer.cc
@@ -42,7 +42,9 @@ OnlMonServer *OnlMonServer::instance()
 }
 
 OnlMonServer::OnlMonServer(const std::string &name)
-  : Fun4AllServer(name), m_go_end(false), m_svr_ready(false)
+  : Fun4AllServer(name)
+  , m_go_end(false)
+  , m_svr_ready(false)
 {
   pthread_mutexattr_t mutex_attr;
   pthread_mutexattr_init(&mutex_attr);
@@ -211,7 +213,6 @@ void OnlMonServer::HandleConnection(TSocket* sock)
     printf("recvbuffer size: %d\n", val);
   */
   TMessage *mess = NULL;
-  //TMessage outgoing(kMESS_OBJECT);
   while (1) {
     if (Verbosity() > 2) cout << "OnlMonServer::HandleConnection(): while loop." << endl;
     sock->Recv(mess);
@@ -243,6 +244,7 @@ void OnlMonServer::HandleConnection(TSocket* sock)
         int id_min, id_max;
         OnlMonComm::instance()->FindFullSpillRange(id_min, id_max);
         ostringstream oss;
+        oss << id_min << " " << id_max;
         sock->Send(oss.str().c_str());
       } else if (msg_str.substr(0, 7) == "SUBSYS:") {
         istringstream iss(msg_str.substr(7));

--- a/online/onlmonserver/OnlMonServer.cc
+++ b/online/onlmonserver/OnlMonServer.cc
@@ -94,6 +94,7 @@ void OnlMonServer::StartServer()
 
 int OnlMonServer::End()
 {
+  m_go_end = true;
   int ret = Fun4AllServer::End();
   for (int ii = 0; ii < 30; ii++) { // Wait for one minute at max
     if (m_svr_ready) break;
@@ -217,6 +218,10 @@ void OnlMonServer::HandleConnection(TSocket* sock)
     sock->Recv(mess);
     if (! mess) {
       if (Verbosity() > 2) cout << "  Broken Connection, closing socket." << endl;
+      break;
+    }
+    if (m_go_end) {
+      if (Verbosity() > 2) cout << "  Already going to end, closing socket." << endl;
       break;
     }
     

--- a/online/onlmonserver/OnlMonServer.h
+++ b/online/onlmonserver/OnlMonServer.h
@@ -1,12 +1,20 @@
 #ifndef __H_OnlMonServer__H__
 #define __H_OnlMonServer__H__
+#include <map>
 #include <string>
 #include <fun4all/Fun4AllServer.h>
 #include <pthread.h>
 class TSocket;
+class OnlMonClient;
 
 class OnlMonServer : public Fun4AllServer
 {
+  //typedef std::vector<int> SpillList_t;
+  //SpillList_t m_list_sp;
+
+  //typedef std::map<std::string, OnlMonClient*> ClientMap_t;
+  //ClientMap_t m_map_cli;
+
   //static std::string m_out_dir;
   static std::string m_mon_host;
   static int         m_mon_port; //< The port being used
@@ -18,6 +26,8 @@ class OnlMonServer : public Fun4AllServer
  public:
   static OnlMonServer *instance();
   virtual ~OnlMonServer();
+
+  //void AddClient(OnlMonClient* cli);
 
   //static void SetOutDir  (const std::string dir)  { m_out_dir    = dir ; }
   static void SetHost    (const std::string host) { m_mon_host   = host; }

--- a/online/onlmonserver/OnlMonServer.h
+++ b/online/onlmonserver/OnlMonServer.h
@@ -9,12 +9,6 @@ class OnlMonClient;
 
 class OnlMonServer : public Fun4AllServer
 {
-  //typedef std::vector<int> SpillList_t;
-  //SpillList_t m_list_sp;
-
-  //typedef std::map<std::string, OnlMonClient*> ClientMap_t;
-  //ClientMap_t m_map_cli;
-
   //static std::string m_out_dir;
   static std::string m_mon_host;
   static int         m_mon_port; //< The port being used
@@ -22,12 +16,13 @@ class OnlMonServer : public Fun4AllServer
   static int         m_mon_n_port; //< The number of available ports
 
   bool m_go_end;
+  bool m_svr_ready;
 
  public:
   static OnlMonServer *instance();
   virtual ~OnlMonServer();
 
-  //void AddClient(OnlMonClient* cli);
+  int End();
 
   //static void SetOutDir  (const std::string dir)  { m_out_dir    = dir ; }
   static void SetHost    (const std::string host) { m_mon_host   = host; }
@@ -46,6 +41,8 @@ class OnlMonServer : public Fun4AllServer
   void HandleConnection(TSocket* sock);
   void SetGoEnd(const bool val) { m_go_end = val; }
   bool GetGoEnd()        { return m_go_end; }
+  void SetServerReady(const bool val) { m_svr_ready = val; }
+  bool GetServerReady()        { return m_svr_ready; }
 
 #ifndef __CINT__
   pthread_mutex_t* GetMutex() { return &mutex; }

--- a/online/onlmonserver/OnlMonServer.h
+++ b/online/onlmonserver/OnlMonServer.h
@@ -1,11 +1,9 @@
 #ifndef __H_OnlMonServer__H__
 #define __H_OnlMonServer__H__
-#include <map>
 #include <string>
 #include <fun4all/Fun4AllServer.h>
 #include <pthread.h>
 class TSocket;
-class OnlMonClient;
 
 class OnlMonServer : public Fun4AllServer
 {

--- a/online/onlmonserver/OnlMonTrigNim.cc
+++ b/online/onlmonserver/OnlMonTrigNim.cc
@@ -119,7 +119,7 @@ int OnlMonTrigNim::EndOnlMon(PHCompositeNode* topNode)
 
 int OnlMonTrigNim::FindAllMonHist()
 {
-  h2_count = (TH2*)FindMonObj("h2_count");
+  h2_count = (TH2*)FindMonHist("h2_count");
   return (h2_count  ?  0  :  1);
 }
 

--- a/online/onlmonserver/OnlMonTrigSig.cc
+++ b/online/onlmonserver/OnlMonTrigSig.cc
@@ -124,12 +124,12 @@ int OnlMonTrigSig::EndOnlMon(PHCompositeNode* topNode)
 
 int OnlMonTrigSig::FindAllMonHist()
 {
-  h2_bi_fpga = (TH2*)FindMonObj("h2_bi_fpga");
-  h2_ai_fpga = (TH2*)FindMonObj("h2_ai_fpga");
-  h2_bi_nim  = (TH2*)FindMonObj("h2_bi_nim" );
-  h2_ai_nim  = (TH2*)FindMonObj("h2_ai_nim" );
-  h2_rf      = (TH2*)FindMonObj("h2_rf"     );
-  h2_stop    = (TH2*)FindMonObj("h2_stop"   );
+  h2_bi_fpga = (TH2*)FindMonHist("h2_bi_fpga");
+  h2_ai_fpga = (TH2*)FindMonHist("h2_ai_fpga");
+  h2_bi_nim  = (TH2*)FindMonHist("h2_bi_nim" );
+  h2_ai_nim  = (TH2*)FindMonHist("h2_ai_nim" );
+  h2_rf      = (TH2*)FindMonHist("h2_rf"     );
+  h2_stop    = (TH2*)FindMonHist("h2_stop"   );
   return (h2_bi_fpga && h2_ai_fpga && h2_bi_nim && h2_ai_nim && h2_rf && h2_stop  ?  0  :  1);
 }
 

--- a/online/onlmonserver/OnlMonTrigSig.cc
+++ b/online/onlmonserver/OnlMonTrigSig.cc
@@ -45,10 +45,10 @@ int OnlMonTrigSig::InitOnlMon(PHCompositeNode* topNode)
 
 int OnlMonTrigSig::InitRunOnlMon(PHCompositeNode* topNode)
 {
-  const double DT = 4/9.0; // 4/9 ns per single count of Taiwan TDC
-  const int NT = 4000;
-  const double T0 = 0.5*DT;
-  const double T1 = (NT+0.5)*DT;
+  const double DT = 40/9.0; // 4/9 ns per single count of Taiwan TDC
+  const int NT    = 100;
+  const double T0 = 100.5*DT;
+  const double T1 = 200.5*DT;
   h2_bi_fpga = new TH2D("h2_bi_fpga", "FPGA Before Inhibit;tdcTime;", NT, T0, T1,  5, 0.5, 5.5);
   h2_ai_fpga = new TH2D("h2_ai_fpga",  "FPGA After Inhibit;tdcTime;", NT, T0, T1,  5, 0.5, 5.5);
   h2_bi_nim  = new TH2D("h2_bi_nim" ,  "NIM Before Inhibit;tdcTime;", NT, T0, T1,  5, 0.5, 5.5);

--- a/online/onlmonserver/OnlMonUI.cc
+++ b/online/onlmonserver/OnlMonUI.cc
@@ -1,15 +1,26 @@
 #include <iostream>
+#include <sstream>
 #include <sys/stat.h>
 #include <TSystem.h>
 #include <TGFrame.h>
 #include <TGTextView.h>
 #include <TGButton.h>
+#include <TGLabel.h>
+#include <TGNumberEntry.h>
+#include <TGDoubleSlider.h>
+#include "OnlMonComm.h"
 #include "OnlMonClient.h"
 #include "OnlMonUI.h"
 using namespace std;
 
-OnlMonUI::OnlMonUI(OnlMonClientList_t* list) :
-  m_auto_cycle(false), m_interval(10), m_thread_id(0), m_list_omc(list)
+OnlMonUI::OnlMonUI(OnlMonClientList_t* list)
+ : m_auto_cycle(false)
+ , m_interval(10)
+ , m_tid1(0)
+ , m_tid2(0)
+ , m_list_omc(list)
+ , m_sp_min(0)
+ , m_sp_max(0)
 {
   ;
 }
@@ -17,63 +28,130 @@ OnlMonUI::OnlMonUI(OnlMonClientList_t* list) :
 void OnlMonUI::Run()
 {
   BuildInterface();
-  //StartAutoCycle();
+  StartBgProc();
 }
 
 void OnlMonUI::BuildInterface()
 {
-  TGMainFrame* frame = new TGMainFrame(gClient->GetRoot(), 200, 900);
-  frame->SetWMPosition(0, 0); // Often ignored by the window manager
+  //TGMainFrame* frame = new TGMainFrame(gClient->GetRoot(), 200, 900);
+  m_fr_main = new TGMainFrame(gClient->GetRoot(), 200, 900);
+  m_fr_main->SetWMPosition(0, 0); // Often ignored by the window manager
 
   string fn_img = gSystem->Getenv("E1039_RESOURCE");
   fn_img += "/image/onlmon_banner.png";
   struct stat st;
   if (stat(fn_img.c_str(), &st) == 0) {
-    TGPictureButton* head2 = new TGPictureButton(frame, fn_img.c_str());
+    TGPictureButton* head2 = new TGPictureButton(m_fr_main, fn_img.c_str());
     head2->SetCommand("cout << \">> E1039 Online Monitor <<\" << endl;");
-    frame->AddFrame(head2);
+    m_fr_main->AddFrame(head2);
   } else {
-    TGTextView* head = new TGTextView(frame, 200, 40, "E1039 Online Monitor");
-    frame->AddFrame(head); 
+    TGTextView* head = new TGTextView(m_fr_main, 200, 40, "E1039 Online Monitor");
+    m_fr_main->AddFrame(head); 
   }
 
   TGTextButton*  button[99];
   for (unsigned int ii = 0; ii < m_list_omc->size(); ii++) {
-    button[ii] = new TGTextButton(frame, m_list_omc->at(ii)->Title().c_str());
+    button[ii] = new TGTextButton(m_fr_main, m_list_omc->at(ii)->Title().c_str());
     button[ii]->Connect("Clicked()", "OnlMonClient", m_list_omc->at(ii), "StartMonitor()");
-    frame->AddFrame(button[ii], new TGLayoutHints(kLHintsNormal | kLHintsExpandX, 2,2,5,5)); // (l, r, t, b) 
+    m_fr_main->AddFrame(button[ii], new TGLayoutHints(kLHintsNormal | kLHintsExpandX, 2,2,5,5)); // (l, r, t, b) 
   }
 
-  TGCheckButton* check = new TGCheckButton(frame, new TGHotString("Auto-close all canvases"), 99);
+  TGLabel* lbl_sp_sel = new TGLabel(m_fr_main, "- - - Spill Selection - - -");
+  m_fr_main->AddFrame(lbl_sp_sel, new TGLayoutHints(kLHintsCenterY | kLHintsExpandX, 2,2,5,5));
+
+  { // Spill selector by none
+    TGHorizontalFrame* fr_sp_all = new TGHorizontalFrame(m_fr_main);
+
+    m_rad_sp_all = new TGRadioButton(fr_sp_all, "All    ");
+    m_rad_sp_all->Connect("Pressed()", "OnlMonUI", this, "HandleSpRadAll()");
+    fr_sp_all->AddFrame(m_rad_sp_all, new TGLayoutHints(kLHintsCenterY | kLHintsExpandX, 2,2,5,5));
+
+    m_lbl_sp = new TGLabel(fr_sp_all, "?-?");
+    fr_sp_all->AddFrame(m_lbl_sp, new TGLayoutHints(kLHintsCenterY | kLHintsExpandX | kLHintsRight, 2,2,5,5));
+
+    m_fr_main->AddFrame(fr_sp_all);
+  }
+
+  { // Spill selector by number
+    TGHorizontalFrame* fr_sp_last = new TGHorizontalFrame(m_fr_main);
+    
+    m_rad_sp_last = new TGRadioButton(fr_sp_last, "Last   ");
+    m_rad_sp_last->Connect("Pressed()", "OnlMonUI", this, "HandleSpRadLast()");
+    fr_sp_last->AddFrame(m_rad_sp_last, new TGLayoutHints(kLHintsCenterY | kLHintsExpandX, 2,2,5,5));
+
+    m_num_sp = new TGNumberEntry(fr_sp_last, OnlMonComm::instance()->GetSpillNum(), 2);
+    m_num_sp->Connect("ValueSet(Long_t)", "OnlMonUI", this, "HandleSpLastNum()");
+    fr_sp_last->AddFrame(m_num_sp, new TGLayoutHints(kLHintsCenterY | kLHintsCenterX, 2,2,5,5));
+ 
+    TGLabel* lbl_sp_last = new TGLabel(fr_sp_last, "spills");
+    fr_sp_last->AddFrame(lbl_sp_last, new TGLayoutHints(kLHintsCenterY | kLHintsRight, 2,2,5,5));
+    
+    m_fr_main->AddFrame(fr_sp_last);
+  }
+
+  { // Spill selector by spill range
+    m_rad_sp_range = new TGRadioButton(m_fr_main, "Range");
+    m_rad_sp_range->Connect("Pressed()", "OnlMonUI", this, "HandleSpRadRange()");
+    m_fr_main->AddFrame(m_rad_sp_range, new TGLayoutHints(kLHintsCenterY | kLHintsExpandX, 2,2,5,5));  
+    
+    m_fr_sp_range = new TGVerticalFrame(m_fr_main);
+    
+    TGHorizontalFrame* fr_sp = new TGHorizontalFrame(m_fr_sp_range);
+    
+    m_num_sp0 = new TGNumberEntry(fr_sp, 0, 5);
+    m_num_sp0->Connect("ValueSet(Long_t)", "OnlMonUI", this, "HandleSpEntLo()");
+    fr_sp->AddFrame(m_num_sp0, new TGLayoutHints(kLHintsCenterY | kLHintsCenterX));
+    
+    TGLabel* lbl_sp2 = new TGLabel(fr_sp, "-");
+    fr_sp->AddFrame(lbl_sp2, new TGLayoutHints(kLHintsCenterY | kLHintsCenterX));
+    
+    m_num_sp1 = new TGNumberEntry(fr_sp, 0, 5);
+    m_num_sp1->Connect("ValueSet(Long_t)", "OnlMonUI", this, "HandleSpEntHi()");
+    fr_sp->AddFrame(m_num_sp1, new TGLayoutHints(kLHintsCenterY | kLHintsRight));
+    
+    m_fr_sp_range->AddFrame(fr_sp, new TGLayoutHints(kLHintsCenterX | kLHintsCenterY, 2,2,2,2));
+    
+    m_slider = new TGDoubleHSlider(m_fr_sp_range, 180, 0);
+    m_slider->Connect("PositionChanged()", "OnlMonUI", this, "HandleSpSlider()");
+    m_slider->SetRange(1, 10);
+    m_fr_sp_range->AddFrame(m_slider, new TGLayoutHints(kLHintsCenterX | kLHintsCenterY, 2,2,2,2));
+
+    m_fr_main->AddFrame(m_fr_sp_range);
+  }
+
+
+  TGCheckButton* check = new TGCheckButton(m_fr_main, new TGHotString("Auto-close all canvases"), 99);
   check->SetToolTipText("When checked, all existing canvases are closed by clicking any button above.");
   check->SetState(OnlMonClient::GetClearUsFlag() ? kButtonDown : kButtonUp);
   check->Connect("Toggled(Bool_t)", "OnlMonClient", m_list_omc->at(0), "SetClearUsFlag(Bool_t)");
-  frame->AddFrame(check, new TGLayoutHints(kLHintsCenterX | kLHintsCenterY, 2,2,5,5));
+  m_fr_main->AddFrame(check, new TGLayoutHints(kLHintsCenterX | kLHintsCenterY, 2,2,5,5));
 
-  //TGCheckButton* cycle = new TGCheckButton(frame, new TGHotString("Auto-cycle all subsystems"), 99);
+  //TGCheckButton* cycle = new TGCheckButton(m_fr_main, new TGHotString("Auto-cycle all subsystems"), 99);
   //cycle->SetToolTipText("When checked, all subsystems are automatically drawn.");
   //cycle->SetState(GetAutoCycleFlag() ? kButtonDown : kButtonUp);
   //cycle->Connect("Toggled(Bool_t)", "OnlMonUI", this, "SetAutoCycleFlag(Bool_t)");
-  //frame->AddFrame(cycle, new TGLayoutHints(kLHintsCenterX | kLHintsCenterY, 2,2,5,5));
+  //m_fr_main->AddFrame(cycle, new TGLayoutHints(kLHintsCenterX | kLHintsCenterY, 2,2,5,5));
  
-  TGTextButton* fExit = new TGTextButton(frame, "Exit","gApplication->Terminate(0)");
-  frame->AddFrame(fExit, new TGLayoutHints(kLHintsTop | kLHintsExpandX, 2,2,5,5));
+  TGTextButton* fExit = new TGTextButton(m_fr_main, "Exit","gApplication->Terminate(0)");
+  m_fr_main->AddFrame(fExit, new TGLayoutHints(kLHintsTop | kLHintsExpandX, 2,2,5,5));
 
-  frame->SetWindowName("E1039 Online Monitor");
-  frame->MapSubwindows();
-  frame->Resize(frame->GetDefaultSize());
-  frame->MapWindow();
+  m_fr_main->SetWindowName("E1039 Online Monitor");
+  m_fr_main->MapSubwindows();
+  HandleSpRadAll();
+  //m_fr_main->Resize(m_fr_main->GetDefaultSize());
+  //m_fr_main->MapWindow();
 }
 
-void OnlMonUI::StartAutoCycle()
+void OnlMonUI::StartBgProc()
 {
-  pthread_create(&m_thread_id, NULL, FuncAutoCycle, this);
+  pthread_create(&m_tid1, NULL, FuncAutoCycle, this);
+  pthread_create(&m_tid2, NULL, ExecSpillRangeCheck, this);
 }
 
 void* OnlMonUI::FuncAutoCycle(void* arg)
 {
   OnlMonUI* ui = (OnlMonUI*)arg;
-  ui->RunAutoCycle();
+  ui->ExecAutoCycle();
   return 0;
 }
 
@@ -83,7 +161,7 @@ void* OnlMonUI::FuncAutoCycle(void* arg)
  * The ROOT graphic classes seem not thread-safe since they manage global variables (like gPad).
  * It is hard for me to control when global variables are auto-modified by GUI.
  */
-void OnlMonUI::RunAutoCycle()
+void OnlMonUI::ExecAutoCycle()
 {
   unsigned int idx = 0;
   while (true) {
@@ -95,4 +173,99 @@ void OnlMonUI::RunAutoCycle()
     }
     sleep(m_interval);
   }
+}
+
+void* OnlMonUI::ExecSpillRangeCheck(void* arg)
+{
+  OnlMonUI* ui = (OnlMonUI*)arg;
+  while (true) {
+    ui->UpdateFullSpillRange();
+    sleep(6);
+  }
+  return 0;
+}
+
+void OnlMonUI::UpdateFullSpillRange()
+{
+  OnlMonComm::instance()->ReceiveSpillRange(m_sp_min, m_sp_max);
+
+  m_num_sp0->SetLimits(TGNumberFormat::kNELLimitMinMax, m_sp_min, m_sp_max);
+  m_num_sp1->SetLimits(TGNumberFormat::kNELLimitMinMax, m_sp_min, m_sp_max);
+  m_slider->SetRange(m_sp_min, m_sp_max);
+
+  ostringstream oss;
+  oss << m_sp_min << "-" << m_sp_max;
+  m_lbl_sp->SetText(oss.str().c_str());
+}
+
+void OnlMonUI::HandleSpRadAll()
+{
+  OnlMonComm::instance()->SetSpillMode(OnlMonComm::SP_ALL);
+  m_rad_sp_all  ->SetOn(true );
+  m_rad_sp_last ->SetOn(false);
+  m_rad_sp_range->SetOn(false);
+  m_fr_main->HideFrame(m_fr_sp_range);
+  m_fr_main->Resize(m_fr_main->GetDefaultSize());
+  m_fr_main->MapWindow();
+}
+
+void OnlMonUI::HandleSpRadLast()
+{
+  OnlMonComm::instance()->SetSpillMode(OnlMonComm::SP_LAST);
+  m_rad_sp_all  ->SetOn(false);
+  m_rad_sp_last ->SetOn(true );
+  m_rad_sp_range->SetOn(false);
+  m_fr_main->HideFrame(m_fr_sp_range);
+  m_fr_main->Resize(m_fr_main->GetDefaultSize());
+  m_fr_main->MapWindow();
+}
+
+void OnlMonUI::HandleSpRadRange()
+{
+  OnlMonComm::instance()->SetSpillRange((m_sp_min+m_sp_max)/2, m_sp_max);
+  SyncSpillRange();
+
+  OnlMonComm::instance()->SetSpillMode(OnlMonComm::SP_RANGE);
+  m_rad_sp_all  ->SetOn(false);
+  m_rad_sp_last ->SetOn(false);
+  m_rad_sp_range->SetOn(true );
+  m_fr_main->ShowFrame(m_fr_sp_range);
+  m_fr_main->Resize(m_fr_main->GetDefaultSize());
+  m_fr_main->MapWindow();
+}
+
+void OnlMonUI::HandleSpLastNum()
+{
+  int num = (int)m_num_sp->GetNumber();
+  m_num_sp->SetNumber(num); // Make it integer
+  OnlMonComm::instance()->SetSpillNum(num);
+}
+
+void OnlMonUI::HandleSpEntLo()
+{
+  OnlMonComm::instance()->SetSpillRangeLow((int)m_num_sp0->GetNumber());
+  SyncSpillRange();
+}
+
+void OnlMonUI::HandleSpEntHi()
+{
+  OnlMonComm::instance()->SetSpillRangeHigh((int)m_num_sp1->GetNumber());
+  SyncSpillRange();
+}
+
+void OnlMonUI::HandleSpSlider()
+{
+  float sp_lo, sp_hi;
+  m_slider->GetPosition(sp_lo, sp_hi);
+  OnlMonComm::instance()->SetSpillRange((int)sp_lo, (int)sp_hi);
+  SyncSpillRange();
+}
+
+void OnlMonUI::SyncSpillRange()
+{
+  int sp_lo, sp_hi;
+  OnlMonComm::instance()->GetSpillRange(sp_lo, sp_hi);
+  m_slider->SetPosition(sp_lo, sp_hi);
+  m_num_sp0->SetNumber (sp_lo);
+  m_num_sp1->SetNumber (sp_hi);
 }

--- a/online/onlmonserver/OnlMonUI.cc
+++ b/online/onlmonserver/OnlMonUI.cc
@@ -14,13 +14,11 @@
 using namespace std;
 
 OnlMonUI::OnlMonUI(OnlMonClientList_t* list)
- : m_auto_cycle(false)
- , m_interval(10)
- , m_tid1(0)
- , m_tid2(0)
- , m_list_omc(list)
- , m_sp_min(0)
- , m_sp_max(0)
+  : m_auto_cycle(false)
+  , m_interval(10)
+  , m_tid1(0)
+  , m_tid2(0)
+  , m_list_omc(list)
 {
   ;
 }
@@ -187,14 +185,17 @@ void* OnlMonUI::ExecSpillRangeCheck(void* arg)
 
 void OnlMonUI::UpdateFullSpillRange()
 {
-  OnlMonComm::instance()->ReceiveSpillRange(m_sp_min, m_sp_max);
+  OnlMonComm* comm = OnlMonComm::instance();
+  int sp_min, sp_max;
+  comm->ReceiveFullSpillRange();
+  comm->GetFullSpillRange(sp_min, sp_max);
 
-  m_num_sp0->SetLimits(TGNumberFormat::kNELLimitMinMax, m_sp_min, m_sp_max);
-  m_num_sp1->SetLimits(TGNumberFormat::kNELLimitMinMax, m_sp_min, m_sp_max);
-  m_slider->SetRange(m_sp_min, m_sp_max);
+  m_num_sp0->SetLimits(TGNumberFormat::kNELLimitMinMax, sp_min, sp_max);
+  m_num_sp1->SetLimits(TGNumberFormat::kNELLimitMinMax, sp_min, sp_max);
+  m_slider->SetRange(sp_min, sp_max);
 
   ostringstream oss;
-  oss << m_sp_min << "-" << m_sp_max;
+  oss << sp_min << "-" << sp_max;
   m_lbl_sp->SetText(oss.str().c_str());
 }
 
@@ -222,7 +223,11 @@ void OnlMonUI::HandleSpRadLast()
 
 void OnlMonUI::HandleSpRadRange()
 {
-  OnlMonComm::instance()->SetSpillRange((m_sp_min+m_sp_max)/2, m_sp_max);
+  UpdateFullSpillRange();
+
+  int sp_min, sp_max;
+  OnlMonComm::instance()->GetFullSpillRange(sp_min, sp_max);
+  OnlMonComm::instance()->SetSpillRange((sp_min+sp_max)/2, sp_max);
   SyncSpillRange();
 
   OnlMonComm::instance()->SetSpillMode(OnlMonComm::SP_RANGE);

--- a/online/onlmonserver/OnlMonUI.cc
+++ b/online/onlmonserver/OnlMonUI.cc
@@ -31,7 +31,6 @@ void OnlMonUI::Run()
 
 void OnlMonUI::BuildInterface()
 {
-  //TGMainFrame* frame = new TGMainFrame(gClient->GetRoot(), 200, 900);
   m_fr_main = new TGMainFrame(gClient->GetRoot(), 200, 900);
   m_fr_main->SetWMPosition(0, 0); // Often ignored by the window manager
 
@@ -51,21 +50,21 @@ void OnlMonUI::BuildInterface()
   for (unsigned int ii = 0; ii < m_list_omc->size(); ii++) {
     button[ii] = new TGTextButton(m_fr_main, m_list_omc->at(ii)->Title().c_str());
     button[ii]->Connect("Clicked()", "OnlMonClient", m_list_omc->at(ii), "StartMonitor()");
-    m_fr_main->AddFrame(button[ii], new TGLayoutHints(kLHintsNormal | kLHintsExpandX, 2,2,5,5)); // (l, r, t, b) 
+    m_fr_main->AddFrame(button[ii], new TGLayoutHints(kLHintsNormal | kLHintsExpandX, 2,2,2,2)); // (l, r, t, b) 
   }
 
   TGLabel* lbl_sp_sel = new TGLabel(m_fr_main, "- - - Spill Selection - - -");
-  m_fr_main->AddFrame(lbl_sp_sel, new TGLayoutHints(kLHintsCenterY | kLHintsExpandX, 2,2,5,5));
+  m_fr_main->AddFrame(lbl_sp_sel, new TGLayoutHints(kLHintsCenterY | kLHintsExpandX, 2,2,5,2));
 
   { // Spill selector by none
     TGHorizontalFrame* fr_sp_all = new TGHorizontalFrame(m_fr_main);
 
     m_rad_sp_all = new TGRadioButton(fr_sp_all, "All    ");
     m_rad_sp_all->Connect("Pressed()", "OnlMonUI", this, "HandleSpRadAll()");
-    fr_sp_all->AddFrame(m_rad_sp_all, new TGLayoutHints(kLHintsCenterY | kLHintsExpandX, 2,2,5,5));
+    fr_sp_all->AddFrame(m_rad_sp_all, new TGLayoutHints(kLHintsCenterY | kLHintsExpandX, 2,2,2,2));
 
     m_lbl_sp = new TGLabel(fr_sp_all, "?-?");
-    fr_sp_all->AddFrame(m_lbl_sp, new TGLayoutHints(kLHintsCenterY | kLHintsExpandX | kLHintsRight, 2,2,5,5));
+    fr_sp_all->AddFrame(m_lbl_sp, new TGLayoutHints(kLHintsCenterY | kLHintsExpandX | kLHintsRight, 2,2,2,2));
 
     m_fr_main->AddFrame(fr_sp_all);
   }
@@ -75,14 +74,14 @@ void OnlMonUI::BuildInterface()
     
     m_rad_sp_last = new TGRadioButton(fr_sp_last, "Last   ");
     m_rad_sp_last->Connect("Pressed()", "OnlMonUI", this, "HandleSpRadLast()");
-    fr_sp_last->AddFrame(m_rad_sp_last, new TGLayoutHints(kLHintsCenterY | kLHintsExpandX, 2,2,5,5));
+    fr_sp_last->AddFrame(m_rad_sp_last, new TGLayoutHints(kLHintsCenterY | kLHintsExpandX, 2,2,2,2));
 
     m_num_sp = new TGNumberEntry(fr_sp_last, OnlMonComm::instance()->GetSpillNum(), 2);
     m_num_sp->Connect("ValueSet(Long_t)", "OnlMonUI", this, "HandleSpLastNum()");
-    fr_sp_last->AddFrame(m_num_sp, new TGLayoutHints(kLHintsCenterY | kLHintsCenterX, 2,2,5,5));
+    fr_sp_last->AddFrame(m_num_sp, new TGLayoutHints(kLHintsCenterY | kLHintsCenterX, 2,2,2,2));
  
     TGLabel* lbl_sp_last = new TGLabel(fr_sp_last, "spills");
-    fr_sp_last->AddFrame(lbl_sp_last, new TGLayoutHints(kLHintsCenterY | kLHintsRight, 2,2,5,5));
+    fr_sp_last->AddFrame(lbl_sp_last, new TGLayoutHints(kLHintsCenterY | kLHintsRight, 2,2,2,2));
     
     m_fr_main->AddFrame(fr_sp_last);
   }
@@ -90,7 +89,7 @@ void OnlMonUI::BuildInterface()
   { // Spill selector by spill range
     m_rad_sp_range = new TGRadioButton(m_fr_main, "Range");
     m_rad_sp_range->Connect("Pressed()", "OnlMonUI", this, "HandleSpRadRange()");
-    m_fr_main->AddFrame(m_rad_sp_range, new TGLayoutHints(kLHintsCenterY | kLHintsExpandX, 2,2,5,5));  
+    m_fr_main->AddFrame(m_rad_sp_range, new TGLayoutHints(kLHintsCenterY | kLHintsExpandX, 2,2,2,2));  
     
     m_fr_sp_range = new TGVerticalFrame(m_fr_main);
     
@@ -122,7 +121,7 @@ void OnlMonUI::BuildInterface()
   check->SetToolTipText("When checked, all existing canvases are closed by clicking any button above.");
   check->SetState(OnlMonClient::GetClearUsFlag() ? kButtonDown : kButtonUp);
   check->Connect("Toggled(Bool_t)", "OnlMonClient", m_list_omc->at(0), "SetClearUsFlag(Bool_t)");
-  m_fr_main->AddFrame(check, new TGLayoutHints(kLHintsCenterX | kLHintsCenterY, 2,2,5,5));
+  m_fr_main->AddFrame(check, new TGLayoutHints(kLHintsCenterX | kLHintsCenterY, 2,2,2,2));
 
   //TGCheckButton* cycle = new TGCheckButton(m_fr_main, new TGHotString("Auto-cycle all subsystems"), 99);
   //cycle->SetToolTipText("When checked, all subsystems are automatically drawn.");

--- a/online/onlmonserver/OnlMonUI.h
+++ b/online/onlmonserver/OnlMonUI.h
@@ -2,15 +2,39 @@
 #define _ONL_MON_UI__H_
 #include <vector>
 class OnlMonClient;
+class TGMainFrame;
+class TGCompositeFrame;
+class TGHorizontalFrame;
 class TGTextButton;
+class TGRadioButton;
+class TGLabel;
+class TGNumberEntry;
+class TGDoubleSlider;
 
 typedef std::vector<OnlMonClient*> OnlMonClientList_t;
 
 class OnlMonUI {
   bool m_auto_cycle;
   int  m_interval; //< Cycle interval in second
-  pthread_t m_thread_id;
+  pthread_t m_tid1;
+  pthread_t m_tid2;
   OnlMonClientList_t* m_list_omc;
+
+  int m_sp_min; //< Min of full (not selected) range
+  int m_sp_max; //< Max of full scale
+
+  TGMainFrame* m_fr_main;
+  TGCompositeFrame* m_fr_sp_range;
+
+  TGRadioButton* m_rad_sp_all;
+  TGRadioButton* m_rad_sp_last;
+  TGRadioButton* m_rad_sp_range;
+
+  TGLabel* m_lbl_sp;
+  TGNumberEntry* m_num_sp;
+  TGNumberEntry* m_num_sp0;
+  TGNumberEntry* m_num_sp1;
+  TGDoubleSlider* m_slider;
 
  public:
   OnlMonUI(OnlMonClientList_t* list);
@@ -22,11 +46,24 @@ class OnlMonUI {
   int  GetCycleInterval() { return m_interval; }
   void Run();
 
+  void UpdateFullSpillRange();
+
+  void HandleSpRadAll();
+  void HandleSpRadLast();
+  void HandleSpRadRange();
+  void HandleSpLastNum();
+  void HandleSpEntLo();
+  void HandleSpEntHi();
+  void HandleSpSlider();
+  void SyncSpillRange();
+
  protected:
   void BuildInterface();
-  void StartAutoCycle();
+  void StartBgProc();
   static void* FuncAutoCycle(void* arg);
-  void RunAutoCycle();
+  void ExecAutoCycle();
+  static void* ExecSpillRangeCheck(void* arg);
+
 };
 
 #endif /* _ONL_MON_UI__H_ */

--- a/online/onlmonserver/OnlMonUI.h
+++ b/online/onlmonserver/OnlMonUI.h
@@ -20,9 +20,6 @@ class OnlMonUI {
   pthread_t m_tid2;
   OnlMonClientList_t* m_list_omc;
 
-  int m_sp_min; //< Min of full (not selected) range
-  int m_sp_max; //< Max of full scale
-
   TGMainFrame* m_fr_main;
   TGCompositeFrame* m_fr_sp_range;
 

--- a/online/onlmonserver/OnlMonV1495.cc
+++ b/online/onlmonserver/OnlMonV1495.cc
@@ -127,19 +127,19 @@ int OnlMonV1495::FindAllMonHist()
   for (int pl = 0; pl < m_n_pl; pl++) {
     oss.str("");
     oss << "h1_ele_" << pl;
-    h1_ele[pl] = (TH1*)FindMonObj(oss.str().c_str());
+    h1_ele[pl] = FindMonHist(oss.str().c_str());
     if (! h1_ele[pl]) return 1;
     oss.str("");
     oss << "h1_ele_in_" << pl;
-    h1_ele_in[pl] = (TH1*)FindMonObj(oss.str().c_str());
+    h1_ele_in[pl] = FindMonHist(oss.str().c_str());
     if (! h1_ele_in[pl]) return 1;
     oss.str("");
     oss << "h1_time_" << pl;
-    h1_time[pl] = (TH1*)FindMonObj(oss.str().c_str());
+    h1_time[pl] = FindMonHist(oss.str().c_str());
     if (! h1_time[pl]) return 1;
     oss.str("");
     oss << "h1_time_in_" << pl;
-    h1_time_in[pl] = (TH1*)FindMonObj(oss.str().c_str());
+    h1_time_in[pl] = FindMonHist(oss.str().c_str());
     if (! h1_time_in[pl]) return 1;
   }
   return 0;

--- a/online/onlmonserver/OnlMonV1495.cc
+++ b/online/onlmonserver/OnlMonV1495.cc
@@ -64,10 +64,10 @@ int OnlMonV1495::InitRunOnlMon(PHCompositeNode* topNode)
     oss << name << ";Element ID;In-time hit count";
     h1_ele_in[pl]->SetTitle(oss.str().c_str());
 
-    const double DT = 1.0; // 1 ns per single count of v1495 TDC
-    const int NT = 2000;
-    const double T0 = 0.5*DT;
-    const double T1 = (NT+0.5)*DT;
+    const double DT = 5.0; // 1 ns per single count of v1495 TDC
+    const int NT    = 100;
+    const double T0 = 100.5*DT;
+    const double T1 = 200.5*DT;
 
     //double center, width;
     //calib.Find(m_pl0 + pl, 1, m_lvl, center, width);

--- a/packages/UtilAna/UtilSQHit.cc
+++ b/packages/UtilAna/UtilSQHit.cc
@@ -36,7 +36,7 @@ SQHitVector* UtilSQHit::FindFirstHits(const SQHitVector* vec_in, const int det_i
     if (hit->get_detector_id() != det_id) continue;
     short  ele_id = hit->get_element_id();
     double time   = hit->get_tdc_time();
-    if (id2time.find(ele_id) != id2time.end() || time > id2time[ele_id]) {
+    if (id2time.find(ele_id) == id2time.end() || time > id2time[ele_id]) {
       id2time[ele_id] = time;
       id2idx [ele_id] = idx;
     }


### PR DESCRIPTION
This update mainly adds a function to the OnlMon viewer that selects a set of spills to be monitored.  The updated version is already in use after it was tested on e1039-monitor by Abi and me last week.

This update also includes other small changes;
- A new plot was added to OnlMonHodo.
- OnlMonServer::HandleConnection() now ignores unexpected message (rather than gets stuck).
- The decoder (MainDaqParser) now ignores the spill-counter event so that spill ID is always set by the internal counter.  Details can be found in elog #1687.
- The bug in UtilSQHit::FindFirstHits() was fixed, as done in e1039-analysis.

Below is technical details about the spill selector.

An OnlMon hist is filled at the side of OnlMon server.  Individual OnlMon clients (such as OnlMonHodo) need not check when new spill comes in.  Instead the base class (`OnlMonClient`) checks it and automatically makes spill-by-spill hists in `OnlMonClient::MakeSpillHist()`.

The OnlMon viewer (= `OnlMonUI`) communicates with the OnlMon server in order to receive the range of available spill IDs and send the range of spill IDs to be monitored.  It is done via `OnlMonComm`.  When the OnlMon viewer requests a set of OnlMon hists in a spill-ID range, the OnlMon server first merges the spill-by-spill hists in the given spill-ID range (via `OnlMonClient::MakeMergedHist()`) and then sends the merged hists to the OnlMon viewer.
