### PR TITLE
Generation of in-acceptance events

### DIFF
--- a/simulation/g4dst/LinkDef.h
+++ b/simulation/g4dst/LinkDef.h
@@ -4,5 +4,6 @@
 #pragma link off all global;
 
 #pragma link C++ class TruthNodeMaker-!;
+#pragma link C++ class RequireParticlesInAcc-!;
 
 #endif

--- a/simulation/g4dst/RequireParticlesInAcc.cc
+++ b/simulation/g4dst/RequireParticlesInAcc.cc
@@ -1,0 +1,109 @@
+#include <iomanip>
+#include <algorithm>
+#include <g4main/PHG4HitContainer.h>
+#include <g4main/PHG4Hit.h>
+#include <fun4all/Fun4AllReturnCodes.h>
+#include <phool/PHNodeIterator.h>
+#include <phool/PHIODataNode.h>
+#include <phool/getClass.h>
+#include "RequireParticlesInAcc.h"
+using namespace std;
+
+RequireParticlesInAcc::RequireParticlesInAcc()
+  : m_npl_per_par(4)
+  , m_npar_per_evt(2)
+{
+  ;
+}
+
+RequireParticlesInAcc::~RequireParticlesInAcc()
+{
+  ;
+}
+
+int RequireParticlesInAcc::Init(PHCompositeNode* topNode)
+{
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int RequireParticlesInAcc::InitRun(PHCompositeNode* topNode)
+{
+  int ret = GetNodes(topNode);
+  if (ret != Fun4AllReturnCodes::EVENT_OK) return ret;
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int RequireParticlesInAcc::process_event(PHCompositeNode* topNode)
+{
+  /// Make lists of particle IDs
+  vector<int> vec_id_h1 = ExtractParticleID(g4hc_h1t, g4hc_h1b);
+  vector<int> vec_id_h2 = ExtractParticleID(g4hc_h2t, g4hc_h2b);
+  vector<int> vec_id_h3 = ExtractParticleID(g4hc_h3t, g4hc_h3b);
+  vector<int> vec_id_h4 = ExtractParticleID(g4hc_h4t, g4hc_h4b);
+
+  /// Count the number of hits per particle
+  map<int, int> map_nhit; // [particle ID] -> N of hit planes
+  CountHitPlanesPerParticle(vec_id_h1, map_nhit);
+  CountHitPlanesPerParticle(vec_id_h2, map_nhit);
+  CountHitPlanesPerParticle(vec_id_h3, map_nhit);
+  CountHitPlanesPerParticle(vec_id_h4, map_nhit);
+
+  /// Count the number of in-acceptance particles
+  int n_par_ok = 0;
+  for (map<int, int>::iterator it = map_nhit.begin(); it != map_nhit.end(); it++) {
+    if (it->second >= m_npl_per_par) n_par_ok++;
+  }
+
+  return n_par_ok >= m_npar_per_evt ? Fun4AllReturnCodes::EVENT_OK : Fun4AllReturnCodes::ABORTEVENT;
+}
+
+int RequireParticlesInAcc::End(PHCompositeNode* topNode)
+{
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int RequireParticlesInAcc::GetNodes(PHCompositeNode* topNode)
+{
+  g4hc_h1t  = findNode::getClass<PHG4HitContainer>(topNode, "G4HIT_H1T");
+  g4hc_h1b  = findNode::getClass<PHG4HitContainer>(topNode, "G4HIT_H1B");
+  g4hc_h2t  = findNode::getClass<PHG4HitContainer>(topNode, "G4HIT_H2T");
+  g4hc_h2b  = findNode::getClass<PHG4HitContainer>(topNode, "G4HIT_H2B");
+  g4hc_h3t  = findNode::getClass<PHG4HitContainer>(topNode, "G4HIT_H3T");
+  g4hc_h3b  = findNode::getClass<PHG4HitContainer>(topNode, "G4HIT_H3B");
+  g4hc_h4t  = findNode::getClass<PHG4HitContainer>(topNode, "G4HIT_H4T");
+  g4hc_h4b  = findNode::getClass<PHG4HitContainer>(topNode, "G4HIT_H4B");
+
+  if (!g4hc_h1t || !g4hc_h1b || !g4hc_h2t || !g4hc_h2b ||
+      !g4hc_h3t || !g4hc_h3b || !g4hc_h4t || !g4hc_h4b   ) {
+    return Fun4AllReturnCodes::ABORTEVENT;
+  }
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+void RequireParticlesInAcc::ExtractParticleID(const PHG4HitContainer* g4hc, vector<int>& vec_par_id)
+{
+  PHG4HitContainer::ConstRange range = g4hc->getHits();
+  for (PHG4HitContainer::ConstIterator it = range.first; it != range.second; it++) {
+    PHG4Hit* hit = it->second;
+    vec_par_id.push_back(hit->get_trkid());
+  }
+}
+
+vector<int> RequireParticlesInAcc::ExtractParticleID(const PHG4HitContainer* g4hc_t, const PHG4HitContainer* g4hc_b)
+{
+  vector<int> vec;
+  ExtractParticleID(g4hc_t, vec);
+  ExtractParticleID(g4hc_b, vec);
+  sort(vec.begin(), vec.end());
+  vec.erase(unique(vec.begin(), vec.end()), vec.end());
+  return vec;
+}
+
+void RequireParticlesInAcc::CountHitPlanesPerParticle(const vector<int> vec_id, map<int, int>& map_nhit)
+{
+  for (vector<int>::const_iterator it = vec_id.begin(); it != vec_id.end(); it++) {
+    int id = *it;
+    if (map_nhit.find(id) == map_nhit.end()) map_nhit[id] = 1;
+    else                                     map_nhit[id]++;
+  }
+}

--- a/simulation/g4dst/RequireParticlesInAcc.h
+++ b/simulation/g4dst/RequireParticlesInAcc.h
@@ -1,0 +1,39 @@
+#ifndef _REQUIRE_PARTICLES_IN_ACC__H_
+#define _REQUIRE_PARTICLES_IN_ACC__H_
+#include <map>
+#include <fun4all/SubsysReco.h>
+class PHG4HitContainer;
+
+/// An SubsysReco module to select in-acceptance events.
+class RequireParticlesInAcc: public SubsysReco {
+  int m_npl_per_par; //< Min number of hit planes per particle in order to regard particle good.
+  int m_npar_per_evt; //< Min number of particles per event in order to regard event good.
+
+  PHG4HitContainer *g4hc_h1t;
+  PHG4HitContainer *g4hc_h1b;
+  PHG4HitContainer *g4hc_h2t;
+  PHG4HitContainer *g4hc_h2b;
+  PHG4HitContainer *g4hc_h3t;
+  PHG4HitContainer *g4hc_h3b;
+  PHG4HitContainer *g4hc_h4t;
+  PHG4HitContainer *g4hc_h4b;
+
+ public:
+  RequireParticlesInAcc();
+  virtual ~RequireParticlesInAcc();
+  int Init(PHCompositeNode *topNode);
+  int InitRun(PHCompositeNode *topNode);
+  int process_event(PHCompositeNode *topNode);
+  int End(PHCompositeNode *topNode);
+
+  void SetNumHitPlanesPerParticle(const int val) { m_npl_per_par  = val; }
+  void SetNumParticlesPerEvent   (const int val) { m_npar_per_evt = val; }
+
+ private:
+  int GetNodes(PHCompositeNode *topNode);
+  void ExtractParticleID(const PHG4HitContainer* g4hc, std::vector<int>& vec_par_id);
+  std::vector<int> ExtractParticleID(const PHG4HitContainer* g4hc_t, const PHG4HitContainer* g4hc_b);
+  void CountHitPlanesPerParticle(const std::vector<int> vec_id, std::map<int, int>& map_nhit);
+};
+
+#endif /* _REQUIRE_PARTICLES_IN_ACC__H_ */


### PR DESCRIPTION
A new SubsysReco module, "RequireParticlesInAcc", is a selector that saves an event into DST only when two (or more) particles in the event go into the acceptance.  It can be activated easily via `se->registerSubsystem(new RequireParticlesInAcc())` in `Fun4Sim.C` etc.

It reduces the size of DST files largely.  Below are results of 10k J/psi event generations without and with "RequireParticlesInAcc":
 * Without:  288 MB, 10,000 events in DST, 77 minutes for process
 * WIth     :      4 MB,        72 events in DST, 72 minutes
So the size becomes ~1%, where the reduction should be weaker when D-Y (i.e. higher-mass) event is generated. 

The process time does not change much as seen above, because most of the time are spent on the Geant part.  It cannot be skipped since "RequireParticlesInAcc" needs its output (i.e. Geant hit).  We could speed it up further if we modify the Geant part somehow, but I think it too complicated.