### PR TITLE
Interface of error checker in MainDAQ decoder / Creation of spill-by-spill DST files

### DIFF
--- a/framework/fun4all/Fun4AllDstOutputManager.cc
+++ b/framework/fun4all/Fun4AllDstOutputManager.cc
@@ -16,15 +16,17 @@ Fun4AllDstOutputManager::Fun4AllDstOutputManager(const string &myname, const str
  Fun4AllOutputManager( myname )
 {
   outfilename = fname;
-  dstOut = new PHNodeIOManager(fname.c_str(), PHWrite);
-  if (!dstOut->isFunctional())
-    {
+  if (fname == "") {
+    dstOut = 0;
+  } else {
+    dstOut = new PHNodeIOManager(fname.c_str(), PHWrite);
+    if (!dstOut->isFunctional()) {
       delete dstOut;
-      cout << PHWHERE << " Could not open " << fname 
-	   << " exiting now" << endl;
+      cout << PHWHERE << "Could not open " << fname << ".  Exit." << endl;
       exit(1);
     }
-  dstOut->SetCompressionLevel(3);
+    dstOut->SetCompressionLevel(3);
+  }
   return ;
 }
 

--- a/framework/fun4all/Fun4AllDstOutputManager.h
+++ b/framework/fun4all/Fun4AllDstOutputManager.h
@@ -23,8 +23,8 @@ class Fun4AllDstOutputManager: public Fun4AllOutputManager
 
   void Print(const std::string &what = "ALL") const;
 
-  int Write(PHCompositeNode *startNode);
-  int WriteNode(PHCompositeNode *thisNode);
+  virtual int Write(PHCompositeNode *startNode);
+  virtual int WriteNode(PHCompositeNode *thisNode);
 
   void EnableRealTimeSave();
 

--- a/online/decoder_maindaq/DecoError.cc
+++ b/online/decoder_maindaq/DecoError.cc
@@ -41,6 +41,7 @@ void DecoError::CountFlush()
 void DecoError::AddTdcError(const int event, const int roc, const TdcError_t type)
 {
   m_n_err_tdc[roc][type].push_back(event);
+  cout << "AddTdcError: " << event << " " << roc << " " << type << "." << endl;
   m_flush_has_error = true;
 }
 

--- a/online/decoder_maindaq/DecoError.cc
+++ b/online/decoder_maindaq/DecoError.cc
@@ -51,6 +51,25 @@ void DecoError::AggregateData()
   UpdateDbInfo(&db);
   UpdateDbTdc (&db);
 }
+
+void DecoError::PrintData(std::ostream& os)
+{
+  os << "DecoError::PrintData(): " << m_run_id << " " << m_spill_id << "\n";
+  for (int roc = 0; roc < N_ROC; roc++) {
+    for (int err = 0; err < N_TDC_ERROR; err++) {
+      int n_evt = m_n_err_tdc[roc][err].size();
+      if (n_evt == 0) continue;
+      os << "  ROC " << setw(2) << roc << ", type " << setw(2) << err << ": n=" << n_evt;
+      if (n_evt > 100) n_evt = 100; // Print 100 event IDs at max.
+      for (int i_evt = 0; i_evt < n_evt; i_evt++) {
+        if (i_evt % 10 == 0) os << "\n    ";
+        os << " " << m_n_err_tdc[roc][err].at(i_evt);
+      }
+      os << "\n";
+    }
+  }
+  os << endl;
+}
       
 void DecoError::UpdateDbInfo(DbSvc* db)
 {

--- a/online/decoder_maindaq/DecoError.cc
+++ b/online/decoder_maindaq/DecoError.cc
@@ -1,0 +1,118 @@
+#include <iostream>
+#include <iomanip>
+#include <sstream>
+#include <TSQLServer.h>
+#include <db_svc/DbSvc.h>
+#include <UtilAna/UtilOnline.h>
+#include "DecoError.h"
+using namespace std;
+
+DecoError::DecoError()
+  : m_run_id(0)
+  , m_spill_id(0)
+  , m_flush_has_error(false)
+{
+  InitData();
+}
+
+void DecoError::SetID(const int run_id, const int spill_id)
+{
+  m_run_id   = run_id;
+  m_spill_id = spill_id;
+}
+
+void DecoError::InitData()
+{
+  m_n_evt_all = 0;
+  m_n_evt_ng  = 0;
+  for (int roc = 0; roc < N_ROC; roc++) {
+    for (int err = 0; err < N_TDC_ERROR; err++) {
+      m_n_err_tdc[roc][err].clear();
+    }
+  }
+}
+
+void DecoError::CountFlush()
+{
+  m_n_evt_all++;
+  if (m_flush_has_error) m_n_evt_ng++;
+}
+
+void DecoError::AddTdcError(const int event, const int roc, const TdcError_t type)
+{
+  m_n_err_tdc[roc][type].push_back(event);
+  m_flush_has_error = true;
+}
+
+void DecoError::AggregateData()
+{
+  DbSvc db(DbSvc::DB1);
+  db.UseSchema(UtilOnline::GetSchemaMainDaq(), true);
+  UpdateDbInfo(&db);
+  UpdateDbTdc (&db);
+}
+      
+void DecoError::UpdateDbInfo(DbSvc* db)
+{
+  const char* table_name = "deco_error_info";
+  //db->DropTable(table_name);
+  if (! db->HasTable(table_name)) {
+    DbSvc::VarList list;
+    list.Add("run_id"   , "INT", true);
+    list.Add("spill_id" , "INT");
+    list.Add("utime"    , "INT");
+    list.Add("n_evt_all", "INT");
+    list.Add("n_evt_ng" , "INT");
+    db->CreateTable(table_name, list);
+  }
+
+  ostringstream oss;
+  oss << "delete from " << table_name << " where run_id = " << m_run_id;
+  if (! db->Con()->Exec(oss.str().c_str())) {
+    cerr << "!!ERROR!!  DecoError::UpdateDbInfo(): delete." << endl;
+    return;
+  }
+  oss.str("");
+  oss << "insert into " << table_name << " values (" << m_run_id << ", " << m_spill_id << ", " << time(0) << ", " << m_n_evt_all << ", " << m_n_evt_ng << ")";
+  if (! db->Con()->Exec(oss.str().c_str())) {
+    cerr << "!!ERROR!!  DecoError::UpdateDbInfo(): insert." << endl;
+  }
+}
+
+void DecoError::UpdateDbTdc(DbSvc* db)
+{
+  const char* table_name = "deco_error_tdc";
+  db->DropTable(table_name);
+  if (! db->HasTable(table_name)) { // always true for now
+    DbSvc::VarList list;
+    list.Add("roc_id"      , "INT", true);
+    list.Add("error_id"    , "INT", true);
+    list.Add("error_count" , "INT");
+    list.Add("event_id_min", "INT");
+    list.Add("event_id_max", "INT");
+    db->CreateTable(table_name, list);
+  }
+
+  int n_err = 0;
+  ostringstream oss;
+  oss << "insert into " << table_name << " values";
+  for (int roc = 0; roc < N_ROC; roc++) {
+    for (int err = 0; err < N_TDC_ERROR; err++) {
+      if (m_n_err_tdc[roc][err].size() == 0) continue;
+      oss << " (" << roc
+          << ", " << err
+          << ", " << m_n_err_tdc[roc][err].size()
+          << ", " << m_n_err_tdc[roc][err].at(0)
+          << ", " << m_n_err_tdc[roc][err].back()
+          << "),";
+      n_err++;
+    }
+  }
+  if (n_err > 0) {
+    oss.seekp(-1, oss.cur);
+    oss << " "; // Erase the last ',' char.
+    if (! db->Con()->Exec(oss.str().c_str())) {
+      cerr << "!!ERROR!!  DecoError::UpdateDbTdc()." << endl;
+    }
+  }
+}

--- a/online/decoder_maindaq/DecoError.h
+++ b/online/decoder_maindaq/DecoError.h
@@ -47,6 +47,7 @@ class DecoError {
   void CountFlush();
   void AddTdcError(const int event, const int roc, const TdcError_t type);
   void AggregateData();
+  void PrintData(std::ostream& os=std::cout);
 
  private:
   void UpdateDbInfo(DbSvc* db);

--- a/online/decoder_maindaq/DecoError.h
+++ b/online/decoder_maindaq/DecoError.h
@@ -1,0 +1,56 @@
+#ifndef __DECO_ERROR_H__
+#define __DECO_ERROR_H__
+#include <vector>
+//#include "assert.h"
+class DbSvc;
+
+/** This class manages errors found in the decoder.
+ * At present the decoder error is aggregated once per spill.
+ * Therefore
+ *  - InitData() is called at EOS.
+ *  - Errors are recorded during flush events are decoded.
+ *  - UploadToDB() is called at BOS.
+ */
+class DecoError {
+ public:
+  typedef enum {
+    WORD_ONLY89     = 0,
+    WORD_OVERFLOW   = 1,
+    MULTIPLE_HEADER = 2,
+    EVT_ID_ONLY     = 3,
+    START_WO_STOP   = 4,
+    START_NOT_RISE  = 5,
+    DIRTY_FINISH    = 6,
+    N_TDC_ERROR     = 7
+  } TdcError_t;
+
+ private:
+  static const int N_ROC = 33;
+
+  int m_run_id;
+  int m_spill_id;
+  bool m_flush_has_error;
+
+  int m_n_evt_all;
+  int m_n_evt_ng;
+  std::vector<int> m_n_err_tdc[N_ROC][N_TDC_ERROR];
+
+ public:
+  DecoError();
+  ~DecoError() {;}
+
+  void SetID(const int run_id, const int spill_id);
+  void SetFlushError(const bool val) { m_flush_has_error = val; }
+  bool GetFlushError()        { return m_flush_has_error; }
+
+  void InitData();
+  void CountFlush();
+  void AddTdcError(const int event, const int roc, const TdcError_t type);
+  void AggregateData();
+
+ private:
+  void UpdateDbInfo(DbSvc* db);
+  void UpdateDbTdc (DbSvc* db);
+};
+
+#endif // __DECO_ERROR_H__

--- a/online/decoder_maindaq/DecoParam.cc
+++ b/online/decoder_maindaq/DecoParam.cc
@@ -5,7 +5,7 @@
 using namespace std;
 
 DecoParam::DecoParam() :
-  fn_in(""), dir_param(""), sampling(0), verbose(0), time_wait(0), 
+  fn_in(""), dir_param(""), is_online(false), sampling(0), verbose(0), time_wait(0), 
   runID(0), spillID(0), spillID_cntr(0), spillID_slow(0),
   targPos(0), targPos_slow(0), codaID(0), rocID(0), eventIDstd(0), hitID(0), 
   has_1st_bos(false), at_bos(false), turn_id_max(0)

--- a/online/decoder_maindaq/DecoParam.h
+++ b/online/decoder_maindaq/DecoParam.h
@@ -17,6 +17,7 @@ struct DecoParam {
   ///
   std::string fn_in;
   std::string dir_param;
+  bool is_online;
   int sampling;
   int verbose;
   int time_wait; //< waiting time in second to pretend the online data flow.
@@ -45,17 +46,6 @@ struct DecoParam {
   bool has_1st_bos; //< Set 'true' at the 1st BOS event.
   bool at_bos; //< Set 'true' at BOS, which triggers parsing the data in one spill.
 
-  typedef enum {
-    WORD_ONLY89     = 0x01,
-    WORD_OVERFLOW   = 0x02,
-    MULTIPLE_HEADER = 0x04,
-    NO_EVT_ID       = 0x08,
-    START_WO_STOP   = 0x10,
-    START_NOT_RISE  = 0x20,
-    DIRTY_FINISH    = 0x40
-  } CodaPhysEvtStatus_t;
-  int coda_phys_evt_status; //< Bits to hold the status of an Coda event.
-  
   /// Max turnOnset in a spill.  Used to drop NIM3 events that came after the beam stops.  See elog 15010
   unsigned int turn_id_max;
 

--- a/online/decoder_maindaq/Fun4AllEVIOInputManager.cc
+++ b/online/decoder_maindaq/Fun4AllEVIOInputManager.cc
@@ -546,6 +546,7 @@ Fun4AllEVIOInputManager::SyncIt(const SyncObject *mastersync)
 
 void Fun4AllEVIOInputManager::SetOnline(const bool is_online)
 {
+  parser->dec_par.is_online = is_online;
   parser->GetCoda()->SetOnline(is_online);
 }
 

--- a/online/decoder_maindaq/Fun4AllSpillDstOutputManager.cc
+++ b/online/decoder_maindaq/Fun4AllSpillDstOutputManager.cc
@@ -1,0 +1,63 @@
+#include <sstream>
+#include <TSystem.h>
+#include <interface_main/SQEvent.h>
+#include <phool/getClass.h>
+#include <fun4all/Fun4AllServer.h>
+#include "Fun4AllSpillDstOutputManager.h"
+using namespace std;
+
+Fun4AllSpillDstOutputManager::Fun4AllSpillDstOutputManager(const string &dir_base, const string &myname)
+  : Fun4AllDstOutputManager(myname, "")
+  , m_dir_base(dir_base)
+  , m_sp_step(10)
+  , m_run_id(0)
+  , m_sp_id(0)
+{
+  ;
+}
+
+Fun4AllSpillDstOutputManager::~Fun4AllSpillDstOutputManager()
+{
+  ;
+}
+
+int Fun4AllSpillDstOutputManager::Write(PHCompositeNode *startNode)
+{
+  SQEvent* evt = findNode::getClass<SQEvent>(startNode, "SQEvent");
+  if (! evt) {
+    cout << PHWHERE << "SQEvent not found.  Abort." << endl;
+    exit(1);
+  }
+  int run_id = evt->get_run_id();
+  int sp_id  = (evt->get_spill_id() / m_sp_step) * m_sp_step;
+  if (m_run_id != run_id || m_sp_id != sp_id) {
+    m_run_id = run_id;
+    m_sp_id  = sp_id;
+
+    if (dstOut) { /// Write out and close the current DST file.
+      PHNodeIterator nodeiter(Fun4AllServer::instance()->topNode());
+      PHCompositeNode* run = dynamic_cast<PHCompositeNode*>(nodeiter.findFirst("PHCompositeNode", "RUN"));
+      if (! run) {
+        cout << PHWHERE << "RUN not found.  Abort." << endl;
+        exit(1);
+      }
+      WriteNode(run); // dstOut is deleted at the beginning of this function.
+    }
+
+    /// Open a new DST file.
+    ostringstream oss;
+    oss << m_dir_base << "/run_" << setfill('0') << setw(6) << run_id;
+    gSystem->mkdir(oss.str().c_str(), true);
+    oss << "/run_" << setw(6) << run_id << "_spill_" << setw(9) << sp_id << "_spin.root";
+    outfilename = oss.str();
+    dstOut = new PHNodeIOManager(outfilename.c_str(), PHWrite);
+    if (!dstOut->isFunctional()) {
+      delete dstOut;
+      dstOut = 0;
+      cout << PHWHERE << "Could not open " << oss.str() << ".  Abort." << endl;
+      exit(1);
+    }
+    dstOut->SetCompressionLevel(3);
+  }
+  return Fun4AllDstOutputManager::Write(startNode);
+}

--- a/online/decoder_maindaq/Fun4AllSpillDstOutputManager.h
+++ b/online/decoder_maindaq/Fun4AllSpillDstOutputManager.h
@@ -1,0 +1,28 @@
+#ifndef __FUN4ALL_SPILL_DST_OUTPUT_MANAGER_H__
+#define __FUN4ALL_SPILL_DST_OUTPUT_MANAGER_H__
+#include <fun4all/Fun4AllDstOutputManager.h>
+
+/// A Fun4All output manger that creates one DST file per spill group.
+/**
+ * The number of spills per group (= spill step) is 10 by default.
+ * One can simply register it to Fun4AllServer as usual.
+ *
+ * Fun4AllSpillDstOutputManager* out_sp = new Fun4AllSpillDstOutputManager(UtilOnline::GetDstFileDir() + "/spill");
+ * //out_sp->SetSpillStep(50);
+ * se->registerOutputManager(out_sp);
+ */
+class Fun4AllSpillDstOutputManager: public Fun4AllDstOutputManager {
+  std::string m_dir_base;
+  int m_sp_step;
+  int m_run_id;
+  int m_sp_id;
+
+ public:
+  Fun4AllSpillDstOutputManager(const std::string &dir_base, const std::string &myname = "SPILLDSTOUT");
+  virtual ~Fun4AllSpillDstOutputManager();
+
+  void SetSpillStep(const int step) { m_sp_step = step; }
+  int Write(PHCompositeNode *startNode);
+};
+
+#endif /* __FUN4ALL_SPILL_DST_OUTPUT_MANAGER_H__ */

--- a/online/decoder_maindaq/Fun4AllSpillDstOutputManagerLinkDef.h
+++ b/online/decoder_maindaq/Fun4AllSpillDstOutputManagerLinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class Fun4AllSpillDstOutputManager-!;
+
+#endif /* __CINT__ */

--- a/online/decoder_maindaq/MainDaqParser.cc
+++ b/online/decoder_maindaq/MainDaqParser.cc
@@ -136,6 +136,10 @@ int MainDaqParser::End()
          << "  v1495 hits: total = " << run_data.n_t_hit << ", bad = " << run_data.n_t_hit_bad << "\n"
          << "  Real decoding time: " << (dec_par.timeEnd - dec_par.timeStart) << endl;
   }
+  if (dec_par.is_online) {
+    dec_err.PrintData();
+    dec_err.InitData();
+  }
   return 0;
 }
 
@@ -1316,7 +1320,7 @@ int MainDaqParser::PackOneSpillData()
 {
   if (dec_par.verbose > 2) cout << "PackOneSpillData(): n=" << list_ed->size() << endl;
 
-  if (true) { // (dec_par.is_online) {
+  if (dec_par.is_online) {
     dec_err.SetID(dec_par.runID, dec_par.spillID);
     dec_err.AggregateData();
   }

--- a/online/decoder_maindaq/MainDaqParser.cc
+++ b/online/decoder_maindaq/MainDaqParser.cc
@@ -1005,7 +1005,6 @@ int MainDaqParser::ProcessBoardJyTDC2 (int* words, int idx_begin, int idx_roc_en
     // "0x8*******" or "0x9*******".  This "if" condition is strict enough to 
     // catch this error.  Shifter has to reset VME crate to clear this error.
     dec_err.AddTdcError(dec_par.codaID, roc, DecoError::WORD_ONLY89);
-    cerr << "WARNING: Strange 'ID&N' word (0x" << hex << words[idx_begin] << dec << ") @ " << roc << endl;
     return idx_begin + 1;
   }
 
@@ -1018,7 +1017,6 @@ int MainDaqParser::ProcessBoardJyTDC2 (int* words, int idx_begin, int idx_roc_en
   }
   if (idx_events_end > idx_roc_end) {
     dec_err.AddTdcError(dec_par.codaID, roc, DecoError::WORD_OVERFLOW);
-    cerr << "WARNING: Word overflow.  Skip ROC (" << roc << ")" << endl;
     return -1;
   }
 
@@ -1031,7 +1029,6 @@ int MainDaqParser::ProcessBoardJyTDC2 (int* words, int idx_begin, int idx_roc_en
     if (get_hex_bits(words[idx], 7, 1) == 8) { // header = stop hit
       if (header_found) { // Not seen in run 23930, but seen in run 23751.
         dec_err.AddTdcError(dec_par.codaID, roc, DecoError::MULTIPLE_HEADER);
-	cerr << "WARNING:  Header after header." << endl;
       }
       int word = words[idx];
       if (get_bin_bit(word, 16) == 0) Abort("Stop signal is not rising.  Not supported.");
@@ -1042,8 +1039,7 @@ int MainDaqParser::ProcessBoardJyTDC2 (int* words, int idx_begin, int idx_roc_en
     } else if (get_hex_bits(words[idx], 7, 1) == 0 &&
 	       get_hex_bits(words[idx], 6, 7) != 0   ) { // event ID
       if (! header_found) { // Not seen in run 23930, but seen in run 23751.
-        dec_err.AddTdcError(dec_par.codaID, roc, DecoError::EVT_ID_ONLY);
-	cerr << "WARNING:  eventID without stop word." << endl; // Possible to miss a stop signal???
+        dec_err.AddTdcError(dec_par.codaID, roc, DecoError::EVT_ID_ONLY); // eventID without stop word
 	run_data.n_hit_bad++;
 	continue;
       }
@@ -1071,15 +1067,13 @@ int MainDaqParser::ProcessBoardJyTDC2 (int* words, int idx_begin, int idx_roc_en
       list_time.clear();
     } else { // start hit
       if (! header_found) { // Not seen in run 23930, but seen in run 23751.
-        dec_err.AddTdcError(dec_par.codaID, roc, DecoError::START_WO_STOP);
-	cerr << "WARNING:  Start without stop word." << endl; // Possible to miss a stop signal???
+        dec_err.AddTdcError(dec_par.codaID, roc, DecoError::START_WO_STOP); // Start without stop word
 	run_data.n_hit_bad++;
 	continue;
       }
       int word = words[idx];
       if (get_bin_bit(word, 16) == 0) { // Not seen in run 23930, but seen in run 23751.
-        dec_err.AddTdcError(dec_par.codaID, roc, DecoError::START_NOT_RISE);
-	cerr << "WARNING:  Start signal is not rising." << endl;
+        dec_err.AddTdcError(dec_par.codaID, roc, DecoError::START_NOT_RISE); // Start signal is not rising
 	run_data.n_hit_bad++;
       }
       double fine  = 4.0 - get_hex_bit (word, 0) * 4.0 / 9.0;
@@ -1095,8 +1089,7 @@ int MainDaqParser::ProcessBoardJyTDC2 (int* words, int idx_begin, int idx_roc_en
     }
   }
   if (header_found) { // Not seen in run 23930, but seen in run 23751.
-    dec_err.AddTdcError(dec_par.codaID, roc, DecoError::DIRTY_FINISH);
-    cerr << "WARNING:  Not finished cleanly." << endl;
+    dec_err.AddTdcError(dec_par.codaID, roc, DecoError::DIRTY_FINISH); // Not finished cleanly
   }
   
   return idx_events_end;

--- a/online/decoder_maindaq/MainDaqParser.h
+++ b/online/decoder_maindaq/MainDaqParser.h
@@ -2,6 +2,7 @@
 #define _MAIN_DAQ_PARSER_H_
 #include "DecoData.h"
 #include "DecoParam.h"
+#include "DecoError.h"
 class CodaInputManager;
 
 class MainDaqParser {
@@ -67,6 +68,7 @@ public:
   int End();
 
   DecoParam dec_par;
+  DecoError dec_err;
 };
 
 #endif // _MAIN_DAQ_PARSER_H_


### PR DESCRIPTION
1.
Several errors found by the MainDAQ decoder are so critical that shift crew should notice them.
Here I introduced a new interface for it, where "IntegrityWatch.py" took care of it in E906.

A new class, "DecoError", holds errors found by MainDaqParser and uploads them to DB (once per spill).  The uploaded info is parsed and drawn the DAQ Status Monitor, which is out of e1039-core.

2.
The size of one DST file could be too large for several purposes such as the track reconstruction on grid.  I created a new Fun4All output manager, "Fun4AllSpillDstOutputManager", which creates one DST file per 10 spills.  The number, 10, is adjustable.
```
ls /data2/e1039/dst-devel/spill/run_001685
run_001685_spill_000000000_spin.root
run_001685_spill_000000010_spin.root
run_001685_spill_000000020_spin.root
run_001685_spill_000000030_spin.root
```