### PR TITLE
fixed a bug in GeomSvc to account for the unique elementID numbering …

### DIFF
--- a/packages/geom_svc/GeomSvc.cxx
+++ b/packages/geom_svc/GeomSvc.cxx
@@ -569,12 +569,12 @@ void GeomSvc::init()
     zmin_kmag = 1064.26 - 120.*2.54;
     zmax_kmag = 1064.26 + 120.*2.54;
 
-//#ifdef 1//_DEBUG_ON
+#ifdef _DEBUG_ON
     for(int i = 1; i <= nChamberPlanes+nHodoPlanes+nPropPlanes+nDarkPhotonPlanes; ++i)
     {
         cout << planes[i] << endl;
     }
-//#endif
+#endif
 }
 
 void GeomSvc::initPlaneDirect() {


### PR DESCRIPTION
…scheme for botton DP detectors

Unlike other detectors whose elementID always counts from left to right and bottom to up (looking against the beam direction), the DP detectors count the elements closest to beam plane as channel 1. This unique numbering scheme is easier to visualize but causes a problem to use existing GeomSvc code to calculate the position of the bottom detector elements using their elementIDs. 

This fix changed two functions to account for this opposite numbering scheme. 