### PR TITLE
Bug fix in Genfit integration 

### DIFF
--- a/packages/PHField/PHFieldConfig_v3.cc
+++ b/packages/PHField/PHFieldConfig_v3.cc
@@ -38,7 +38,7 @@ PHFieldConfig_v3::PHFieldConfig_v3(
     cout << "PHFieldConfig_v3::PHFieldConfig_v3:" << endl;
     cout << " from file1 [" << filename1 << "]" << endl;
     cout << "  and file2 [" << filename2 << "]" << endl;
-    cout << "scale1: " << scale1_ << ", scale2: " << scale2_ << ", targetmag_y: " << _taregetmag_y << endl;
+    cout << "scale1: " << setprecision(5) << scale1_ << ", scale2: " << setprecision(5) << scale2_ << ", targetmag_y: " << _taregetmag_y << endl;
   }
 }
 

--- a/packages/reco/interface/FastTrackletLinkDef.h
+++ b/packages/reco/interface/FastTrackletLinkDef.h
@@ -6,6 +6,7 @@
 
 #pragma link C++ class SignedHit+;
 #pragma link C++ class PropSegment+;
-#pragma link C++ class Tracklet;
+#pragma link C++ class Tracklet+;
+#pragma link C++ class TrackletVector+;
 
 #endif

--- a/packages/reco/interface/SRecEvent.h
+++ b/packages/reco/interface/SRecEvent.h
@@ -235,11 +235,11 @@ class SRecDimuon: public PHObject
 {
 public:
 
-		/// PHObject virtual overloads
-		void         identify(std::ostream& os = std::cout) const { os << "SRecDimuon: TODO: NOT IMPLEMENTED!" << std::endl;}
-		void         Reset() {*this = SRecDimuon();}
-		int          isValid() const;
-		SRecDimuon*        Clone() const {return (new SRecDimuon(*this));}
+    /// PHObject virtual overloads
+    void         identify(std::ostream& os = std::cout) const { os << "SRecDimuon: TODO: NOT IMPLEMENTED!" << std::endl;}
+    void         Reset() {*this = SRecDimuon();}
+    int          isValid() const;
+    SRecDimuon*        Clone() const {return (new SRecDimuon(*this));}
 
     //Get the total momentum of the virtual photon
     TLorentzVector getVPhoton() { return p_pos + p_neg; }

--- a/packages/reco/ktracker/KalmanFastTracking.cxx
+++ b/packages/reco/ktracker/KalmanFastTracking.cxx
@@ -654,7 +654,7 @@ void KalmanFastTracking::buildBackPartialTracks()
 #endif
         }
 
-        if(tracklet_best.isValid()) trackletsInSt[3].push_back(tracklet_best);
+        if(tracklet_best.isValid() > 0) trackletsInSt[3].push_back(tracklet_best);
     }
 
     reduceTrackletList(trackletsInSt[3]);
@@ -754,15 +754,15 @@ void KalmanFastTracking::buildGlobalTracks()
             _timers["global_link"]->stop();
 
             //The selection logic is, prefer the tracks with best p-value, as long as it's not low-pz
-            if(enable_KF && tracklet_best_prob.isValid() && 1./tracklet_best_prob.invP > 18.)
+            if(enable_KF && tracklet_best_prob.isValid() > 0 && 1./tracklet_best_prob.invP > 18.)
             {
                 tracklet_best[i] = tracklet_best_prob;
             }
-            else if(enable_KF && tracklet_best_vtx.isValid()) //otherwise select the one with best vertex chisq, TODO: maybe add a z-vtx constraint
+            else if(enable_KF && tracklet_best_vtx.isValid() > 0) //otherwise select the one with best vertex chisq, TODO: maybe add a z-vtx constraint
             {
                 tracklet_best[i] = tracklet_best_vtx;
             }
-            else if(tracklet_best_prob.isValid()) //then fall back to the default only choice
+            else if(tracklet_best_prob.isValid() > 0) //then fall back to the default only choice
             {
                 tracklet_best[i] = tracklet_best_prob;
             }
@@ -784,21 +784,21 @@ void KalmanFastTracking::buildGlobalTracks()
 #endif
         }
 
-        if(tracklet_merge.isValid() && tracklet_merge < tracklet_best[0] && tracklet_merge < tracklet_best[1])
+        if(tracklet_merge.isValid() > 0 && tracklet_merge < tracklet_best[0] && tracklet_merge < tracklet_best[1])
         {
 #ifdef _DEBUG_ON
             LogInfo("Choose merged tracklet");
 #endif
             trackletsInSt[4].push_back(tracklet_merge);
         }
