### PR TITLE
Bug fix in the field map and G4 simulation performance improvement

### DIFF
--- a/packages/PHField/CMakeLists.txt
+++ b/packages/PHField/CMakeLists.txt
@@ -65,6 +65,7 @@ add_library(phfield SHARED
   ${PROJECT_SOURCE_DIR}/PHField2D.cc
   ${PROJECT_SOURCE_DIR}/PHField3DCylindrical.cc
   ${PROJECT_SOURCE_DIR}/PHField3DCartesian.cc
+  ${PROJECT_SOURCE_DIR}/SQField3DCartesian.cc
   ${PROJECT_SOURCE_DIR}/PHFieldRegionalConst.cc
   ${PROJECT_SOURCE_DIR}/PHFieldSeaQuest.cc
   PHFieldUtility_Dict.C

--- a/packages/PHField/PHField.h
+++ b/packages/PHField/PHField.h
@@ -1,5 +1,3 @@
-
-
 #ifndef __PHFIELD_H__
 #define __PHFIELD_H__
 
@@ -7,7 +5,7 @@
 
 // units of this class. To convert internal value to Geant4/CLHEP units for fast access
 //#include <CLHEP/Units/SystemOfUnits.h>
-#include <G4SystemOfUnits.hh>
+#include <Geant4/G4SystemOfUnits.hh>
 
 #include <vector>
 

--- a/packages/PHField/PHField3DCartesian.cc
+++ b/packages/PHField/PHField3DCartesian.cc
@@ -61,7 +61,7 @@ PHField3DCartesian::PHField3DCartesian(const string &fname, const float magfield
          << "\n      Magnetic field Module - Verbosity:"
          << "\n-----------------------------------------------------------\n";
 
-  bool root_input = (filename.find(".root") != string::npos);
+  bool root_input = false;
   if(root_input) {
 		// open file
 		TFile *rootinput = TFile::Open(filename.c_str());
@@ -148,6 +148,11 @@ PHField3DCartesian::PHField3DCartesian(const string &fname, const float magfield
   ystepsize = (ymax - ymin) / (yvals.size() - 1);
   zstepsize = (zmax - zmin) / (zvals.size() - 1);
 
+  std::cout << "  its demensions and ranges of the field: " << fieldmap.size() << std::endl;
+  std::cout << "    X: " << xvals.size() << " bins, " << xmin/cm << " cm -- " << xmax/cm << " cm." << std::endl;
+  std::cout << "    Y: " << xvals.size() << " bins, " << ymin/cm << " cm -- " << ymax/cm << " cm." << std::endl;
+  std::cout << "    Z: " << xvals.size() << " bins, " << zmin/cm << " cm -- " << zmax/cm << " cm." << std::endl;
+
 #ifdef _DEBUG_ON
   auto key = boost::make_tuple(0, 0, 0);
   auto magval = fieldmap.find(key);
@@ -221,6 +226,7 @@ void PHField3DCartesian::GetFieldValue(const double point[4], double *Bfield) co
       point[1] < ymin || point[1] > ymax ||
       point[2] < zmin || point[2] > zmax)
   {
+    //std::cout << " sdsadsadsadasdasdasdas" << std::endl;
     return;
   }
   set<double>::const_iterator it = xvals.lower_bound(x);

--- a/packages/PHField/PHField3DCartesian.cc
+++ b/packages/PHField/PHField3DCartesian.cc
@@ -61,7 +61,7 @@ PHField3DCartesian::PHField3DCartesian(const string &fname, const float magfield
          << "\n      Magnetic field Module - Verbosity:"
          << "\n-----------------------------------------------------------\n";
 
-  bool root_input = false;
+  bool root_input = (filename.find(".root") != string::npos);
   if(root_input) {
 		// open file
 		TFile *rootinput = TFile::Open(filename.c_str());

--- a/packages/PHField/PHField3DCartesian.h
+++ b/packages/PHField/PHField3DCartesian.h
@@ -21,6 +21,10 @@ class PHField3DCartesian : public PHField
   //! @param[out] Bfield  field value. In the case of magnetic field, the order is Bx, By, Bz in in Geant4/CLHEP units
   void GetFieldValue(const double Point[4], double *Bfield) const;
 
+  //! return the min and max in z
+  double GetZMin() const { return zmin; }
+  double GetZMax() const { return zmax; }
+
  protected:
   std::string filename;
 	std::set<double> xvals;

--- a/packages/PHField/PHFieldSeaQuest.cc
+++ b/packages/PHField/PHFieldSeaQuest.cc
@@ -77,6 +77,16 @@ void PHFieldSeaQuest::GetFieldValue(const double point[4], double *Bfield) const
     Bfield[1] = 0.;
     Bfield[2] = 0.;
   }
+
+  /*
+  std::cout << "GetFieldValue: " 
+                << "x: " << point[0]/cm
+                << ", y: " << point[1]/cm
+                << ", z: " << point[2]/cm
+                << ", Bx: " << Bfield[0]/tesla
+                << ", By: " << Bfield[1]/tesla
+                << ", Bz: " << Bfield[2]/tesla << std::endl;
+  */
 }
 
 void PHFieldSeaQuest::identify(std::ostream& os) const {

--- a/packages/PHField/PHFieldSeaQuest.cc
+++ b/packages/PHField/PHFieldSeaQuest.cc
@@ -24,12 +24,12 @@ PHFieldSeaQuest::PHFieldSeaQuest(
 		targetmag(targermag_y)
 
 {
-  zValues[0] = -204.0*cm;  // front of fmag field map
-  zValues[1] = 403.74*cm;  // front of kmag field map
-  zValues[2] = 712.0*cm;   // end of fmag field map
-  zValues[3] = 1572.26*cm; // end of kmag field map
-
   kmagZOffset = 1064.26*cm;
+
+  zValues[0] = fmag.GetZMin();                // front of fmag field map
+  zValues[1] = kmag.GetZMin() + kmagZOffset;  // front of kmag field map
+  zValues[2] = fmag.GetZMax();                // end of fmag field map
+  zValues[3] = kmag.GetZMax() + kmagZOffset;  // end of kmag field map
 
   targetmag.set_mean_x(0*cm);
   targetmag.set_mean_y(0*cm);
@@ -43,30 +43,39 @@ PHFieldSeaQuest::~PHFieldSeaQuest()
   //        << endl;
 }
 
-void PHFieldSeaQuest::GetFieldValue(const double point[4], double *Bfield) const {
+void PHFieldSeaQuest::GetFieldValue(const double point[4], double *Bfield) const 
+{
+  double kmag_point[4] = {point[0], point[1], point[2]-kmagZOffset, point[3]};
 
-	double kmag_point[4] = {point[0], point[1], point[2]-kmagZOffset, point[3]};
-
-	if(point[2] < zValues[0]) {
-		targetmag.GetFieldValue(point, Bfield);
-	}else if (point[2]>zValues[0] && point[2]<zValues[1])
+  if(point[2] < zValues[0]) 
   {
-    fmag.GetFieldValue( point, Bfield );
-  } else if ((point[2]>zValues[2])&&(point[2]<zValues[3])) {
-    kmag.GetFieldValue( kmag_point, Bfield );
-  } else if ((point[2]>zValues[1])&&(point[2]<zValues[2])) {
-  	fmag.GetFieldValue( point, Bfield );
+    targetmag.GetFieldValue(point, Bfield);
+  }
+  else if(point[2] > zValues[0] && point[2] < zValues[1])
+  {
+    fmag.GetFieldValue(point, Bfield);
+  } 
+  else if(point[2] > zValues[2] && point[2] < zValues[3]) 
+  {
+    kmag.GetFieldValue(kmag_point, Bfield);
+  } 
+  else if(point[2] > zValues[1] && point[2] < zValues[2]) 
+  {
+    fmag.GetFieldValue(point, Bfield);
     double xTemp = Bfield[0];
     double yTemp = Bfield[1];
     double zTemp = Bfield[2];
-    kmag.GetFieldValue( kmag_point, Bfield );
+
+    kmag.GetFieldValue(kmag_point, Bfield);
     Bfield[0] = Bfield[0] + xTemp;
     Bfield[1] = Bfield[1] + yTemp;
     Bfield[2] = Bfield[2] + zTemp;
-  } else {
-  	Bfield[0] = 0;
-  	Bfield[1] = 0;
-  	Bfield[2] = 0;
+  } 
+  else 
+  {
+    Bfield[0] = 0.;
+    Bfield[1] = 0.;
+    Bfield[2] = 0.;
   }
 }
 

--- a/packages/PHField/PHFieldSeaQuest.h
+++ b/packages/PHField/PHFieldSeaQuest.h
@@ -37,4 +37,4 @@ class PHFieldSeaQuest : public PHField
   PHFieldRegionalConst targetmag;
 };
 
-#endif  // __PHFIELD3D_H
+#endif  // __SQField3D_H

--- a/packages/PHField/PHFieldSeaQuest.h
+++ b/packages/PHField/PHFieldSeaQuest.h
@@ -2,7 +2,7 @@
 #define __PHFieldSeaQuest_H__
 
 #include "PHField.h"
-#include "PHField3DCartesian.h"
+#include "SQField3DCartesian.h"
 #include "PHFieldRegionalConst.h"
 
 #include <map>
@@ -32,8 +32,8 @@ class PHFieldSeaQuest : public PHField
   float zValues[4];
   float kmagZOffset;
 
-  PHField3DCartesian fmag;
-  PHField3DCartesian kmag;
+  SQField3DCartesian fmag;
+  SQField3DCartesian kmag;
   PHFieldRegionalConst targetmag;
 };
 

--- a/packages/PHField/SQField3DCartesian.cc
+++ b/packages/PHField/SQField3DCartesian.cc
@@ -113,8 +113,8 @@ SQField3DCartesian::SQField3DCartesian(const std::string& fname, const float mag
 
   std::cout << "  its demensions and ranges of the field: " << records.size() << std::endl;
   std::cout << "    X: " << xvals.size() << " bins, " << xmin/cm << " cm -- " << xmax/cm << " cm." << std::endl;
-  std::cout << "    Y: " << xvals.size() << " bins, " << ymin/cm << " cm -- " << ymax/cm << " cm." << std::endl;
-  std::cout << "    Z: " << xvals.size() << " bins, " << zmin/cm << " cm -- " << zmax/cm << " cm." << std::endl;
+  std::cout << "    Y: " << yvals.size() << " bins, " << ymin/cm << " cm -- " << ymax/cm << " cm." << std::endl;
+  std::cout << "    Z: " << zvals.size() << " bins, " << zmin/cm << " cm -- " << zmax/cm << " cm." << std::endl;
 
   //Fill the 3D fieldmap for each dimension
   for(int i = 0; i < 3; ++i)
@@ -129,7 +129,7 @@ SQField3DCartesian::SQField3DCartesian(const std::string& fname, const float mag
   {
     bgrid[0]->Fill(iter->x, iter->y, iter->z, iter->Bx);
     bgrid[1]->Fill(iter->x, iter->y, iter->z, iter->By);
-    bgrid[2]->Fill(iter->x, iter->y, iter->z, iter->By);
+    bgrid[2]->Fill(iter->x, iter->y, iter->z, iter->Bz);
   }
 
   std::cout << "\n================= End Construct Mag Field ======================\n" << std::endl;

--- a/packages/PHField/SQField3DCartesian.cc
+++ b/packages/PHField/SQField3DCartesian.cc
@@ -1,0 +1,170 @@
+#include "SQField3DCartesian.h"
+
+#include <TFile.h>
+#include <TTree.h>
+
+#include <iostream>
+#include <fstream>
+#include <sstream>
+
+SQField3DCartesian::SQField3DCartesian(const std::string& fname, const float magfield_rescale)
+  : filename(fname)
+  , fieldstr(magfield_rescale)
+  , xvals()
+  , yvals()
+  , zvals()
+  , xmin(1000000)
+  , xmax(-1000000)
+  , ymin(1000000)
+  , ymax(-1000000)
+  , zmin(1000000)
+  , zmax(-1000000)
+  , xstepsize(-1.)
+  , ystepsize(-1.)
+  , zstepsize(-1.)
+{
+  std::cout << "\n================ Begin Construct Mag Field =====================" << std::endl;
+  std::cout << "\n-----------------------------------------------------------"
+            << "\n      Magnetic field Module - Verbosity:"
+            << "\n-----------------------------------------------------------\n";
+  for(int i = 0; i < 3; ++i) bgrid[i] = nullptr;
+
+  //load from input file first
+  std::vector<FieldRecord> records;
+  if(filename.find(".root") != std::string::npos) 
+  {
+    TFile* inputFile = TFile::Open(filename.c_str());
+    if(!inputFile)
+    {
+      std::cout << "SQField3DCartesian: cannot find the input ROOT field map, abort " << filename << std::endl;
+      exit(EXIT_FAILURE);
+    }
+    std::cout << "SQField3DCartesian: loading field map from ROOT file " << filename << std::endl;
+
+    float x, y, z, Bx, By, Bz;
+    TTree* inputTree = (TTree*)inputFile->Get("fieldmap");
+    inputTree->SetBranchAddress("x", &x);
+    inputTree->SetBranchAddress("y", &y);
+    inputTree->SetBranchAddress("z", &z);
+    inputTree->SetBranchAddress("Bx", &Bx);
+    inputTree->SetBranchAddress("By", &By);
+    inputTree->SetBranchAddress("Bz", &Bz);
+
+    unsigned int nRecords = inputTree->GetEntries();
+    records.reserve(nRecords);
+    for(unsigned int i = 0; i < nRecords; ++i)
+    {
+      inputTree->GetEntry(i);
+
+      FieldRecord r;
+      r.x = x*cm; r.y = y*cm; r.z = z*cm;
+      r.Bx = fieldstr*Bx*tesla; r.By = fieldstr*By*tesla; r.Bz = fieldstr*Bz*tesla;
+      records.push_back(r);
+
+      xvals.insert(r.x);
+      yvals.insert(r.y);
+      zvals.insert(r.z);
+    }
+
+    inputFile->Close();
+  }
+  else  //load from ascii input
+  {
+    std::ifstream fin(filename.c_str());
+    if(!fin)
+    {
+      std::cout << "SQField3DCartesian: cannot find the input ASCII field map, abort " << filename << std::endl;
+      exit(EXIT_FAILURE);
+    }
+    std::cout << "SQField3DCartesian: loading field map from ASCII file " << filename << std::endl;
+
+    std::string line;
+    getline(fin, line);  //header line
+    while(getline(fin, line))
+    {
+      float x, y, z, Bx, By, Bz;
+      std::stringstream ss(line);
+      ss >> x >> y >> z >> Bx >> By >> Bz;
+
+      FieldRecord r;
+      r.x = x*cm; r.y = y*cm; r.z = z*cm;
+      r.Bx = fieldstr*Bx*tesla; r.By = fieldstr*By*tesla; r.Bz = fieldstr*Bz*tesla;
+      records.push_back(r);
+
+      xvals.insert(r.x);
+      yvals.insert(r.y);
+      zvals.insert(r.z);
+    }
+
+    fin.close();
+  }
+
+  //Extract information on each dimension
+  xmin = *(xvals.begin());
+  xmax = *(xvals.rbegin());
+  ymin = *(yvals.begin());
+  ymax = *(yvals.rbegin());
+  zmin = *(zvals.begin());
+  zmax = *(zvals.rbegin());
+
+  xstepsize = (xmax - xmin)/(xvals.size() - 1);
+  ystepsize = (ymax - ymin)/(yvals.size() - 1);
+  zstepsize = (zmax - zmin)/(zvals.size() - 1);
+
+  std::cout << "  its demensions and ranges of the field: " << records.size() << std::endl;
+  std::cout << "    X: " << xvals.size() << " bins, " << xmin/cm << " cm -- " << xmax/cm << " cm." << std::endl;
+  std::cout << "    Y: " << xvals.size() << " bins, " << ymin/cm << " cm -- " << ymax/cm << " cm." << std::endl;
+  std::cout << "    Z: " << xvals.size() << " bins, " << zmin/cm << " cm -- " << zmax/cm << " cm." << std::endl;
+
+  //Fill the 3D fieldmap for each dimension
+  for(int i = 0; i < 3; ++i)
+  {
+    bgrid[i] = new TH3D(Form("field_map_%d_%s", i, filename.c_str()), Form("field_map_%d_%s", i, filename.c_str()),
+                        xvals.size(), xmin - 0.5*xstepsize, xmax + 0.5*xstepsize,
+                        yvals.size(), ymin - 0.5*ystepsize, ymax + 0.5*ystepsize,
+                        zvals.size(), zmin - 0.5*zstepsize, zmax + 0.5*zstepsize);
+  }
+
+  for(auto iter = records.begin(); iter != records.end(); ++iter)
+  {
+    bgrid[0]->Fill(iter->x, iter->y, iter->z, iter->Bx);
+    bgrid[1]->Fill(iter->x, iter->y, iter->z, iter->By);
+    bgrid[2]->Fill(iter->x, iter->y, iter->z, iter->By);
+  }
+
+  std::cout << "\n================= End Construct Mag Field ======================\n" << std::endl;
+}
+
+SQField3DCartesian::~SQField3DCartesian()
+{
+  for(int i = 0; i < 3; ++i) delete bgrid[i];
+}
+
+void SQField3DCartesian::GetFieldValue(const double point[4], double* Bfield) const
+{
+  for(int i = 0; i < 3; ++i) Bfield[i] = 0.;
+
+  double x = point[0];
+  double y = point[1];
+  double z = point[2];
+  if(!std::isfinite(x) || !std::isfinite(y) || !std::isfinite(z) ||
+     x < xmin || x > xmax || y < ymin || y > ymax || z < zmin || z > zmax)
+  {
+    static int ifirst = 0;
+    if(ifirst < 10)
+    {
+      ++ifirst;
+      std::cout << "SQField3DCartesian::GetFieldValue: WARNING " << filename << " "
+                << "Invalid coordinates: "
+                << "x: " << x/cm
+                << ", y: " << y/cm
+                << ", z: " << z/cm
+                << " bailing out returning zero bfield" << std::endl;
+    }
+    return;
+  }
+
+  for(int i = 0; i < 3; ++i) Bfield[i] = bgrid[i]->Interpolate(x, y, z);
+
+  return;
+}

--- a/packages/PHField/SQField3DCartesian.h
+++ b/packages/PHField/SQField3DCartesian.h
@@ -1,0 +1,58 @@
+#ifndef __SQField3DCartesian_H__
+#define __SQField3DCartesian_H__
+
+#include "PHField.h"
+
+#include <TH3D.h>
+
+#include <vector>
+#include <string>
+#include <set>
+
+class SQField3DCartesian: public PHField
+{
+public:
+  SQField3DCartesian(const std::string& fname, const float magfield_rescale = 1.0);
+  virtual ~SQField3DCartesian();
+
+  //! access field value
+  //! Follow the convention of G4ElectroMagneticField
+  //! @param[in]  Point   space time coordinate. x, y, z, t in Geant4/CLHEP units
+  //! @param[out] Bfield  field value. In the case of magnetic field, the order is Bx, By, Bz in in Geant4/CLHEP units
+  void GetFieldValue(const double Point[4], double *Bfield) const;
+
+  //! return the min and max in z
+  double GetZMin() const { return zmin; }
+  double GetZMax() const { return zmax; }
+
+protected:
+  std::string filename;
+  std::set<double> xvals;
+  std::set<double> yvals;
+  std::set<double> zvals;
+  TH3D* bgrid[3];
+
+  double xmin;
+  double xmax;
+  double ymin;
+  double ymax;
+  double zmin;
+  double zmax;
+  double xstepsize;
+  double ystepsize;
+  double zstepsize;
+
+  double fieldstr;
+
+  struct FieldRecord
+  {
+    double x;
+    double y;
+    double z;
+    double Bx;
+    double By;
+    double Bz;
+  };
+};
+
+#endif  // __SQField3D_H

--- a/packages/PHField/SQField3DCartesian.h
+++ b/packages/PHField/SQField3DCartesian.h
@@ -3,7 +3,7 @@
 
 #include "PHField.h"
 
-#include <TH3D.h>
+#include <TVector3.h>
 
 #include <vector>
 #include <string>
@@ -25,13 +25,28 @@ public:
   double GetZMin() const { return zmin; }
   double GetZMax() const { return zmax; }
 
+  //! return the index of the global index based on the local index
+  int GetGlobalIndex(int xIdx, int yIdx, int zIdx) const;
+
 protected:
+  class FieldPoint
+  {
+  public:
+    double x;
+    double y;
+    double z;
+    TVector3 B;
+  };
+
   std::string filename;
   std::set<double> xvals;
   std::set<double> yvals;
   std::set<double> zvals;
-  TH3D* bgrid[3];
+  std::vector<FieldPoint> fpoints;
 
+  int xsteps;
+  int ysteps;
+  int zsteps;
   double xmin;
   double xmax;
   double ymin;
@@ -43,16 +58,6 @@ protected:
   double zstepsize;
 
   double fieldstr;
-
-  struct FieldRecord
-  {
-    double x;
-    double y;
-    double z;
-    double Bx;
-    double By;
-    double Bz;
-  };
 };
 
 #endif  // __SQField3D_H

--- a/packages/PHField/utils/convert.cxx
+++ b/packages/PHField/utils/convert.cxx
@@ -1,0 +1,43 @@
+#include <iostream>
+#include <fstream>
+#include <sstream>
+#include <string>
+
+#include <TROOT.h>
+#include <TFile.h>
+#include <TTree.h>
+
+using namespace std;
+
+int main(int argc, char* argv[])
+{
+  ifstream fin(argv[1]);
+  string line;
+
+  TFile saveFile(argv[2], "recreate");
+  TTree* saveTree = new TTree("fieldmap", "fieldmap");
+
+  float x, y, z, bx, by, bz;
+
+  saveTree->Branch("x", &x, "x/F");
+  saveTree->Branch("y", &y, "y/F");
+  saveTree->Branch("z", &z, "z/F");
+  saveTree->Branch("Bx", &bx, "Bx/F");
+  saveTree->Branch("By", &by, "By/F");
+  saveTree->Branch("Bz", &bz, "Bz/F");
+   
+  getline(fin, line); //dummy read for the header
+  while(getline(fin, line))
+  {
+    stringstream ss(line);
+    ss >> x >> y >> z >> bx >> by >> bz;
+
+    saveTree->Fill();
+  }
+
+  saveFile.cd();
+  saveTree->Write();
+  saveFile.Close();
+
+  return 0;
+}

--- a/packages/geom_svc/GeomSvc.cxx
+++ b/packages/geom_svc/GeomSvc.cxx
@@ -396,12 +396,12 @@ void GeomSvc::init()
     zmin_kmag = 1064.26 - 120.*2.54;
     zmax_kmag = 1064.26 + 120.*2.54;
 
-//#ifdef _DEBUG_ON
+#ifdef _DEBUG_ON
     for(int i = 1; i <= nChamberPlanes+nHodoPlanes+nPropPlanes+nDarkPhotonPlanes; ++i)
     {
         cout << planes[i] << endl;
     }
-//#endif
+#endif
 }
 
 void GeomSvc::initPlaneDirect() {

--- a/simulation/g4detectors/PHG4DetectorSubsystem.cc
+++ b/simulation/g4detectors/PHG4DetectorSubsystem.cc
@@ -21,7 +21,7 @@ using namespace std;
 
 PHG4DetectorSubsystem::PHG4DetectorSubsystem(const std::string &name, const int lyr): 
   PHG4Subsystem(name),
-  params(new PHParameters(Name())),
+  //params(new PHParameters(Name())),
   paramscontainer(NULL),
   savetopNode(NULL),
   overlapcheck(false),
@@ -37,6 +37,8 @@ PHG4DetectorSubsystem::PHG4DetectorSubsystem(const std::string &name, const int 
   ostringstream nam;
   nam << name << "_" << lyr;
   Name(nam.str().c_str());
+
+  params = new PHParameters(Name());
 }
 
 int 

--- a/simulation/g4detectors/PHG4DetectorSubsystem.h
+++ b/simulation/g4detectors/PHG4DetectorSubsystem.h
@@ -82,7 +82,7 @@ class PHG4DetectorSubsystem : public PHG4Subsystem
   int BeginRunExecuted() const {return beginrunexecuted;}
 
  private:
-  PHParameters *params;
+  //PHParameters *params;
   PHParametersContainer *paramscontainer;
   PHCompositeNode *savetopNode;
   bool overlapcheck;

--- a/simulation/g4main/G4TBMagneticFieldSetup.cc
+++ b/simulation/g4main/G4TBMagneticFieldSetup.cc
@@ -104,6 +104,9 @@ G4TBMagneticFieldSetup::G4TBMagneticFieldSetup(PHField * phfield)
      << ", z: " << magfield_at_000[2]
      << endl;
     }
+
+  fDummyFieldManager = new G4FieldManager();
+  fDummyFieldManager->SetDetectorField(0);
 }
 
 //G4TBMagneticFieldSetup::G4TBMagneticFieldSetup(const float magfield)

--- a/simulation/g4main/G4TBMagneticFieldSetup.hh
+++ b/simulation/g4main/G4TBMagneticFieldSetup.hh
@@ -78,6 +78,8 @@ public:
 
   double get_magfield_at_000(const int i) const {return magfield_at_000[i];}
 
+  G4FieldManager* GetDummyFieldManager() { return fDummyFieldManager; }
+
 protected:
 
       // Find the global Field Manager
@@ -90,7 +92,7 @@ private:
 
   G4ChordFinder*          fChordFinder ;
 
- G4Mag_UsualEqRhs*   fEquation ;
+  G4Mag_UsualEqRhs*   fEquation ;
 
   G4MagneticField*        fEMfield;
  
@@ -104,6 +106,8 @@ private:
   G4double                fMinStep ;
  
   G4TBFieldMessenger*      fFieldMessenger;
+
+  G4FieldManager* fDummyFieldManager;
 
   double magfield_at_000[3];
 };

--- a/simulation/g4main/PHG4PhenixDetector.cc
+++ b/simulation/g4main/PHG4PhenixDetector.cc
@@ -17,6 +17,7 @@
 #include <Geant4/G4SystemOfUnits.hh>
 #include <Geant4/G4Tubs.hh>
 #include <Geant4/G4VisAttributes.hh>
+#include <Geant4/G4FieldManager.hh>
 
 #include <cmath>
 #include <iostream>
@@ -26,14 +27,18 @@ using namespace std;
 //____________________________________________________________________________
 PHG4PhenixDetector::PHG4PhenixDetector( void ):
   verbosity(0),
-  defaultMaterial( NULL ),
-  logicWorld( NULL ),
-  physiWorld( NULL ),
+  defaultMaterial(nullptr),
+  logicWorld(nullptr),
+  physiWorld(nullptr),
   WorldSizeX(1000*cm),
   WorldSizeY(1000*cm),
   WorldSizeZ(1000*cm),
-  worldshape("G4TUBS"),
-  worldmaterial("G4_AIR")
+  worldshape("G4BOX"),
+  worldmaterial("G4_AIR"),
+  ZeroFieldStartZ(99999.*cm),
+  lZeroFieldSubWorld(nullptr),
+  pZeroFieldSubWorld(nullptr),
+  zeroFieldManager(nullptr)
 {
 }
 
@@ -50,59 +55,81 @@ PHG4PhenixDetector::~PHG4PhenixDetector()
 //_______________________________________________________________________________________________
 G4VPhysicalVolume* PHG4PhenixDetector::Construct()
 {
-
   recoConsts *rc = recoConsts::instance();
-  if (verbosity > 0) std::cout << "PHG4PhenixDetector::Construct." << std::endl;
+  if(verbosity > 0) cout << "PHG4PhenixDetector::Construct." << endl;
+
   // Clean old geometry, if any
   G4GeometryManager::GetInstance()->OpenGeometry();
   G4PhysicalVolumeStore::GetInstance()->Clean();
   G4LogicalVolumeStore::GetInstance()->Clean();
   G4SolidStore::GetInstance()->Clean();
-  if (verbosity > 0) std::cout << "PHG4PhenixDetector::Construct - cleaning done." << std::endl;
+  if(verbosity > 0) cout << "PHG4PhenixDetector::Construct - cleaning done." << endl;
+
   //default materials of the World
   //  defaultMaterial  = nist->FindOrBuildMaterial("G4_AIR");
 
   // World
-  G4VSolid *solidWorld = NULL;
-  if (worldshape == "G4BOX")
-    {
-      solidWorld = new G4Box("World", WorldSizeX / 2, WorldSizeY / 2, WorldSizeZ / 2);
-    }
-  else if (worldshape == "G4Tubs")
-    {
-      solidWorld = new G4Tubs("World", 0., WorldSizeY / 2, WorldSizeZ / 2, 0, 2 * M_PI);
-    }
+  G4VSolid* solidWorld = nullptr;
+  if(worldshape == "G4BOX")
+  {
+    solidWorld = new G4Box("World", WorldSizeX/2., WorldSizeY/2., WorldSizeZ/2.);
+  }
+  else if(worldshape == "G4Tubs")
+  {
+    solidWorld = new G4Tubs("World", 0., WorldSizeY/2., WorldSizeZ/2., 0., 2.*M_PI);
+  }
   else
-    {
-      cout << "Unknown world shape " << worldshape << endl;
-      cout << "implemented are G4BOX, G4Tubs" << endl;
-      exit(1);
-    }
-  rc->set_CharFlag("WorldShape",solidWorld->GetEntityType()); // needed for checks if a particle is inside or outside of our world
-  logicWorld = new G4LogicalVolume(solidWorld, G4Material::GetMaterial(worldmaterial),"World");
+  {
+    cout << "Unknown world shape " << worldshape << endl;
+    cout << "implemented are G4BOX, G4Tubs" << endl;
+    exit(1);
+  }
+  rc->set_CharFlag("WorldShape", solidWorld->GetEntityType()); // needed for checks if a particle is inside or outside of our world
+  logicWorld = new G4LogicalVolume(solidWorld, G4Material::GetMaterial(worldmaterial), "World");
   logicWorld->SetVisAttributes(G4VisAttributes::Invisible);
-  physiWorld = new G4PVPlacement(0, G4ThreeVector(), logicWorld, "World", 0, false, 0 );
+  physiWorld = new G4PVPlacement(0, G4ThreeVector(), logicWorld, "World", 0, false, 0);
 
   G4Region* defaultRegion = (*(G4RegionStore::GetInstance()))[0];
   PHG4RegionInformation* info = new PHG4RegionInformation();
   info->SetWorld();
   defaultRegion->SetUserInformation(info);
-  if (verbosity > 0) {
-    std::cout << "PHG4PhenixDetector::Construct " << solidWorld->GetEntityType() << " world "
-	      << "material " << logicWorld->GetMaterial()->GetName() << " done." << std::endl;
+  if(verbosity > 0) 
+  {
+    cout << "PHG4PhenixDetector::Construct " << solidWorld->GetEntityType() << " world "
+	       << "material " << logicWorld->GetMaterial()->GetName() << " done." << endl;
+  }
+
+  // Zero field zone if activated
+  if(worldshape == "G4BOX" && fabs(ZeroFieldStartZ) < 0.5*WorldSizeZ)
+  {
+    G4double subWorldSizeZ = 0.5*WorldSizeZ - ZeroFieldStartZ;
+    G4double subWorldPlaceZ = ZeroFieldStartZ + 0.5*subWorldSizeZ;
+
+    G4VSolid* sZeroFieldSubWorld = new G4Box("ZeroFieldSubWorld", WorldSizeX/2., WorldSizeY/2., subWorldSizeZ/2.);
+    lZeroFieldSubWorld = new G4LogicalVolume(sZeroFieldSubWorld, G4Material::GetMaterial(worldmaterial), "ZeroFieldSubWorld");
+    pZeroFieldSubWorld = new G4PVPlacement(0, G4ThreeVector(0., 0., subWorldPlaceZ), lZeroFieldSubWorld, "ZeroFieldSubWorld", logicWorld, false, 0, false);
   }
   
   // construct all detectors
-  for( DetectorList::iterator iter = detectors_.begin(); iter != detectors_.end(); ++iter )
+  DetectorList::iterator iter = detectors_.begin();
+  list<int>::iterator flag = zeroFieldFlags.begin();
+  for(; iter != detectors_.end() && flag != zeroFieldFlags.end(); ++iter, ++flag)
   {
-    if( *iter )
+    if(*iter)
     {
-      (*iter)->Construct( logicWorld );
+      (*iter)->Construct((*flag) == 0 ? logicWorld : lZeroFieldSubWorld);
     }
   }
 
-  if (verbosity > 0) std::cout << "PHG4PhenixDetector::Construct - done." << std::endl;
-
+  if(verbosity > 0) cout << "PHG4PhenixDetector::Construct - done." << endl;
   return physiWorld;
+}
+
+void PHG4PhenixDetector::ConstructSDandField()
+{
+  if(lZeroFieldSubWorld != nullptr)
+  {
+    lZeroFieldSubWorld->SetFieldManager(zeroFieldManager, true);
+  }
 }
 

--- a/simulation/g4main/PHG4PhenixDetector.h
+++ b/simulation/g4main/PHG4PhenixDetector.h
@@ -9,6 +9,7 @@ class PHG4Detector;
 class G4Material;
 class G4LogicalVolume;
 class G4VPhysicalVolume;
+class G4FieldManager;
 
 //! this is the main detector construction class, passed to geant to construct the entire phenix detector
 class PHG4PhenixDetector: public G4VUserDetectorConstruction
@@ -25,11 +26,14 @@ class PHG4PhenixDetector: public G4VUserDetectorConstruction
   void Verbosity(int verb) {verbosity = verb;}
   
   //! register a detector. This is called in PHG4Reco::Init based on which detectors are found on the tree
-  void AddDetector( PHG4Detector* detector )
-  { detectors_.push_back( detector ); }
+  void AddDetector(PHG4Detector* detector, int zero_field = 0)
+  { detectors_.push_back(detector); zeroFieldFlags.push_back(zero_field); }
 
   //! this is called by geant to actually construct all detectors
   virtual G4VPhysicalVolume* Construct( void );
+
+  //! this is used to associate the local field manager to the no-field-zone logical volume
+  virtual void ConstructSDandField();
 
   G4double GetWorldSizeX() const
   {return WorldSizeX;}
@@ -47,6 +51,9 @@ class PHG4PhenixDetector: public G4VUserDetectorConstruction
   void SetWorldMaterial(const std::string &s) {worldmaterial = s;}
   G4VPhysicalVolume* GetPhysicalVolume(void) {return physiWorld;}
 
+  void SetZeroFieldStartZ(const G4double z) { ZeroFieldStartZ = z; }
+  void SetZeroFieldManager(G4FieldManager* man) { zeroFieldManager = man; }
+
   protected:
 
   private:
@@ -55,6 +62,7 @@ class PHG4PhenixDetector: public G4VUserDetectorConstruction
   //! list of detectors to be constructed
   typedef std::list<PHG4Detector*> DetectorList;
   DetectorList detectors_;
+  std::list<int> zeroFieldFlags;
 
   G4Material* defaultMaterial;
 
@@ -65,6 +73,11 @@ class PHG4PhenixDetector: public G4VUserDetectorConstruction
   G4double WorldSizeZ;
   std::string worldshape;
   std::string worldmaterial;
+
+  G4double ZeroFieldStartZ;
+  G4LogicalVolume*   lZeroFieldSubWorld;
+  G4VPhysicalVolume* pZeroFieldSubWorld;
+  G4FieldManager*    zeroFieldManager;
 };
 
 #endif

--- a/simulation/g4main/PHG4PhenixSteppingAction.cc
+++ b/simulation/g4main/PHG4PhenixSteppingAction.cc
@@ -1,6 +1,12 @@
 #include "PHG4PhenixSteppingAction.h"
 #include "PHG4SteppingAction.h"
 
+#include <Geant4/G4Track.hh>
+#include <Geant4/G4SystemOfUnits.hh>
+
+PHG4PhenixSteppingAction::PHG4PhenixSteppingAction(): energy_threshold_(-1.)
+{}
+
 PHG4PhenixSteppingAction::~PHG4PhenixSteppingAction()
 {
   while (actions_.begin() != actions_.end())
@@ -14,6 +20,23 @@ PHG4PhenixSteppingAction::~PHG4PhenixSteppingAction()
 //_________________________________________________________________
 void PHG4PhenixSteppingAction::UserSteppingAction( const G4Step* aStep )
 {
+  // kill tracks to save time
+  if(energy_threshold_ > 0.)
+  {
+    G4Track* theTrack = aStep->GetTrack();
+    if(theTrack->GetMomentumDirection()[2] < 0.) //track is going backwards
+    {
+      theTrack->SetTrackStatus(fStopAndKill);
+      return;
+    }
+
+    if(theTrack->GetTotalEnergy() < energy_threshold_*GeV)
+    {
+      theTrack->SetTrackStatus(fStopAndKill);
+      return;
+    }
+  }
+
   // loop over registered actions, and process
   bool hit_was_used = false;
   for( ActionList::const_iterator iter = actions_.begin(); iter != actions_.end(); ++iter )

--- a/simulation/g4main/PHG4PhenixSteppingAction.h
+++ b/simulation/g4main/PHG4PhenixSteppingAction.h
@@ -12,8 +12,7 @@ class PHG4PhenixSteppingAction : public G4UserSteppingAction
 {
 
   public:
-  PHG4PhenixSteppingAction( void )
-  {}
+  PHG4PhenixSteppingAction( void );
 
   virtual ~PHG4PhenixSteppingAction();
   
@@ -27,6 +26,8 @@ class PHG4PhenixSteppingAction : public G4UserSteppingAction
       }
   }
 
+  void set_energy_threshold(double t) { energy_threshold_ = t; }
+
   virtual void UserSteppingAction(const G4Step*);
 
   private:
@@ -34,6 +35,9 @@ class PHG4PhenixSteppingAction : public G4UserSteppingAction
   //! list of subsystem specific stepping actions
   typedef std::list<PHG4SteppingAction*> ActionList;
   ActionList actions_;
+
+  //! energy threshold
+  double energy_threshold_;
 
 };
 

--- a/simulation/g4main/PHG4Reco.cc
+++ b/simulation/g4main/PHG4Reco.cc
@@ -382,7 +382,7 @@ int PHG4Reco::InitRun(PHCompositeNode *topNode)
   for (PHG4Subsystem *g4sub : subsystems_)
   {
     //re-calculate the place_z for some of the volumes in the non-field-zone
-    if(fabs(zero_field_line_) < 0.5*WorldSize[2] && g4sub->GetDetector() != nullptr)
+    if(fabs(zero_field_line_) < 0.5*WorldSize[2] && g4sub->GetParams() != nullptr) //only true for class inherited from PHG4DetectorSubsystem
     {
       double z_in_world = g4sub->GetParams()->get_double_param("place_z");
       if(z_in_world > zero_field_line_)
@@ -394,6 +394,10 @@ int PHG4Reco::InitRun(PHCompositeNode *topNode)
       {
         detector_->AddDetector(g4sub->GetDetector(), 0);
       }
+    }
+    else
+    {
+      detector_->AddDetector(g4sub->GetDetector(), 0);
     }
   }
   runManager_->SetUserInitialization(detector_);

--- a/simulation/g4main/PHG4Reco.cc
+++ b/simulation/g4main/PHG4Reco.cc
@@ -143,7 +143,7 @@ PHG4Reco::PHG4Reco(const string &name)
   , force_decay_type_(kAll)
   , save_DST_geometry_(true)
   , optical_photon_(false)
-  , energy_threshold_(-1.)
+  , energy_threshold_(0.0005)
   , zero_field_line_(99999.)
   , _timer(PHTimeServer::get()->insert_new(name))
 {

--- a/simulation/g4main/PHG4Reco.cc
+++ b/simulation/g4main/PHG4Reco.cc
@@ -31,6 +31,7 @@
 #include <phool/getClass.h>
 #include <phool/recoConsts.h>
 
+#include <phparameter/PHParameters.h>
 
 #include <TThread.h>
 
@@ -116,7 +117,7 @@ void g4guithread(void *ptr);
 //_________________________________________________________________
 PHG4Reco::PHG4Reco(const string &name)
   : SubsysReco(name)
-  , magfield(1.4)
+  , magfield(0.)
   , magfield_rescale(1.0)
   , field_(nullptr)
   , runManager_(nullptr)
@@ -141,6 +142,9 @@ PHG4Reco::PHG4Reco(const string &name)
   , active_force_decay_(false)
   , force_decay_type_(kAll)
   , save_DST_geometry_(true)
+  , optical_photon_(false)
+  , energy_threshold_(-1.)
+  , zero_field_line_(99999.)
   , _timer(PHTimeServer::get()->insert_new(name))
 {
   for (int i = 0; i < 3; i++)
@@ -360,15 +364,37 @@ int PHG4Reco::InitRun(PHCompositeNode *topNode)
   detector_->SetWorldSizeZ(WorldSize[2] * cm);
   detector_->SetWorldShape(worldshape);
   detector_->SetWorldMaterial(worldmaterial);
-
+  detector_->SetZeroFieldStartZ(zero_field_line_*cm);
+  detector_->SetZeroFieldManager(field_->GetDummyFieldManager());
+  
   rc->set_FloatFlag("WorldSizex", WorldSize[0]);
   rc->set_FloatFlag("WorldSizey", WorldSize[1]);
   rc->set_FloatFlag("WorldSizez", WorldSize[2]);
 
+  double z_offset = 0.;
+  if(fabs(zero_field_line_) < 0.5*WorldSize[2])
+  {
+    z_offset = 0.5*(zero_field_line_ + 0.5*WorldSize[2]);  //unit cm
+    cout << "Will update the z-positions of the downstream volumes by zOffset = " << z_offset << "cm." << endl;
+  }
+
   //BOOST_FOREACH (PHG4Subsystem *g4sub, subsystems_)
   for (PHG4Subsystem *g4sub : subsystems_)
   {
-    detector_->AddDetector(g4sub->GetDetector());
+    //re-calculate the place_z for some of the volumes in the non-field-zone
+    if(fabs(zero_field_line_) < 0.5*WorldSize[2] && g4sub->GetDetector() != nullptr)
+    {
+      double z_in_world = g4sub->GetParams()->get_double_param("place_z");
+      if(z_in_world > zero_field_line_)
+      {
+        g4sub->GetParams()->set_double_param("place_z", z_in_world - z_offset);
+        detector_->AddDetector(g4sub->GetDetector(), 1);
+      }
+      else
+      {
+        detector_->AddDetector(g4sub->GetDetector(), 0);
+      }
+    }
   }
   runManager_->SetUserInitialization(detector_);
 
@@ -389,6 +415,7 @@ int PHG4Reco::InitRun(PHCompositeNode *topNode)
 
   // create main stepping action, add subsystems and register to GEANT
   steppingAction_ = new PHG4PhenixSteppingAction();
+  steppingAction_->set_energy_threshold(energy_threshold_);
   //BOOST_FOREACH (PHG4Subsystem *g4sub, subsystems_)
   for (PHG4Subsystem *g4sub : subsystems_)
   {
@@ -426,68 +453,71 @@ int PHG4Reco::InitRun(PHCompositeNode *topNode)
 
   // initialize
   runManager_->Initialize();
-
-  // add cerenkov and optical photon processes
-  // cout << endl << "Ignore the next message - we implemented this correctly" << endl;
-  G4Cerenkov *theCerenkovProcess = new G4Cerenkov("Cerenkov");
-  // cout << "End of bogus warning message" << endl << endl;
-  // G4Scintillation* theScintillationProcess      = new G4Scintillation("Scintillation");
-
-  /*
-    if (verbosity > 0)
-    {
-    // This segfaults
-    theCerenkovProcess->DumpPhysicsTable();
-    }
-  */
-  theCerenkovProcess->SetMaxNumPhotonsPerStep(100);
-  theCerenkovProcess->SetMaxBetaChangePerStep(10.0);
-  theCerenkovProcess->SetTrackSecondariesFirst(true);
-
-  // theScintillationProcess->SetScintillationYieldFactor(1.);
-  // theScintillationProcess->SetTrackSecondariesFirst(true);
-
-  // Use Birks Correction in the Scintillation process
-
-  // G4EmSaturation* emSaturation = G4LossTableManager::Instance()->EmSaturation();
-  // theScintillationProcess->AddSaturation(emSaturation);
-
-  G4ParticleTable *theParticleTable = G4ParticleTable::GetParticleTable();
-  G4ParticleTable::G4PTblDicIterator *_theParticleIterator;
-  _theParticleIterator = theParticleTable->GetIterator();
-  _theParticleIterator->reset();
-  while ((*_theParticleIterator)())
+  
+  if(optical_photon_)
   {
-    G4ParticleDefinition *particle = _theParticleIterator->value();
-    G4String particleName = particle->GetParticleName();
-    G4ProcessManager *pmanager = particle->GetProcessManager();
-    if (theCerenkovProcess->IsApplicable(*particle))
-    {
-      pmanager->AddProcess(theCerenkovProcess);
-      pmanager->SetProcessOrdering(theCerenkovProcess, idxPostStep);
-    }
-    // if (theScintillationProcess->IsApplicable(*particle))
-    // {
-    //   pmanager->AddProcess(theScintillationProcess);
-    //   pmanager->SetProcessOrderingToLast(theScintillationProcess, idxAtRest);
-    //   pmanager->SetProcessOrderingToLast(theScintillationProcess, idxPostStep);
-    // }
-  }
-  G4ProcessManager *pmanager = G4OpticalPhoton::OpticalPhoton()->GetProcessManager();
-  // G4cout << " AddDiscreteProcess to OpticalPhoton " << G4endl;
-  pmanager->AddDiscreteProcess(new G4OpAbsorption());
-  pmanager->AddDiscreteProcess(new G4OpRayleigh());
-  pmanager->AddDiscreteProcess(new G4OpMieHG());
-  pmanager->AddDiscreteProcess(new G4OpBoundaryProcess());
-  pmanager->AddDiscreteProcess(new G4OpWLS());
-  pmanager->AddDiscreteProcess(new G4PhotoElectricEffect());
-  // pmanager->DumpInfo();
+    // add cerenkov and optical photon processes
+    // cout << endl << "Ignore the next message - we implemented this correctly" << endl;
+    G4Cerenkov *theCerenkovProcess = new G4Cerenkov("Cerenkov");
+    // cout << "End of bogus warning message" << endl << endl;
+    // G4Scintillation* theScintillationProcess      = new G4Scintillation("Scintillation");
 
-  // needs large amount of memory which kills central hijing events
-  // store generated trajectories
-  //if( G4TrackingManager* trackingManager = G4EventManager::GetEventManager()->GetTrackingManager() ){
-  //  trackingManager->SetStoreTrajectory( true );
-  //}
+
+    // if (verbosity > 0)
+    // {
+    //   // This segfaults
+    //   theCerenkovProcess->DumpPhysicsTable();
+    // }
+
+    theCerenkovProcess->SetMaxNumPhotonsPerStep(100);
+    theCerenkovProcess->SetMaxBetaChangePerStep(10.0);
+    theCerenkovProcess->SetTrackSecondariesFirst(true);
+
+    // theScintillationProcess->SetScintillationYieldFactor(1.);
+    // theScintillationProcess->SetTrackSecondariesFirst(true);
+
+    // Use Birks Correction in the Scintillation process
+
+    // G4EmSaturation* emSaturation = G4LossTableManager::Instance()->EmSaturation();
+    // theScintillationProcess->AddSaturation(emSaturation);
+
+    G4ParticleTable *theParticleTable = G4ParticleTable::GetParticleTable();
+    G4ParticleTable::G4PTblDicIterator *_theParticleIterator;
+    _theParticleIterator = theParticleTable->GetIterator();
+    _theParticleIterator->reset();
+    while ((*_theParticleIterator)())
+    {
+      G4ParticleDefinition *particle = _theParticleIterator->value();
+      G4String particleName = particle->GetParticleName();
+      G4ProcessManager *pmanager = particle->GetProcessManager();
+      if (theCerenkovProcess->IsApplicable(*particle))
+      {
+        pmanager->AddProcess(theCerenkovProcess);
+        pmanager->SetProcessOrdering(theCerenkovProcess, idxPostStep);
+      }
+      // if (theScintillationProcess->IsApplicable(*particle))
+      // {
+      //   pmanager->AddProcess(theScintillationProcess);
+      //   pmanager->SetProcessOrderingToLast(theScintillationProcess, idxAtRest);
+      //   pmanager->SetProcessOrderingToLast(theScintillationProcess, idxPostStep);
+      // }
+    }
+    G4ProcessManager *pmanager = G4OpticalPhoton::OpticalPhoton()->GetProcessManager();
+    // G4cout << " AddDiscreteProcess to OpticalPhoton " << G4endl;
+    pmanager->AddDiscreteProcess(new G4OpAbsorption());
+    pmanager->AddDiscreteProcess(new G4OpRayleigh());
+    pmanager->AddDiscreteProcess(new G4OpMieHG());
+    pmanager->AddDiscreteProcess(new G4OpBoundaryProcess());
+    pmanager->AddDiscreteProcess(new G4OpWLS());
+    pmanager->AddDiscreteProcess(new G4PhotoElectricEffect());
+    // pmanager->DumpInfo();
+
+    // needs large amount of memory which kills central hijing events
+    // store generated trajectories
+    //if( G4TrackingManager* trackingManager = G4EventManager::GetEventManager()->GetTrackingManager() ){
+    //  trackingManager->SetStoreTrajectory( true );
+    //}
+  }
 
   // quiet some G4 print-outs (EM and Hadronic settings during first event)
   G4HadronicProcessStore::Instance()->SetVerbose(0);

--- a/simulation/g4main/PHG4Reco.h
+++ b/simulation/g4main/PHG4Reco.h
@@ -101,6 +101,11 @@ class PHG4Reco : public SubsysReco
     force_decay_type_ = force_decay_type;
   }
 
+  //! speed-up options setters
+  void set_optical_photon(bool b) { optical_photon_ = b; }
+  void set_energy_threshold(double t) { energy_threshold_ = t; }
+  void set_zero_field_line_(double z) { zero_field_line_ = z; }
+
   //! Save geometry from Geant4 to DST
   void save_DST_geometry(bool b) { save_DST_geometry_ = b; }
   void SetWorldSizeX(const double sx) { WorldSize[0] = sx; }
@@ -185,6 +190,11 @@ class PHG4Reco : public SubsysReco
 
   //! module timer.
   PHTimeServer::timer _timer;
+
+  //! speed up options
+  bool   optical_photon_;        //< enable process for the optical photon, default disabled
+  double energy_threshold_;      //< kill low-energy tracks fast, set to 0. to disable
+  double zero_field_line_;       //< z position after which the field manager will be set to nullptr, set to numbers larger than the world size to disable
 };
 
 #endif

--- a/simulation/g4main/PHG4Reco.h
+++ b/simulation/g4main/PHG4Reco.h
@@ -104,7 +104,7 @@ class PHG4Reco : public SubsysReco
   //! speed-up options setters
   void set_optical_photon(bool b) { optical_photon_ = b; }
   void set_energy_threshold(double t) { energy_threshold_ = t; }
-  void set_zero_field_line_(double z) { zero_field_line_ = z; }
+  void set_zero_field_line(double z) { zero_field_line_ = z; }
 
   //! Save geometry from Geant4 to DST
   void save_DST_geometry(bool b) { save_DST_geometry_ = b; }

--- a/simulation/g4main/PHG4Subsystem.h
+++ b/simulation/g4main/PHG4Subsystem.h
@@ -10,6 +10,7 @@ class PHG4Detector;
 class PHG4EventAction;
 class PHG4SteppingAction;
 class PHG4TrackingAction;
+class PHParameters;
 
 class PHG4Subsystem: public SubsysReco
 {
@@ -18,7 +19,7 @@ class PHG4Subsystem: public SubsysReco
 
   //! constructor
   PHG4Subsystem( const std::string &name = "Generic Subsystem" ): SubsysReco(name),
-overlapcheck(false)
+overlapcheck(false), params(nullptr)
   {}
 
   //! destructor
@@ -48,8 +49,12 @@ overlapcheck(false)
 
   bool CheckOverlap() const {return overlapcheck;}
 
+  PHParameters* GetParams() { return params; }
+
  protected:
   bool overlapcheck;
+  PHParameters* params;
+
 
 };
 


### PR DESCRIPTION
This PR consists of 2 parts: the first one is to fix a bug in the `PH3DFieldCartisian` class which was used for the field map interpolation in our core software; the second one is to improve the speed of G4 simulation via several changes. The original purpose of the PR was only to improve the simulation speed, however during the process I noticed the bug in the field map which caused the momentum reconstruction to be off by ~1%.

## Bug fix in the `PH3DFieldCartisian` 

In the current core software, the KMag and FMag are implemented by `packages/PHField/PHField3DCartesian`. This class read the text-based input grid file (contains x/y/z/Bx/By/Bz), save the content in a map using (x, y, z) as key and (Bx, By, Bz) as value. To obtain the magnetic field strength at a spacepoint (x, y, z), this class uses the map to locate the 8 grid points that are closest to the give spacepoint and performs a trilinear interpolation. There are two problems with this approach:
 1. using a map to locate the closest grid points, although being a o(log N) operation, is still very inefficient given that we are using fixed step size on x/y/z thus the index of the 8 closest grid points should be directly calculated using constant time;
 2. the implementation of the trilinear interpolation in `PHField3DCartesian` has a bug which have the upper-bound and lower-bound inverted. The difference is almost negligible inside the dipole magnets, but is noticeable in the fringe field region. The overall effect of this bug is that the field integral is increased by about 1%, which makes the reconstructed momentum smaller than the true momentum, as reported by Abi.

To fix this bug, I implemented another field map class `SQ3DFieldCartesian` under `package/PHField` with a hand-crafted trilinear interpolation algorithm (https://en.wikipedia.org/wiki/Trilinear_interpolation). The class `PHFieldSeaQuest` is also changed to use the new field map class.

## G4 simulation performance improvement

In addition to the more efficient field map interpolation method implemented above, this PR introduced 4 other small changes to speed up the simulation process.

  1. currently in addition to the default `"FTFP_BERT"` physics list, in the `PHG4Reco::InitRun()` optical photon process is also enabled by default, which is not useful in our simulation. I disabled this part by default and added a method `PHG4Reco::set_optical_photon(bool)` so that user can manually turn it back on;
  2. currently the simulation will track all particles till it's out-of-boundary or killed by Geant, a large amount of soft particles takes a lot of time to process. I added a function `PHG4Reco::set_energy_threshold(double)` to set the energy threshold for the G4 tracking, all the particles below this energy threshold will be killed without further propagation. This feature is turned off by default and user needs to explicitly set a threshold value to turn it on;
  3. currently we are using a global magnetic field manager even though the field map itself only covers down to z ~1550 cm. For tracks with z > 1550 cm the global field manager will always return 0 magnetic field but the RK4 propagation is still carried out for each step which generates a lot of useless computation. I created a zero-field-sub-world volume that contains all the downstream detectors with no magnetic field (all station-3 and station-4). The RK4 propagation is turned off in this volume to save time. This feature is turned off by default, user needs to call `PHG4Reco::set_zero_field_line(double)` to specify the beginning z position of the zero-field-sub-world to turn it on;
 4. currently at the beginning of the simulation, we read the text-based field map for FMag and KMag to create the look-up table for the field map interpolation. The text-based field map files are 59MB for FMag and 7MB for KMag. They take about 5 seconds to be loaded while running locally, which is not too bad. But when running tens of thousands of jobs on the grid, both field maps need to be uploaded to each node and thus constitute a significant overhead. In this PR I converted them to `TTree` and saved in a ROOT file, the size of the files are significantly reduced to 13MB and 1MB respectively. The local loading time dropped to about 1s. The old text-based field map is still supported but we should remove them from the resource package at a later stage.

## Tests

For all the tests below I generated 1500 single mu+ from `z = -300cm` with `-6GeV < px < 6GeV, -3GeV < py < 3GeV, 25GeV < pz < 100GeV`. The macro can be found here: https://github.com/liuk/e1039-analysis/blob/master/RecoDev/RecoE1039Sim.C.

### Field map bug fix

By changing to the new field map implementation, the average running time of `PHG4Reco` per event is reduced from **198ms** to **161ms**.  Below are the resolution of the momentum reconstruction at station-1 before/after the change. Left is before the change, right is after.

<img src="https://user-images.githubusercontent.com/4968504/86506598-6a09e980-bd96-11ea-8950-0e10c8917f06.png" alt="drawing" width="350"/><img src="https://user-images.githubusercontent.com/4968504/86506602-6e360700-bd96-11ea-8b06-42628021af7d.png" alt="drawing" width="350"/>

### Simulation speed improvement

On top of the test above, following three lines are added after line 124 of https://github.com/liuk/e1039-analysis/blob/master/RecoDev/RecoE1039Sim.C to enable the new speed improvement features in this PR:

```
g4Reco->set_optical_photon(false);   // disable the optical photon process
g4Reco->set_energy_threshold(0.0005);    // set the minimum energy threshold of particles to 0.0005GeV/0.5MeV
g4Reco->set_zero_field_line(1600);    // set the starting z position of the zero-field-sub-world to be 1600cm
```

The average time per event consumed by `PHG4Reco` reduced from **161ms** to **67ms**, the most significant contribution comes from the energy threshold cut. The momentum resolution plot below shows there is essentially no difference with these additional time-saving features.

<img src="https://user-images.githubusercontent.com/4968504/86507125-3a111500-bd9b-11ea-9b80-2e0f5c330cd1.png" width="350"/>
