### PR TITLE
Function to disable spill-by-spill histograms in OnlMonClient.

### DIFF
--- a/online/macros/Fun4MainDaq.C
+++ b/online/macros/Fun4MainDaq.C
@@ -38,6 +38,9 @@ int Fun4MainDaq(const int run=46, const int nevent=0, const bool is_online=false
 
   OnlMonServer* se = OnlMonServer::instance();
   //se->Verbosity(1);
+  //se->SetOnline(is_online);
+  OnlMonClient::SetMaxNumSpills(100);
+
 
   Fun4AllEVIOInputManager *in = new Fun4AllEVIOInputManager("MainDaq");
   in->Verbosity(2);
@@ -80,7 +83,6 @@ int Fun4MainDaq(const int run=46, const int nevent=0, const bool is_online=false
     se->registerSubsystem(new OnlMonH4   (OnlMonH4::H4Y2L));
     se->registerSubsystem(new OnlMonH4   (OnlMonH4::H4Y2R));
     se->registerSubsystem(new OnlMonCham (OnlMonCham::D0));
-    se->registerSubsystem(new OnlMonCham (OnlMonCham::D1));
     se->registerSubsystem(new OnlMonCham (OnlMonCham::D2));
     se->registerSubsystem(new OnlMonCham (OnlMonCham::D3p));
     se->registerSubsystem(new OnlMonCham (OnlMonCham::D3m));

--- a/online/macros/Fun4MainDaq.C
+++ b/online/macros/Fun4MainDaq.C
@@ -39,7 +39,6 @@ int Fun4MainDaq(const int run=46, const int nevent=0, const bool is_online=false
   OnlMonServer* se = OnlMonServer::instance();
   //se->Verbosity(1);
   se->SetOnline(is_online);
-  OnlMonComm::instance()->SetMaxNumSelSpills(20);
 
   Fun4AllEVIOInputManager *in = new Fun4AllEVIOInputManager("MainDaq");
   in->Verbosity(2);

--- a/online/macros/Fun4MainDaq.C
+++ b/online/macros/Fun4MainDaq.C
@@ -38,9 +38,8 @@ int Fun4MainDaq(const int run=46, const int nevent=0, const bool is_online=false
 
   OnlMonServer* se = OnlMonServer::instance();
   //se->Verbosity(1);
-  //se->SetOnline(is_online);
-  OnlMonClient::SetMaxNumSpills(100);
-
+  se->SetOnline(is_online);
+  OnlMonComm::instance()->SetMaxNumSelSpills(20);
 
   Fun4AllEVIOInputManager *in = new Fun4AllEVIOInputManager("MainDaq");
   in->Verbosity(2);

--- a/online/macros/OnlMon4MainDaq.C
+++ b/online/macros/OnlMon4MainDaq.C
@@ -42,7 +42,6 @@ int OnlMon4MainDaq()
   list_omc.push_back(new OnlMonH4   (OnlMonH4   ::H4Y2L));
   list_omc.push_back(new OnlMonH4   (OnlMonH4   ::H4Y2R));
   list_omc.push_back(new OnlMonCham (OnlMonCham ::D0 ));
-  list_omc.push_back(new OnlMonCham (OnlMonCham ::D1 ));
   list_omc.push_back(new OnlMonCham (OnlMonCham ::D2 ));
   list_omc.push_back(new OnlMonCham (OnlMonCham ::D3p));
   list_omc.push_back(new OnlMonCham (OnlMonCham ::D3m));

--- a/online/macros/TestOnlMon4MainDaq.C
+++ b/online/macros/TestOnlMon4MainDaq.C
@@ -38,7 +38,7 @@ int OnlMon4MainDaq()
   return 0;
 }
 
-int Fun4MainDaq(const int run=1330, const int nevent=0)
+int Fun4MainDaq(const int run=1818, const int nevent=0)
 {
   gSystem->Umask(0002);
   gSystem->Load("libinterface_main.so");
@@ -52,6 +52,9 @@ int Fun4MainDaq(const int run=1330, const int nevent=0)
 
   OnlMonServer* se = OnlMonServer::instance();
   //se->Verbosity(1);
+  se->SetOnline(true);
+  OnlMonComm::instance()->SetMaxNumSelSpills(20);
+
   se->StartServer();
   se->registerSubsystem(new OnlMonMainDaq());
   se->registerSubsystem(new OnlMonTrigNim());

--- a/online/onlmonserver/OnlMonClient.cc
+++ b/online/onlmonserver/OnlMonClient.cc
@@ -98,9 +98,11 @@ int OnlMonClient::process_event(PHCompositeNode* topNode)
   if (sp_id != m_spill_id_pre) { // New spill
     OnlMonComm* comm = OnlMonComm::instance();
     if (m_spill_id_pre >= 0 && m_make_sp_hist) { // Not first spill
-      MakeSpillHist(m_spill_id_pre, sp_id);
-      if (comm->GetNumSpills() > comm->GetMaxNumSelSpills()) {
+      if (comm->GetNumSpills() <= comm->GetMaxNumSelSpills()) {
+        MakeSpillHist(m_spill_id_pre, sp_id);
+      } else {
         cout << Name() << ": Disable spill-by-spill hists." << endl;
+        MakeSpillHist(m_spill_id_pre);
         DisableSpillHist();
       }
     }

--- a/online/onlmonserver/OnlMonClient.h
+++ b/online/onlmonserver/OnlMonClient.h
@@ -58,7 +58,6 @@ class OnlMonClient: public SubsysReco {
   Name2SpillHistMap_t m_map_hist_sp;
   int m_spill_id_pre;
   bool m_make_sp_hist; //< True if spill-by-spill hists are active.
-  static unsigned int m_n_sp_max_hist; //< Max number of spills for which spill-by-spill hists are kept.
 
   /// List of OnlMonClient objects created.  Used to clear all canvases opened by all objects.
   typedef std::vector<OnlMonClient*> SelfList_t;
@@ -82,7 +81,6 @@ class OnlMonClient: public SubsysReco {
   void GetBasicCount(int* n_evt=0, int* n_sp=0);
   int StartMonitor();
   TH1* FindMonHist(const std::string name, const bool non_null=true);
-  static void SetMaxNumSpills(const unsigned int val) { m_n_sp_max_hist = val; }
 
   virtual int InitOnlMon(PHCompositeNode *topNode);
   virtual int InitRunOnlMon(PHCompositeNode *topNode);

--- a/online/onlmonserver/OnlMonClient.h
+++ b/online/onlmonserver/OnlMonClient.h
@@ -8,6 +8,30 @@ class TH1;
 class TH2;
 class TH3;
 
+/// Base class for the OnlMon subsystem module.
+/**
+ * All OnlMon histograms are held by "m_hm" via RegisterHist().
+ * They are used in
+ *  - Being filled in process_event() and
+ *  - Being saved into ROOT file in SendHist().
+ *
+ * Spill-by-spill histograms are by default created and held by "m_map_hist_sp".
+ * A set per spill is created when a new spill is found in process_event().
+ * The creation is disabled when
+ *  - Fun4MainDaq.C starts in the offline mode (via OnlMonServer::GetOnline()) or
+ *  - The number of spills processed exceeds "m_n_sp_max_hist".
+ * Spill-by-spill histograms are merged via MakeMergedHist() when
+ *  - The creation is disabled in process_event(),
+ *  - They are sent to the viewer in SendHist() or
+ *  - They are saved in End().
+ * 
+ * Todo:
+ *  - We had better not use "m_hm" but only a set of HistList_t to hold histograms,
+ *    so that we can reduce the number of operations to copy histograms.
+ *  - A count in spill-by-spill histogram is not correct
+ *    when it is an accumulated number over one run (i.e. MODE_UPDATE).
+ *    Should we take a difference from its number in previous spill?
+ */
 class OnlMonClient: public SubsysReco {
  protected:
   typedef enum { MODE_ADD, MODE_UPDATE } HistMode_t;
@@ -27,13 +51,14 @@ class OnlMonClient: public SubsysReco {
   TH1* m_h1_basic_cnt;
 
   typedef std::vector<TH1*> HistList_t;
-  typedef std::vector<TObject*> ObjList_t;
   HistList_t m_list_h1;
 
   typedef std::map<int, TH1*> SpillHistMap_t; // [spill] -> TH1*
   typedef std::map<std::string, SpillHistMap_t> Name2SpillHistMap_t; // [hist name] 
   Name2SpillHistMap_t m_map_hist_sp;
   int m_spill_id_pre;
+  bool m_make_sp_hist; //< True if spill-by-spill hists are active.
+  static unsigned int m_n_sp_max_hist; //< Max number of spills for which spill-by-spill hists are kept.
 
   /// List of OnlMonClient objects created.  Used to clear all canvases opened by all objects.
   typedef std::vector<OnlMonClient*> SelfList_t;
@@ -57,6 +82,7 @@ class OnlMonClient: public SubsysReco {
   void GetBasicCount(int* n_evt=0, int* n_sp=0);
   int StartMonitor();
   TH1* FindMonHist(const std::string name, const bool non_null=true);
+  static void SetMaxNumSpills(const unsigned int val) { m_n_sp_max_hist = val; }
 
   virtual int InitOnlMon(PHCompositeNode *topNode);
   virtual int InitRunOnlMon(PHCompositeNode *topNode);
@@ -78,10 +104,12 @@ class OnlMonClient: public SubsysReco {
   OnlMonCanvas* GetCanvas(const int num=0);
 
  private:
+  void ClearSpillHist();
   void MakeSpillHist();
+  void DisableSpillHist();
   void MakeMergedHist(HistList_t& list_h1, const int sp_min=0, const int sp_max=0);
   int  ReceiveHist();
-  void ClearHistList();
+  void ClearHistList(HistList_t& list_h1);
   void ClearCanvasList();
   int  DrawCanvas(const bool at_end=false);
 };

--- a/online/onlmonserver/OnlMonClient.h
+++ b/online/onlmonserver/OnlMonClient.h
@@ -103,7 +103,7 @@ class OnlMonClient: public SubsysReco {
 
  private:
   void ClearSpillHist();
-  void MakeSpillHist();
+  void MakeSpillHist(const int spill_id, const int spill_id_new=0);
   void DisableSpillHist();
   void MakeMergedHist(HistList_t& list_h1, const int sp_min=0, const int sp_max=0);
   int  ReceiveHist();

--- a/online/onlmonserver/OnlMonComm.cc
+++ b/online/onlmonserver/OnlMonComm.cc
@@ -26,6 +26,8 @@ OnlMonComm::OnlMonComm()
   , m_sp_hi(0)
   , m_sp_min(0)
   , m_sp_max(0)
+  , m_sp_sel(true)
+  , m_n_sp_sel_max(2000)
 {
   ;
 }
@@ -86,7 +88,10 @@ int OnlMonComm::ReceiveFullSpillRange()
     char str[200];
     mess->ReadString(str, 200);
     istringstream iss(str);
-    if (! (iss >> m_sp_min >> m_sp_max)) m_sp_min = m_sp_max = 0;
+    if (! (iss >> m_sp_min >> m_sp_max >> m_sp_sel)) {
+      m_sp_min = m_sp_max = 0;
+      m_sp_sel = false;
+    }
     delete mess;
   } else {
     ret = 1;

--- a/online/onlmonserver/OnlMonComm.h
+++ b/online/onlmonserver/OnlMonComm.h
@@ -35,6 +35,8 @@ class OnlMonComm {
   void SetSpillRange(const int sp_lo, const int sp_hi);
   void GetSpillRange(int& sp_lo, int& sp_hi);
 
+  unsigned int GetNumSpills() { return m_list_sp.size(); } //< Used in the server process
+  void ClearSpill() { m_list_sp.clear(); } //< Used in the server process
   void AddSpill(const int id); //< Used in the server process
   void FindFullSpillRange(int& id_min, int& id_max); //< Used in the server process
 

--- a/online/onlmonserver/OnlMonComm.h
+++ b/online/onlmonserver/OnlMonComm.h
@@ -16,6 +16,8 @@ class OnlMonComm {
   int m_sp_hi; //< High of selected range
   int m_sp_min; //< Min of full (not selected) range
   int m_sp_max; //< Max of full scale
+  bool m_sp_sel; //< True if spills are selectable
+  int m_n_sp_sel_max; //< Max number of spills for which spills are kept selectable.
 
   typedef std::vector<int> SpillList_t;
   SpillList_t m_list_sp;
@@ -27,15 +29,21 @@ class OnlMonComm {
   void SetSpillMode(const SpillMode_t mode) { m_sp_mode = mode; }
   SpillMode_t GetSpillMode() { return m_sp_mode; } 
 
+  void SetSpillSelectability(const bool val) { m_sp_sel = val; }
+  bool GetSpillSelectability()        { return m_sp_sel; }
+
   void SetSpillNum(const int num) { m_sp_num = num; }
   int  GetSpillNum()       { return m_sp_num; }
 
-  void SetSpillRangeLow (const int sp);
-  void SetSpillRangeHigh(const int sp);
-  void SetSpillRange(const int sp_lo, const int sp_hi);
-  void GetSpillRange(int& sp_lo, int& sp_hi);
+  void SetSpillRangeLow (const int sp); //< Set the low  edge of selected spills
+  void SetSpillRangeHigh(const int sp); //< Set the high edge of selected spills
+  void SetSpillRange(const int sp_lo, const int sp_hi); //< Set the range of selected spills
+  void GetSpillRange(int& sp_lo, int& sp_hi); //< Get the range of selected spills
 
-  unsigned int GetNumSpills() { return m_list_sp.size(); } //< Used in the server process
+  void SetMaxNumSelSpills(const int val) { m_n_sp_sel_max = val; }
+  int  GetMaxNumSelSpills()       { return m_n_sp_sel_max; }
+
+  int  GetNumSpills() { return (int)m_list_sp.size(); } //< Used in the server process
   void ClearSpill() { m_list_sp.clear(); } //< Used in the server process
   void AddSpill(const int id); //< Used in the server process
   void FindFullSpillRange(int& id_min, int& id_max); //< Used in the server process

--- a/online/onlmonserver/OnlMonServer.cc
+++ b/online/onlmonserver/OnlMonServer.cc
@@ -247,9 +247,10 @@ void OnlMonServer::HandleConnection(TSocket* sock)
       } else if (msg_str == "Spill") {
         if (Verbosity() > 2) cout << "  Spill." << endl;
         int id_min, id_max;
-        OnlMonComm::instance()->FindFullSpillRange(id_min, id_max);
+        OnlMonComm* comm = OnlMonComm::instance();
+        comm->FindFullSpillRange(id_min, id_max);
         ostringstream oss;
-        oss << id_min << " " << id_max;
+        oss << id_min << " " << id_max << " " << comm->GetSpillSelectability();
         sock->Send(oss.str().c_str());
       } else if (msg_str.substr(0, 7) == "SUBSYS:") {
         istringstream iss(msg_str.substr(7));

--- a/online/onlmonserver/OnlMonServer.cc
+++ b/online/onlmonserver/OnlMonServer.cc
@@ -43,6 +43,7 @@ OnlMonServer *OnlMonServer::instance()
 
 OnlMonServer::OnlMonServer(const std::string &name)
   : Fun4AllServer(name)
+  , m_is_online(true)
   , m_go_end(false)
   , m_svr_ready(false)
 {

--- a/online/onlmonserver/OnlMonServer.h
+++ b/online/onlmonserver/OnlMonServer.h
@@ -13,6 +13,7 @@ class OnlMonServer : public Fun4AllServer
   static int         m_mon_port_0; //< The 1st number of available ports
   static int         m_mon_n_port; //< The number of available ports
 
+  bool m_is_online;
   bool m_go_end;
   bool m_svr_ready;
 
@@ -37,6 +38,8 @@ class OnlMonServer : public Fun4AllServer
   bool CloseExistingServer(const int port);
   static void* FuncServer(void* arg);
   void HandleConnection(TSocket* sock);
+  void SetOnline(const bool val) { m_is_online = val; }
+  bool GetOnline()        { return m_is_online; }
   void SetGoEnd(const bool val) { m_go_end = val; }
   bool GetGoEnd()        { return m_go_end; }
   void SetServerReady(const bool val) { m_svr_ready = val; }

--- a/online/onlmonserver/OnlMonUI.cc
+++ b/online/onlmonserver/OnlMonUI.cc
@@ -59,11 +59,11 @@ void OnlMonUI::BuildInterface()
   { // Spill selector by none
     TGHorizontalFrame* fr_sp_all = new TGHorizontalFrame(m_fr_main);
 
-    m_rad_sp_all = new TGRadioButton(fr_sp_all, "All    ");
+    m_rad_sp_all = new TGRadioButton(fr_sp_all, "All ");
     m_rad_sp_all->Connect("Pressed()", "OnlMonUI", this, "HandleSpRadAll()");
-    fr_sp_all->AddFrame(m_rad_sp_all, new TGLayoutHints(kLHintsCenterY | kLHintsExpandX, 2,2,2,2));
+    fr_sp_all->AddFrame(m_rad_sp_all, new TGLayoutHints(kLHintsCenterY, 2,2,2,2));
 
-    m_lbl_sp = new TGLabel(fr_sp_all, "?-?");
+    m_lbl_sp = new TGLabel(fr_sp_all, "? ? ? ? ? ?-? ? ? ? ? ?");
     fr_sp_all->AddFrame(m_lbl_sp, new TGLayoutHints(kLHintsCenterY | kLHintsExpandX | kLHintsRight, 2,2,2,2));
 
     m_fr_main->AddFrame(fr_sp_all);
@@ -185,17 +185,28 @@ void* OnlMonUI::ExecSpillRangeCheck(void* arg)
 void OnlMonUI::UpdateFullSpillRange()
 {
   OnlMonComm* comm = OnlMonComm::instance();
-  int sp_min, sp_max;
   comm->ReceiveFullSpillRange();
-  comm->GetFullSpillRange(sp_min, sp_max);
-
-  m_num_sp0->SetLimits(TGNumberFormat::kNELLimitMinMax, sp_min, sp_max);
-  m_num_sp1->SetLimits(TGNumberFormat::kNELLimitMinMax, sp_min, sp_max);
-  m_slider->SetRange(sp_min, sp_max);
-
-  ostringstream oss;
-  oss << sp_min << "-" << sp_max;
-  m_lbl_sp->SetText(oss.str().c_str());
+  if (comm->GetSpillSelectability()) {
+    int sp_min, sp_max;
+    comm->GetFullSpillRange(sp_min, sp_max);
+    
+    m_num_sp0->SetLimits(TGNumberFormat::kNELLimitMinMax, sp_min, sp_max);
+    m_num_sp1->SetLimits(TGNumberFormat::kNELLimitMinMax, sp_min, sp_max);
+    m_slider->SetRange(sp_min, sp_max);
+    
+    ostringstream oss;
+    oss << sp_min << "-" << sp_max;
+    m_lbl_sp->SetText(oss.str().c_str());
+    m_rad_sp_last ->SetEnabled(true);
+    m_rad_sp_range->SetEnabled(true);
+  } else {
+    m_lbl_sp->SetText("(not selectable)");
+    m_rad_sp_all  ->SetOn(true );
+    m_rad_sp_last ->SetOn(false);
+    m_rad_sp_range->SetOn(false);
+    m_rad_sp_last ->SetEnabled(false);
+    m_rad_sp_range->SetEnabled(false);
+  }
 }
 
 void OnlMonUI::HandleSpRadAll()

--- a/online/onlmonserver/OnlMonUI.cc
+++ b/online/onlmonserver/OnlMonUI.cc
@@ -197,8 +197,6 @@ void OnlMonUI::UpdateFullSpillRange()
     ostringstream oss;
     oss << sp_min << "-" << sp_max;
     m_lbl_sp->SetText(oss.str().c_str());
-    m_rad_sp_last ->SetEnabled(true);
-    m_rad_sp_range->SetEnabled(true);
   } else {
     m_lbl_sp->SetText("(not selectable)");
     m_rad_sp_all  ->SetOn(true );

--- a/packages/UtilAna/UtilHodo.cc
+++ b/packages/UtilAna/UtilHodo.cc
@@ -10,7 +10,7 @@ bool IsHodoX(const std::string det_name)
 {
   return det_name.length() >= 3 && (det_name[2] == 'T' || det_name[2] == 'B');
 }
-
+  
 bool IsHodoY(const std::string det_name)
 {
   return ! IsHodoX(det_name);
@@ -40,7 +40,7 @@ int GetElementPos(const int det, const int ele, double& x, double& y, double& z)
   GeomSvc* geom = GeomSvc::instance();
   GetPlanePos(det, x, y, z);
   int n_ele = geom->getPlaneNElements(det);
-  double pos_ele = (ele - (n_ele+1)/0.5) * geom->getPlaneSpacing(det);
+  double pos_ele = (ele - 0.5*(n_ele+1)) * geom->getPlaneSpacing(det);
   if (IsHodoX(det)) x += pos_ele;
   else              y += pos_ele;
   return 0;
@@ -61,8 +61,8 @@ int Track1D::DoTracking()
     short ele = list_hit[ih]->get_element_id();
     double x_ele, y_ele, z_ele;
     GetElementPos(det, ele, x_ele, y_ele, z_ele);
-    if (type_xy == X) graph.SetPoint(ih, x_ele, z_ele);
-    else              graph.SetPoint(ih, y_ele, z_ele);
+    if (type_xy == X) graph.SetPoint(ih, z_ele, x_ele);
+    else              graph.SetPoint(ih, z_ele, y_ele);
   }
   graph.Fit("pol1", "Q0");
   TF1* f1 = graph.GetFunction("pol1");


### PR DESCRIPTION
OnlMonClient is now capable of disabling spill-by-spill histograms. This new function is useful when the number of spill per run is too many (i.e. in weekend run) and also the decoder is executed in the offline mode.

As additional changes; "build.sh" can now resume building packages when "-r" option is used.  Bugs in UtilHodo were fixed.