### PR TITLE
3 small changes to the build script which I found useful in the development

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -23,11 +23,11 @@ cmake_args=""
 while getopts ":s:r:i:c:" OPT ; do
     case $OPT in
         s ) mode='single'
-	    package=$OPTARG
+            package=$OPTARG
             echo "Single mode: package = $package"
             ;;
         r ) mode='resume'
-	    package=$OPTARG
+            package=$OPTARG
             echo "Resuming mode: package = $package"
             ;;
         i ) mode='increment'
@@ -38,7 +38,7 @@ while getopts ":s:r:i:c:" OPT ; do
             echo " - pass additional args $cmake_args to cmake"
             ;;
         * ) echo 'Unsupported option.  Abort.'
-	    exit
+            exit
             ;;
     esac
 done

--- a/build.sh
+++ b/build.sh
@@ -23,11 +23,11 @@ cmake_args=""
 while getopts ":s:r:i:c:" OPT ; do
     case $OPT in
         s ) mode='single'
-	          package=$OPTARG
+	    package=$OPTARG
             echo "Single mode: package = $package"
             ;;
         r ) mode='resume'
-	          package=$OPTARG
+	    package=$OPTARG
             echo "Resuming mode: package = $package"
             ;;
         i ) mode='increment'
@@ -38,7 +38,7 @@ while getopts ":s:r:i:c:" OPT ; do
             echo " - pass additional args $cmake_args to cmake"
             ;;
         * ) echo 'Unsupported option.  Abort.'
-	          exit
+	    exit
             ;;
     esac
 done


### PR DESCRIPTION
1. added a -i option to allow build incrementally. It is essentially the -s option without deleting the existing build directory;
2. added a -c option to pass additional options to the cmake
3. for all build modes, the script will attempt to delete the installation files from the previous build to guarantee the new headers/libraries will be installed

changes 1 and 2 do not change the existing behavior; change 3 does change the existing behavior of the script but should be transparent to user.