### PR TITLE
Addition of DP hodoscope to channel mapping and online monitoring

### DIFF
--- a/online/decoder_maindaq/DbUpSpill.cc
+++ b/online/decoder_maindaq/DbUpSpill.cc
@@ -72,7 +72,7 @@ int DbUpSpill::End(PHCompositeNode* topNode)
 void DbUpSpill::ClearTable(const char* table_name, const int run_id)
 {
   DbSvc db(DbSvc::DB1);
-  db.UseSchema("user_e1039_maindaq", true);
+  db.UseSchema(UtilOnline::GetSchemaMainDaq(), true);
   if (! db.HasTable(table_name)) return;
   ostringstream oss;
   oss << "delete from " << table_name << " where run_id = " << run_id;

--- a/online/macros/Fun4MainDaq.C
+++ b/online/macros/Fun4MainDaq.C
@@ -11,6 +11,7 @@ int Fun4MainDaq(const int run=46, const int nevent=0, const bool is_online=false
   gSystem->Load("libinterface_main.so");
   gSystem->Load("libdecoder_maindaq.so");
   gSystem->Load("libonlmonserver.so");
+  GeomSvc::UseDbSvc(true);
   const bool use_onlmon = true;
 
   const char* deco_mode = gSystem->Getenv("E1039_DECODER_MODE");
@@ -68,6 +69,10 @@ int Fun4MainDaq(const int run=46, const int nevent=0, const bool is_online=false
     se->registerSubsystem(new OnlMonHodo (OnlMonHodo::H2Y));
     se->registerSubsystem(new OnlMonHodo (OnlMonHodo::H4Y1));
     se->registerSubsystem(new OnlMonHodo (OnlMonHodo::H4Y2));
+    se->registerSubsystem(new OnlMonHodo (OnlMonHodo::DP1T));
+    se->registerSubsystem(new OnlMonHodo (OnlMonHodo::DP1B));
+    se->registerSubsystem(new OnlMonHodo (OnlMonHodo::DP2T));
+    se->registerSubsystem(new OnlMonHodo (OnlMonHodo::DP2B));
     se->registerSubsystem(new OnlMonH4   (OnlMonH4::H4T));
     se->registerSubsystem(new OnlMonH4   (OnlMonH4::H4B));
     se->registerSubsystem(new OnlMonH4   (OnlMonH4::H4Y1L));

--- a/online/macros/OnlMon4MainDaq.C
+++ b/online/macros/OnlMon4MainDaq.C
@@ -31,6 +31,10 @@ int OnlMon4MainDaq()
   list_omc.push_back(new OnlMonHodo (OnlMonHodo ::H2Y ));
   list_omc.push_back(new OnlMonHodo (OnlMonHodo ::H4Y1));
   list_omc.push_back(new OnlMonHodo (OnlMonHodo ::H4Y2));
+  list_omc.push_back(new OnlMonHodo (OnlMonHodo ::DP1T));
+  list_omc.push_back(new OnlMonHodo (OnlMonHodo ::DP1B));
+  list_omc.push_back(new OnlMonHodo (OnlMonHodo ::DP2T));
+  list_omc.push_back(new OnlMonHodo (OnlMonHodo ::DP2B));
   list_omc.push_back(new OnlMonH4   (OnlMonH4   ::H4T  ));
   list_omc.push_back(new OnlMonH4   (OnlMonH4   ::H4B  ));
   list_omc.push_back(new OnlMonH4   (OnlMonH4   ::H4Y1L));

--- a/online/onlmonserver/OnlMonHodo.cc
+++ b/online/onlmonserver/OnlMonHodo.cc
@@ -11,7 +11,6 @@
 #include <phool/PHIODataNode.h>
 #include <phool/getClass.h>
 #include <geom_svc/GeomSvc.h>
-//#include <geom_svc/CalibParamInTimeTaiwan.h>
 #include <UtilAna/UtilHist.h>
 #include "OnlMonServer.h"
 #include "OnlMonHodo.h"
@@ -20,20 +19,19 @@ using namespace std;
 OnlMonHodo::OnlMonHodo(const HodoType_t type) : m_type(type)
 {
   NumCanvases(2);
-  m_n_pl = 2;
   switch (m_type) {
-  case H1X:  m_pl0 = 31;  Name("OnlMonHodoH1X" );  Title("Hodo: H1X" );  break;
-  case H2X:  m_pl0 = 37;  Name("OnlMonHodoH2X" );  Title("Hodo: H2X" );  break;
-  case H3X:  m_pl0 = 39;  Name("OnlMonHodoH3X" );  Title("Hodo: H3X" );  break;
-  case H4X:  m_pl0 = 45;  Name("OnlMonHodoH4X" );  Title("Hodo: H4X" );  break;
-  case H1Y:  m_pl0 = 33;  Name("OnlMonHodoH1Y" );  Title("Hodo: H1Y" );  break;
-  case H2Y:  m_pl0 = 35;  Name("OnlMonHodoH2Y" );  Title("Hodo: H2Y" );  break;
-  case H4Y1: m_pl0 = 41;  Name("OnlMonHodoH4Y1");  Title("Hodo: H4Y1");  break;
-  case H4Y2: m_pl0 = 43;  Name("OnlMonHodoH4Y2");  Title("Hodo: H4Y2");  break;
-  case DP1T: m_pl0 = 55;  Name("OnlMonHodoDP1T");  Title("Hodo: DP1T");  break;
-  case DP1B: m_pl0 = 57;  Name("OnlMonHodoDP1B");  Title("Hodo: DP1B");  break;
-  case DP2T: m_pl0 = 59;  Name("OnlMonHodoDP2T");  Title("Hodo: DP2T");  break;
-  case DP2B: m_pl0 = 61;  Name("OnlMonHodoDP2B");  Title("Hodo: DP2B");  break;
+  case H1X:  Name("OnlMonHodoH1X" );  Title("Hodo: H1X" );  break;
+  case H2X:  Name("OnlMonHodoH2X" );  Title("Hodo: H2X" );  break;
+  case H3X:  Name("OnlMonHodoH3X" );  Title("Hodo: H3X" );  break;
+  case H4X:  Name("OnlMonHodoH4X" );  Title("Hodo: H4X" );  break;
+  case H1Y:  Name("OnlMonHodoH1Y" );  Title("Hodo: H1Y" );  break;
+  case H2Y:  Name("OnlMonHodoH2Y" );  Title("Hodo: H2Y" );  break;
+  case H4Y1: Name("OnlMonHodoH4Y1");  Title("Hodo: H4Y1");  break;
+  case H4Y2: Name("OnlMonHodoH4Y2");  Title("Hodo: H4Y2");  break;
+  case DP1T: Name("OnlMonHodoDP1T");  Title("Hodo: DP1T");  break;
+  case DP1B: Name("OnlMonHodoDP1B");  Title("Hodo: DP1B");  break;
+  case DP2T: Name("OnlMonHodoDP2T");  Title("Hodo: DP2T");  break;
+  case DP2B: Name("OnlMonHodoDP2B");  Title("Hodo: DP2B");  break;
   }
 }
 
@@ -44,65 +42,77 @@ int OnlMonHodo::InitOnlMon(PHCompositeNode* topNode)
 
 int OnlMonHodo::InitRunOnlMon(PHCompositeNode* topNode)
 {
-  //SQRun* run_header = findNode::getClass<SQRun>(topNode, "SQRun");
-  //if (!run_header) return Fun4AllReturnCodes::ABORTEVENT;
+  const double DT = 20/9.0; // 4/9 ns per single count of Taiwan TDC
+  int NT    = 200;
+  double T0 = 200.5*DT;
+  double T1 = 400.5*DT;
+  switch (m_type) {
+  case H1X:  SetDet("H1T"  ,"H1B"  ); break;
+  case H2X:  SetDet("H2T"  ,"H2B"  ); break;
+  case H3X:  SetDet("H3T"  ,"H3B"  ); break;
+  case H4X:  SetDet("H4T"  ,"H4B"  ); break;
+  case H1Y:  SetDet("H1L"  ,"H1R"  ); break;
+  case H2Y:  SetDet("H2L"  ,"H2R"  ); break;
+  case H4Y1: SetDet("H4Y1L","H4Y1R"); break;
+  case H4Y2: SetDet("H4Y2L","H4Y2R"); break;
+  case DP1T: SetDet("DP1TL","DP1TR"); NT=200; T0=300.5*DT; T1=500.5*DT; break;
+  case DP1B: SetDet("DP1BL","DP1BR"); NT=200; T0=300.5*DT; T1=500.5*DT; break;
+  case DP2T: SetDet("DP2TL","DP2TR"); NT=200; T0=300.5*DT; T1=500.5*DT; break;
+  case DP2B: SetDet("DP2BL","DP2BR"); NT=200; T0=300.5*DT; T1=500.5*DT; break;
+  }
 
   GeomSvc* geom = GeomSvc::instance();
-  //CalibParamInTimeTaiwan calib;
-  //calib.SetMapIDbyDB(run_header->get_run_id());
-  //calib.ReadFromDB();
-
   ostringstream oss;
-  for (int pl = 0; pl < m_n_pl; pl++) {
-    string name = geom->getDetectorName(m_pl0 + pl);
-    int n_ele = geom->getPlaneNElements(m_pl0 + pl); 
+  for (unsigned int i_det = 0; i_det < N_DET; i_det++) {
+    string name = list_det_name[i_det];
+    int  det_id = list_det_id  [i_det];
+    int n_ele  = geom->getPlaneNElements(det_id);
+    if (det_id <= 0 || n_ele <= 0) {
+      cout << "OnlMonHodo::InitRunOnlMon():  Invalid det_id or n_ele: " 
+           << det_id << " " << n_ele << " at name = " << name << "." << endl;
+      return Fun4AllReturnCodes::ABORTEVENT;
+    }
+
     oss.str("");
-    oss << "h1_ele_" << pl;
-    h1_ele[pl] = new TH1D(oss.str().c_str(), "", n_ele, 0.5, n_ele+0.5);
+    oss << "h1_ele_" << i_det;
+    h1_ele[i_det] = new TH1D(oss.str().c_str(), "", n_ele, 0.5, n_ele+0.5);
     oss.str("");
     oss << name << ";Element ID;Hit count";
-    h1_ele[pl]->SetTitle(oss.str().c_str());
+    h1_ele[i_det]->SetTitle(oss.str().c_str());
 
     oss.str("");
-    oss << "h1_ele_in_" << pl;
-    h1_ele_in[pl] = new TH1D(oss.str().c_str(), "", n_ele, 0.5, n_ele+0.5);
+    oss << "h1_ele_in_" << i_det;
+    h1_ele_in[i_det] = new TH1D(oss.str().c_str(), "", n_ele, 0.5, n_ele+0.5);
     oss.str("");
     oss << name << ";Element ID;In-time hit count";
-    h1_ele_in[pl]->SetTitle(oss.str().c_str());
+    h1_ele_in[i_det]->SetTitle(oss.str().c_str());
 
-    const double DT = 20/9.0; // 4/9 ns per single count of Taiwan TDC
-    const int    NT = 200;
-    const double T0 = 200.5*DT;
-    const double T1 = 400.5*DT;
-
-    //double center, width;
-    //calib.Find(m_pl0 + pl, 1, center, width);
     oss.str("");
-    oss << "h1_time_" << pl;
-    h1_time[pl] = new TH1D(oss.str().c_str(), "", NT, T0, T1);
+    oss << "h1_time_" << i_det;
+    h1_time[i_det] = new TH1D(oss.str().c_str(), "", NT, T0, T1);
     oss.str("");
     oss << name << ";tdcTime;Hit count";
-    h1_time[pl]->SetTitle(oss.str().c_str());
+    h1_time[i_det]->SetTitle(oss.str().c_str());
 
     oss.str("");
-    oss << "h1_time_in_" << pl;
-    h1_time_in[pl] = new TH1D(oss.str().c_str(), "", NT, T0, T1);
+    oss << "h1_time_in_" << i_det;
+    h1_time_in[i_det] = new TH1D(oss.str().c_str(), "", NT, T0, T1);
     oss.str("");
     oss << name << ";tdcTime;In-time hit count";
-    h1_time_in[pl]->SetTitle(oss.str().c_str());
+    h1_time_in[i_det]->SetTitle(oss.str().c_str());
 
     oss.str("");
-    oss << "h2_time_ele_" << pl;
-    h2_time_ele[pl] = new TH2D(oss.str().c_str(), "", n_ele, 0.5, n_ele+0.5, NT, T0, T1);
+    oss << "h2_time_ele_" << i_det;
+    h2_time_ele[i_det] = new TH2D(oss.str().c_str(), "", n_ele, 0.5, n_ele+0.5, NT, T0, T1);
     oss.str("");
     oss << name << ";Element ID;tdcTime;Hit count";
-    h2_time_ele[pl]->SetTitle(oss.str().c_str());
+    h2_time_ele[i_det]->SetTitle(oss.str().c_str());
 
-    RegisterHist(h1_ele    [pl]);
-    RegisterHist(h1_ele_in [pl]);
-    RegisterHist(h1_time   [pl]);
-    RegisterHist(h1_time_in[pl]);
-    RegisterHist(h2_time_ele[pl]);
+    RegisterHist(h1_ele     [i_det]);
+    RegisterHist(h1_ele_in  [i_det]);
+    RegisterHist(h1_time    [i_det]);
+    RegisterHist(h1_time_in [i_det]);
+    RegisterHist(h2_time_ele[i_det]);
   }
 
   return Fun4AllReturnCodes::EVENT_OK;
@@ -115,16 +125,18 @@ int OnlMonHodo::ProcessEventOnlMon(PHCompositeNode* topNode)
   if (!event_header || !hit_vec) return Fun4AllReturnCodes::ABORTEVENT;
 
   for (SQHitVector::ConstIter it = hit_vec->begin(); it != hit_vec->end(); it++) {
-    int pl = (*it)->get_detector_id() - m_pl0;
-    if (pl < 0 || pl >= m_n_pl) continue;
-    int    ele  = (*it)->get_element_id();
-    double time = (*it)->get_tdc_time  ();
-    h1_ele [pl]->Fill(ele );
-    h1_time[pl]->Fill(time);
-    h2_time_ele[pl]->Fill(ele, time);
-    if ((*it)->is_in_time()) {
-      h1_ele_in [pl]->Fill(ele );
-      h1_time_in[pl]->Fill(time);
+    int det_id = (*it)->get_detector_id();
+    for (int i_det = 0; i_det < N_DET; i_det++) {
+      if (list_det_id[i_det] != det_id) continue;
+      int    ele  = (*it)->get_element_id();
+      double time = (*it)->get_tdc_time  ();
+      h1_ele     [i_det]->Fill(ele );
+      h1_time    [i_det]->Fill(time);
+      h2_time_ele[i_det]->Fill(ele, time);
+      if ((*it)->is_in_time()) {
+        h1_ele_in [i_det]->Fill(ele );
+        h1_time_in[i_det]->Fill(time);
+      }
     }
   }
   
@@ -139,27 +151,27 @@ int OnlMonHodo::EndOnlMon(PHCompositeNode* topNode)
 int OnlMonHodo::FindAllMonHist()
 {
   ostringstream oss;
-  for (int pl = 0; pl < m_n_pl; pl++) {
+  for (int i_det = 0; i_det < N_DET; i_det++) {
     oss.str("");
-    oss << "h1_ele_" << pl;
-    h1_ele[pl] = FindMonHist(oss.str().c_str());
-    if (! h1_ele[pl]) return 1;
+    oss << "h1_ele_" << i_det;
+    h1_ele[i_det] = FindMonHist(oss.str().c_str());
+    if (! h1_ele[i_det]) return 1;
     oss.str("");
-    oss << "h1_ele_in_" << pl;
-    h1_ele_in[pl] = FindMonHist(oss.str().c_str());
-    if (! h1_ele_in[pl]) return 1;
+    oss << "h1_ele_in_" << i_det;
+    h1_ele_in[i_det] = FindMonHist(oss.str().c_str());
+    if (! h1_ele_in[i_det]) return 1;
     oss.str("");
-    oss << "h1_time_" << pl;
-    h1_time[pl] = FindMonHist(oss.str().c_str());
-    if (! h1_time[pl]) return 1;
+    oss << "h1_time_" << i_det;
+    h1_time[i_det] = FindMonHist(oss.str().c_str());
+    if (! h1_time[i_det]) return 1;
     oss.str("");
-    oss << "h1_time_in_" << pl;
-    h1_time_in[pl] = FindMonHist(oss.str().c_str());
-    if (! h1_time_in[pl]) return 1;
+    oss << "h1_time_in_" << i_det;
+    h1_time_in[i_det] = FindMonHist(oss.str().c_str());
+    if (! h1_time_in[i_det]) return 1;
     oss.str("");
-    oss << "h2_time_ele_" << pl;
-    h2_time_ele[pl] = (TH2*)FindMonHist(oss.str().c_str());
-    if (! h2_time_ele[pl]) return 1;
+    oss << "h2_time_ele_" << i_det;
+    h2_time_ele[i_det] = (TH2*)FindMonHist(oss.str().c_str());
+    if (! h2_time_ele[i_det]) return 1;
   }
   return 0;
 }
@@ -172,20 +184,20 @@ int OnlMonHodo::DrawMonitor()
   pad0->SetGrid();
   pad0->Divide(2, 2);
   bool empty_ele = false;
-  for (int pl = 0; pl < m_n_pl; pl++) {
-    pad0->cd(2*pl+1);
-    h1_ele[pl]->SetLineColor(kBlack);
-    h1_ele[pl]->Draw();
-    h1_ele_in[pl]->SetLineColor(kBlue);
-    h1_ele_in[pl]->SetFillColor(kBlue-7);
-    h1_ele_in[pl]->Draw("same");
-    if (h1_ele[pl]->GetMinimum() == 0) empty_ele = true;
+  for (int i_det = 0; i_det < N_DET; i_det++) {
+    pad0->cd(2*i_det+1);
+    h1_ele[i_det]->SetLineColor(kBlack);
+    h1_ele[i_det]->Draw();
+    h1_ele_in[i_det]->SetLineColor(kBlue);
+    h1_ele_in[i_det]->SetFillColor(kBlue-7);
+    h1_ele_in[i_det]->Draw("same");
+    if (h1_ele[i_det]->GetMinimum() == 0) empty_ele = true;
 
-    pad0->cd(2*pl+2);
-    h2_time_ele[pl]->Draw("colz");
+    pad0->cd(2*i_det+2);
+    h2_time_ele[i_det]->Draw("colz");
     ostringstream oss;
-    oss << "pr_" << h2_time_ele[pl]->GetName();
-    TProfile* pr = h2_time_ele[pl]->ProfileX(oss.str().c_str(), 1, -1, "s");
+    oss << "pr_" << h2_time_ele[i_det]->GetName();
+    TProfile* pr = h2_time_ele[i_det]->ProfileX(oss.str().c_str()); // , 1, -1, "s");
     pr->SetLineColor(kBlack);
     pr->Draw("E1same");
   }
@@ -199,16 +211,26 @@ int OnlMonHodo::DrawMonitor()
   TPad* pad1 = can1->GetMainPad();
   pad1->SetGrid();
   pad1->Divide(1, 2);
-  for (int pl = 0; pl < m_n_pl; pl++) {
-    pad1->cd(pl+1);
-    //UtilHist::AutoSetRange(h1_time[pl]);
-    //h1_time[pl]->GetXaxis()->SetRangeUser(400, 1050);
-    h1_time[pl]->SetLineColor(kBlack);
-    h1_time[pl]->Draw();
-    h1_time_in[pl]->SetLineColor(kBlue);
-    h1_time_in[pl]->SetFillColor(kBlue-7);
-    h1_time_in[pl]->Draw("same");
+  for (int i_det = 0; i_det < N_DET; i_det++) {
+    pad1->cd(i_det+1);
+    //UtilHist::AutoSetRange(h1_time[i_det]);
+    //h1_time[i_det]->GetXaxis()->SetRangeUser(400, 1050);
+    h1_time[i_det]->SetLineColor(kBlack);
+    h1_time[i_det]->Draw();
+    h1_time_in[i_det]->SetLineColor(kBlue);
+    h1_time_in[i_det]->SetFillColor(kBlue-7);
+    h1_time_in[i_det]->Draw("same");
   }
 
   return 0;
+}
+
+void OnlMonHodo::SetDet(const char* det0, const char* det1)
+{
+  list_det_name[0] = det0;
+  list_det_name[1] = det1;
+  GeomSvc* geom = GeomSvc::instance();
+  for (int ii = 0; ii < N_DET; ii++) {
+    list_det_id[ii] = geom->getDetectorID(list_det_name[ii]);
+  }
 }

--- a/online/onlmonserver/OnlMonHodo.cc
+++ b/online/onlmonserver/OnlMonHodo.cc
@@ -30,6 +30,10 @@ OnlMonHodo::OnlMonHodo(const HodoType_t type) : m_type(type)
   case H2Y:  m_pl0 = 35;  Name("OnlMonHodoH2Y" );  Title("Hodo: H2Y" );  break;
   case H4Y1: m_pl0 = 41;  Name("OnlMonHodoH4Y1");  Title("Hodo: H4Y1");  break;
   case H4Y2: m_pl0 = 43;  Name("OnlMonHodoH4Y2");  Title("Hodo: H4Y2");  break;
+  case DP1T: m_pl0 = 55;  Name("OnlMonHodoDP1T");  Title("Hodo: DP1T");  break;
+  case DP1B: m_pl0 = 57;  Name("OnlMonHodoDP1B");  Title("Hodo: DP1B");  break;
+  case DP2T: m_pl0 = 59;  Name("OnlMonHodoDP2T");  Title("Hodo: DP2T");  break;
+  case DP2B: m_pl0 = 61;  Name("OnlMonHodoDP2B");  Title("Hodo: DP2B");  break;
   }
 }
 

--- a/online/onlmonserver/OnlMonHodo.h
+++ b/online/onlmonserver/OnlMonHodo.h
@@ -5,16 +5,18 @@
 class OnlMonHodo: public OnlMonClient {
  public:
   typedef enum { H1X, H2X, H3X, H4X, H1Y, H2Y, H4Y1, H4Y2, DP1T, DP1B, DP2T, DP2B } HodoType_t;
+  static const int N_DET = 2;
 
  private:
   HodoType_t m_type;
-  int m_pl0;
-  int m_n_pl;
-  TH1* h1_ele    [99];
-  TH1* h1_ele_in [99];
-  TH1* h1_time   [99];
-  TH1* h1_time_in[99];
-  TH2* h2_time_ele[99];
+  std::string list_det_name[N_DET];
+  int         list_det_id  [N_DET];
+
+  TH1* h1_ele     [N_DET];
+  TH1* h1_ele_in  [N_DET];
+  TH1* h1_time    [N_DET];
+  TH1* h1_time_in [N_DET];
+  TH2* h2_time_ele[N_DET];
 
  public:
   OnlMonHodo(const HodoType_t type);
@@ -27,6 +29,9 @@ class OnlMonHodo: public OnlMonClient {
   int EndOnlMon(PHCompositeNode *topNode);
   int FindAllMonHist();
   int DrawMonitor();
+
+ private:
+  void SetDet(const char* det0, const char* det1);
 };
 
 #endif /* _ONL_MON_HODO__H_ */

--- a/online/onlmonserver/OnlMonHodo.h
+++ b/online/onlmonserver/OnlMonHodo.h
@@ -4,7 +4,7 @@
 
 class OnlMonHodo: public OnlMonClient {
  public:
-  typedef enum { H1X, H2X, H3X, H4X, H1Y, H2Y, H4Y1, H4Y2 } HodoType_t;
+  typedef enum { H1X, H2X, H3X, H4X, H1Y, H2Y, H4Y1, H4Y2, DP1T, DP1B, DP2T, DP2B } HodoType_t;
 
  private:
   HodoType_t m_type;

--- a/online/onlmonserver/OnlMonV1495.h
+++ b/online/onlmonserver/OnlMonV1495.h
@@ -5,16 +5,19 @@
 class OnlMonV1495: public OnlMonClient {
  public:
   typedef enum { H1X, H2X, H3X, H4X, H1Y, H2Y, H4Y1, H4Y2 } HodoType_t;
+  static const int N_DET = 2;
 
  private:
   HodoType_t m_type;
   int m_lvl;
-  int m_pl0;
-  int m_n_pl;
-  TH1* h1_ele    [99];
-  TH1* h1_ele_in [99];
-  TH1* h1_time   [99];
-  TH1* h1_time_in[99];
+  std::string list_det_name[N_DET];
+  int         list_det_id  [N_DET];
+
+  TH1* h1_ele     [N_DET];
+  TH1* h1_ele_in  [N_DET];
+  TH1* h1_time    [N_DET];
+  TH1* h1_time_in [N_DET];
+  TH2* h2_time_ele[N_DET];
 
  public:
   OnlMonV1495(const HodoType_t type, const int lvl);
@@ -27,6 +30,9 @@ class OnlMonV1495: public OnlMonClient {
   int EndOnlMon(PHCompositeNode *topNode);
   int FindAllMonHist();
   int DrawMonitor();
+
+ private:
+  void SetDet(const char* det0, const char* det1);
 };
 
 #endif /* _ONL_MON_V1495__H_ */

--- a/script/setup-install.sh
+++ b/script/setup-install.sh
@@ -25,6 +25,8 @@ if [ -z "$1" ] ; then
     exit 1
 elif [ "X$1" = 'Xauto' ] ; then
     DIR_INST=$(readlink -f $DIR_SCRIPT/../../core-inst)
+elif [ "X$1" = 'Xonline' ] ; then
+    DIR_INST=/data2/e1039/core-online-new
 else
     DIR_INST=$(readlink -m "$1")
 fi


### PR DESCRIPTION
The DP hodoscope was added to the channel mapping, since its readout was included in Main DAQ and its mapping was provided by Kun.  `Fun4MainDaq.C` now calls `GeomSvc::UseDbSvc(true)`
in order to fetch the latest geometry info (particularly the number of elements per DP-hodo plane).

It was also included in the online monitor.  It is taken care of by `OnlMonHodo` as one of the hodoscope groups.  I took this chance to change the way of selecting detector IDs to be monitored, where detector IDs were hard-coded in the past.

This new version is already running on seaquestdaq01.  Thus I would ask Abi to just review the changes and make a merge.  I think he need not compile nor run this version.