-        else if(tracklet_best[0].isValid() && tracklet_best[0] < tracklet_best[1])
+        else if(tracklet_best[0].isValid() > 0 && tracklet_best[0] < tracklet_best[1])
         {
 #ifdef _DEBUG_ON
             LogInfo("Choose tracklet with station-0");
 #endif
             trackletsInSt[4].push_back(tracklet_best[0]);
         }
-        else if(tracklet_best[1].isValid())
+        else if(tracklet_best[1].isValid() > 0)
         {
 #ifdef _DEBUG_ON
             LogInfo("Choose tracklet with station-1");
@@ -974,7 +974,7 @@ void KalmanFastTracking::removeBadHits(Tracklet& tracklet)
             }
         }
         if(hit_remove == nullptr) continue;
-        if(hit_remove->sign == 0 && tracklet.isValid()) continue;  //if sign is undecided, and chisq is OKay, then pass
+        if(hit_remove->sign == 0 && tracklet.isValid() > 0) continue;  //if sign is undecided, and chisq is OKay, then pass
 
         double cut = hit_remove->sign == 0 ? hit_remove->hit.driftDistance + resol_plane[hit_remove->hit.detectorID] : resol_plane[hit_remove->hit.detectorID];
         if(res_remove1 > cut)
@@ -1200,7 +1200,7 @@ void KalmanFastTracking::buildTrackletsInStation(int stationID, int listID, doub
                 }
 
                 tracklet_new.sortHits();
-                if(!tracklet_new.isValid())
+                if(tracklet_new.isValid() == 0) //TODO: What IS THIS?
                 {
                     fitTracklet(tracklet_new);
                 }
@@ -1244,7 +1244,7 @@ void KalmanFastTracking::buildTrackletsInStation(int stationID, int listID, doub
 bool KalmanFastTracking::acceptTracklet(Tracklet& tracklet)
 {
     //Tracklet itself is okay with enough hits (4-out-of-6) and small chi square
-    if(!tracklet.isValid())
+    if(tracklet.isValid() == 0)
     {
 #ifdef _DEBUG_ON
         LogInfo("Failed in quality check!");
@@ -1340,7 +1340,7 @@ bool KalmanFastTracking::muonID_search(Tracklet& tracklet)
     for(int i = 0; i < 2; ++i)
     {
         //this shorting circuting can only be done to X-Z, Y-Z needs more complicated thing
-        //if(i == 0 && segs[i]->getNHits() > 2 && segs[i]->isValid() && fabs(slope[i] - segs[i]->a) < cut) continue;
+        //if(i == 0 && segs[i]->getNHits() > 2 && segs[i]->isValid() > 0 && fabs(slope[i] - segs[i]->a) < cut) continue;
 
         segs[i]->init();
         for(int j = 0; j < 4; ++j)
@@ -1379,7 +1379,7 @@ bool KalmanFastTracking::muonID_search(Tracklet& tracklet)
         segs[i]->fit();
 
         //this shorting circuting can only be done to X-Z, Y-Z needs more complicated thing
-        //if(i == 0 && !(segs[i]->isValid() && fabs(slope[i] - segs[i]->a) < cut)) return false;
+        //if(i == 0 && !(segs[i]->isValid() > 0 && fabs(slope[i] - segs[i]->a) < cut)) return false;
     }
 
     muonID_hodoAid(tracklet);
@@ -1420,7 +1420,7 @@ bool KalmanFastTracking::muonID_comp(Tracklet& tracklet)
 #endif
 
         double pos_ref = i == 0 ? tracklet.getExpPositionX(MUID_Z_REF) : tracklet.getExpPositionY(MUID_Z_REF);
-        if(segs[i]->getNHits() > 2 && segs[i]->isValid() && fabs(slope[i] - segs[i]->a) < cut && fabs(segs[i]->getExpPosition(MUID_Z_REF) - pos_ref) < MUID_R_CUT)
+        if(segs[i]->getNHits() > 2 && segs[i]->isValid() > 0 && fabs(slope[i] - segs[i]->a) < cut && fabs(segs[i]->getExpPosition(MUID_Z_REF) - pos_ref) < MUID_R_CUT)
         {
 #ifdef _DEBUG_ON
             LogInfo("Muon ID are already avaiable!");
@@ -1444,7 +1444,7 @@ bool KalmanFastTracking::muonID_comp(Tracklet& tracklet)
             }
         }
 
-        if(!segs[i]->isValid()) return false;
+        if(segs[i]->isValid() == 0) return false;
     }
 
     if(segs[0]->getNHits() + segs[1]->getNHits() < 5) return false;
@@ -1549,7 +1549,7 @@ void KalmanFastTracking::buildPropSegments()
                 seg.print();
 #endif
 
-                if(seg.isValid())
+                if(seg.isValid() > 0)
                 {
                     propSegs[i].push_back(seg);
                 }

--- a/packages/reco/ktracker/SQReco.cxx
+++ b/packages/reco/ktracker/SQReco.cxx
@@ -52,6 +52,8 @@ SQReco::SQReco(const std::string& name):
   _eval_file_name("eval.root"),
   _eval_tree(nullptr),
   _tracklets(nullptr),
+  _enable_eval_dst(false),
+  _tracklet_vector(nullptr),
   _evt_reducer_opt(""),
   _fastfinder(nullptr),
   _eventReducer(nullptr),
@@ -428,6 +430,7 @@ int SQReco::process_event(PHCompositeNode* topNode)
     }
 
     if(is_eval_enabled()) new((*_tracklets)[nTracklets]) Tracklet(*iter);
+    if(is_eval_dst_enabled()) _tracklet_vector->push_back(&(*iter));
     ++nTracklets;
   }
   LogDebug("Leaving SQReco::process_event: " << _event << ", finder status " << finderstatus << ", " << nTracklets << " track candidates, " << nFittedTracks << " fitted tracks");
@@ -566,9 +569,18 @@ int SQReco::MakeNodes(PHCompositeNode* topNode)
   }
 
   _recEvent = new SRecEvent();
-  PHIODataNode<PHObject>* recEventNode = new PHIODataNode<PHObject>(_recEvent,"SRecEvent", "PHObject");
+  PHIODataNode<PHObject>* recEventNode = new PHIODataNode<PHObject>(_recEvent, "SRecEvent", "PHObject");
   eventNode->addNode(recEventNode);
   if(Verbosity() >= Fun4AllBase::VERBOSITY_SOME) LogInfo("DST/SRecEvent Added");
+
+  if(_enable_eval_dst)
+  {
+    _tracklet_vector = new TrackletVector();
+    _tracklet_vector->SplitLevel(99);
+    PHIODataNode<PHObject>* trackletVecNode = new PHIODataNode<PHObject>(_tracklet_vector, "TrackletVector", "PHObject");
+    eventNode->addNode(trackletVecNode);
+    if(Verbosity() >= Fun4AllBase::VERBOSITY_SOME) LogInfo("DST/TrackletVector Added");
+  }
 
   return Fun4AllReturnCodes::EVENT_OK;
 }

--- a/packages/reco/ktracker/SQReco.h
+++ b/packages/reco/ktracker/SQReco.h
@@ -70,6 +70,8 @@ public:
 
   bool is_eval_enabled() const { return _enable_eval; }
   void set_enable_eval(bool enable) { _enable_eval = enable; }
+  bool is_eval_dst_enabled() const { return _enable_eval_dst; }
+  void set_enable_eval_dst(bool enable) { _enable_eval_dst = enable; }
   void add_eval_list(int listID) { _eval_listIDs.push_back(listID); }
 
   const TString& get_evt_reducer_opt() const { return _evt_reducer_opt; }
@@ -99,6 +101,9 @@ private:
   TTree*  _eval_tree;
   TClonesArray* _tracklets;
   std::vector<int> _eval_listIDs;
+
+  bool _enable_eval_dst;
+  TrackletVector* _tracklet_vector;
 
   TString _evt_reducer_opt;
   KalmanFastTracking* _fastfinder;


### PR DESCRIPTION
This PR contains three changes:
  1. address the genfit exception reported by Abi, by adding exception handling when calling the genfit track extrapolation function. When the exception happens, for now only an error message is printed on stderr, and the related chisq of the track is set to 999., whether we should discard this track is left to be decided in the later stage (identified by chisq=999.)
  2. fixed a bug in the tracklet global constant initialization - previously the global constants like KMAGSTR is only initialized to default value in the scope of `FastTracklet.cxx`
  3. added an option to save the list of final track candidates (Tracklet with stationID=7) on the DST tree as well. To achieve that, following changes are made (`RecoE1039Sim.C` macro is updated accordingly in e1039-analysis):
       - `SignedHit`, `PropSegment` and `Tracklet` classes now inherit from `PHObject` instead of `TObject`
       - added several essential virtual functions needed by `PHObject`: `identify`, `Reset`, `isValid`, and `Clone`
       - member function `isValid()` was extensively used in the original kTracker framework for various data classes and used to return a boolean. Now they are all changed to return an int (0 for false and 1 for true) to comply with `PHObject` standard
       - changed all the occurrences of `isValid()` from checking a boolean value to checking an int value. It's not absolutely needed since compiler will cast the int to boolean anyways, but it's done for clarity.