### PR TITLE
Performance optimization for the tracking-related code

### DIFF
--- a/packages/geom_svc/GeomSvc.h
+++ b/packages/geom_svc/GeomSvc.h
@@ -23,6 +23,7 @@ and then prop. tubes
 #include <vector>
 #include <string>
 #include <map>
+#include <unordered_map>
 
 #include <TVector3.h>
 #include <TVectorD.h>
@@ -193,40 +194,41 @@ public:
     std::vector<int> getDetectorIDs(std::string pattern);
     bool findPatternInDetector(int detectorID, std::string pattern);
 
-    Plane getPlane(int detectorID) const { return planes[detectorID]; }
-    double getPlanePosition(int detectorID) const { return planes[detectorID].zc; }
-    double getPlaneSpacing(int detectorID) const  { return planes[detectorID].spacing; }
-    double getPlaneOverlap(int detectorID) const  { return planes[detectorID].overlap; }
-    double getCellWidth(int detectorID)     { return planes[detectorID].cellWidth; }
-    double getCostheta(int detectorID) const  { return planes[detectorID].costheta; }
-    double getSintheta(int detectorID) const  { return planes[detectorID].sintheta; }
-    double getTantheta(int detectorID) const  { return planes[detectorID].tantheta; }
-    double getPlaneScaleX(int detectorID)   { return planes[detectorID].x2 - planes[detectorID].x1; }
-    double getPlaneScaleY(int detectorID)   { return planes[detectorID].y2 - planes[detectorID].y1; }
-    double getPlaneScaleZ(int detectorID)   { return planes[detectorID].z2 - planes[detectorID].z1; }
-    int getTriggerLv(int detectorID)   { return map_detid_triggerlv[detectorID]; }
-    int getPlaneNElements(int detectorID)   { return planes[detectorID].nElements; }
+    const Plane& getPlane(int detectorID) const { return planes[detectorID]; }
+    Plane getPlane(int detectorID)              { return planes[detectorID]; }
+
+    double getPlanePosition(int detectorID)   const { return planes[detectorID].zc; }
+    double getPlaneSpacing(int detectorID)    const { return planes[detectorID].spacing; }
+    double getPlaneOverlap(int detectorID)    const { return planes[detectorID].overlap; }
+    double getCellWidth(int detectorID)       const { return planes[detectorID].cellWidth; }
+    double getCostheta(int detectorID)        const { return planes[detectorID].costheta; }
+    double getSintheta(int detectorID)        const { return planes[detectorID].sintheta; }
+    double getTantheta(int detectorID)        const { return planes[detectorID].tantheta; }
+    double getPlaneScaleX(int detectorID)     const { return planes[detectorID].x2 - planes[detectorID].x1; }
+    double getPlaneScaleY(int detectorID)     const { return planes[detectorID].y2 - planes[detectorID].y1; }
+    double getPlaneScaleZ(int detectorID)     const { return planes[detectorID].z2 - planes[detectorID].z1; }
     double getPlaneResolution(int detectorID) const { return planes[detectorID].resolution; }
 
-    double getPlaneCenterX(int detectorID)  { return planes[detectorID].xc; }
-    double getPlaneCenterY(int detectorID)  { return planes[detectorID].yc; }
-    double getPlaneCenterZ(int detectorID)  { return planes[detectorID].zc; }
-    double getRotationInX(int detectorID)    { return planes[detectorID].rX; }
-    double getRotationInY(int detectorID)    { return planes[detectorID].rY; }
-    double getRotationInZ(int detectorID)    { return planes[detectorID].rZ; }
+    double getPlaneCenterX(int detectorID) const { return planes[detectorID].xc; }
+    double getPlaneCenterY(int detectorID) const { return planes[detectorID].yc; }
+    double getPlaneCenterZ(int detectorID) const { return planes[detectorID].zc; }
+    double getRotationInX(int detectorID)  const { return planes[detectorID].rX; }
+    double getRotationInY(int detectorID)  const { return planes[detectorID].rY; }
+    double getRotationInZ(int detectorID)  const { return planes[detectorID].rZ; }
+    double getStereoAngle(int detectorID)  const { return planes[detectorID].angleFromVert+planes[detectorID].rZ; }
 
-    double getPlaneZOffset(int detectorID)   { return planes[detectorID].deltaZ; }
-    double getPlanePhiOffset(int detectorID) { return planes[detectorID].rotZ; }
-    double getPlaneWOffset(int detectorID)   { return planes[detectorID].deltaW; }
-    double getPlaneWOffset(int detectorID, int moduleID) { return planes[detectorID].deltaW_module[moduleID]; }
+    double getPlaneZOffset(int detectorID)   const { return planes[detectorID].deltaZ; }
+    double getPlanePhiOffset(int detectorID) const { return planes[detectorID].rotZ; }
+    double getPlaneWOffset(int detectorID)   const { return planes[detectorID].deltaW; }
+    double getPlaneWOffset(int detectorID, int moduleID) const { return planes[detectorID].deltaW_module[moduleID]; }
 
-    int getPlaneType(int detectorID) const { return planes[detectorID].planeType; }
+    int getPlaneNElements(int detectorID) const { return planes[detectorID].nElements; }
+    int getPlaneType(int detectorID)      const { return planes[detectorID].planeType; }
+
     int getHodoStation(const int detectorID) const; //< Return a station number (1-4) for hodo planes or "0" for others.
     int getHodoStation(const std::string detectorName) const; //< Return a station number (1-4) for hodo planes or "0" for others.
 
-    double getKMAGCenter()     { return (zmin_kmag + zmax_kmag)/2.; }
-    double getKMAGUpstream()   { return zmin_kmag; }
-    double getKMAGDownstream() { return zmax_kmag; }
+    int getTriggerLv(int detectorID)   { return map_detid_triggerlv[detectorID]; }
 
     ///Get the interception of a line an a plane
     double getInterception(int detectorID, double tx, double ty, double x0, double y0) const { return planes[detectorID].intercept(tx, ty, x0, y0); }
@@ -324,11 +326,11 @@ private:
     std::map<int, int> map_detid_triggerlv;
 
     //Mapping to wire position
-    std::map<std::pair<int, int>, double> map_wirePosition;
+    std::unordered_map<int, double> map_wirePosition[nChamberPlanes+nHodoPlanes+nHodoPlanes+nDarkPhotonPlanes+1];
 
     //Mapping to wire end position - wire actually includes all detectors
-    std::map<std::pair<int, int>, TVectorD> map_endPoint1;  
-    std::map<std::pair<int, int>, TVectorD> map_endPoint2;
+    std::unordered_map<int, TVectorD> map_endPoint1[nChamberPlanes+nHodoPlanes+nHodoPlanes+nDarkPhotonPlanes+1];
+    std::unordered_map<int, TVectorD> map_endPoint2[nChamberPlanes+nHodoPlanes+nHodoPlanes+nDarkPhotonPlanes+1];
 
     //Pointer to the reco constants
     recoConsts* rc;

--- a/packages/global_consts/GlobalConsts.h
+++ b/packages/global_consts/GlobalConsts.h
@@ -27,7 +27,19 @@
 #define VFEXIT_FAIL_ITERATION -20;
 
 //-------------- Useful marcros -----------------
-#define LogInfo(message) std::cout << "DEBUG: " << __FILE__ << "  " << __LINE__ << "  " << __FUNCTION__ << " :::  " << message << std::endl
+#define LogInfo(message) std::cout << "INFO: " << __FILE__ << "  " << __LINE__ << "  " << __FUNCTION__ << " :::  " << message << std::endl
 #define varName(x) #x
+
+#ifdef _DEBUG_ON
+#  define LogDebug(exp) std::cout << "DEBUG: " << typeid(*this).name() << " " << __FUNCTION__ << " " << __LINE__ << " :: " << exp << std::endl
+#else
+#  define LogDebug(exp)
+#endif
+
+#ifdef _DEBUG_ON_LEVEL_2
+#  define LogDebuglv2(exp) std::cout << "DEBUG: " << typeid(*this).name() << " " << __FUNCTION__ << " " << __LINE__ << " :: " << exp << std::endl
+#else
+#  define LogDebuglv2(exp)
+#endif
 
 #endif

--- a/packages/reco/SQGenFit/GFFitter.cxx
+++ b/packages/reco/SQGenFit/GFFitter.cxx
@@ -69,7 +69,7 @@ int GFFitter::processTrack(GFTrack& track, bool display)
   catch(genfit::Exception& e)
   {
     std::cerr << "Track fitting failed: " << e.what() << std::endl;
-    return -1;
+    return -2;
   }
   
   //check after fit
@@ -80,14 +80,14 @@ int GFFitter::processTrack(GFTrack& track, bool display)
   catch(genfit::Exception& e)
   {
     std::cerr << "Track consistency error after fit: " << e.what() << std::endl;
-    return -1;
+    return -3;
   }
 
   genfit::AbsTrackRep* rep = gftrack->getCardinalRep();
   if(!gftrack->getFitStatus(rep)->isFitConverged())
   {
     std::cerr << "Fit failed to converge." << std::endl;
-    return -1;
+    return -4;
   }
 
   if(display)

--- a/packages/reco/SQGenFit/GFMeasurement.cxx
+++ b/packages/reco/SQGenFit/GFMeasurement.cxx
@@ -18,7 +18,11 @@
 namespace SQGenFit
 {
 
-GFMeasurement::GFMeasurement(const SignedHit& rawHit, bool en): _bfHit(rawHit)
+GFMeasurement::GFMeasurement(const SignedHit& rawHit, bool en): 
+  _bfHit(rawHit),
+  _proj(0.), 
+  _driftSign(0),
+  _track(nullptr)
 {
   GeomSvc* p_geomSvc = GeomSvc::instance();
 
@@ -52,9 +56,21 @@ GFMeasurement::GFMeasurement(const SignedHit& rawHit, bool en): _bfHit(rawHit)
   //Own data
   _z = p_geomSvc->getPlanePosition(detID);
   _enableInFit = _bfHit.hit.index < 0 ? false : en;
-  _proj = 0.;
-  _driftSign = 0;
+}
+
+GFMeasurement::GFMeasurement(const GFMeasurement& meas):
+  genfit::WireMeasurement(meas.rawHitCoords_, meas.rawHitCov_, meas.detId_, meas.hitId_, meas.trackPoint_),
+  _bfHit(meas._bfHit),
+  _z(meas._z),
+  _enableInFit(meas._enableInFit), 
+  _proj(meas._proj), 
+  _driftSign(meas._driftSign)
+{
   _track = nullptr;
+
+  //WireMeasurement data
+  setMaxDistance(meas.getMaxDistance());
+  setLeftRightResolution(meas.getLeftRightResolution());
 }
 
 void GFMeasurement::setTrackPtr(GFTrack* trackPtr)
@@ -75,7 +91,7 @@ void GFMeasurement::postFitUpdate()
   _proj = H->Hv(state.getState())[0];
 }
 
-void GFMeasurement::print(unsigned int debugLvl)
+void GFMeasurement::print(unsigned int debugLvl) const
 {
   std::cout << " ................................................" << std::endl;
   std::cout << "Hit " << _bfHit.hit.index << ", detID = " << _bfHit.hit.detectorID << ", eleID = " << _bfHit.hit.elementID 
@@ -145,7 +161,7 @@ void GFMeasurement::print(unsigned int debugLvl)
   }
 }
 
-void GFMeasurement::printHelper(double w, TVector3& pos, TVector3& mom, TString name)
+void GFMeasurement::printHelper(double w, TVector3& pos, TVector3& mom, TString name) const
 {
   std::cout << " -- " << name.Data() << ": ";
   std::cout << "pos (X,Y,Z,W) = " << std::setprecision(6) << pos.X() << " " << pos.Y() << " " << pos.Z() << " " << w;

--- a/packages/reco/SQGenFit/GFMeasurement.h
+++ b/packages/reco/SQGenFit/GFMeasurement.h
@@ -14,7 +14,10 @@ class GFMeasurement: public genfit::WireMeasurement
 {
 public:
   GFMeasurement(const SignedHit& rawHit, bool en = true);
+  GFMeasurement(const GFMeasurement& meas);
   virtual ~GFMeasurement() {}
+
+  virtual genfit::AbsMeasurement* clone() const override { return new GFMeasurement(*this); }
 
   void setTrackPtr(GFTrack* trackPtr);
 
@@ -22,13 +25,14 @@ public:
   SignedHit& getBeforeFitHit() { return _bfHit; }
   void postFitUpdate();
 
-  double getZ() { return _z; }
-  bool isEnabled() { return _enableInFit; }
+  double getZ()    const { return _z; }
+  bool isEnabled() const { return _enableInFit; }
 
-  void print(unsigned int debugLvl = 0);
-  void printHelper(double w, TVector3& pos, TVector3& mom, TString name = "none");
-
+  void print(unsigned int debugLvl = 0) const;
+  
 private:
+  void printHelper(double w, TVector3& pos, TVector3& mom, TString name = "none") const;
+
   SignedHit _bfHit;
   double _z;
   bool _enableInFit;
@@ -38,6 +42,13 @@ private:
   GFTrack* _track;
 
 };
+
+class GFMeasurementComp
+{
+public:
+  bool operator() (const GFMeasurement* lhs, const GFMeasurement* rhs) const { return lhs->getZ() < rhs->getZ(); }
+};
+
 }
 
 #endif

--- a/packages/reco/interface/FastTracklet.h
+++ b/packages/reco/interface/FastTracklet.h
@@ -142,7 +142,6 @@ public:
     void sortHits() { hits.sort(); }
 
     //Update/get number of real hits
-    void updateNHits();
     int getNHits() const { return nXHits + nUHits + nVHits; }
 
     //Number of all hits (even excluded)
@@ -162,18 +161,20 @@ public:
     double getExpPosErrorX(double z) const;
     double getExpPositionY(double z) const;
     double getExpPosErrorY(double z) const;
-    double getExpPositionW(int detectorID);
+    double getExpPositionW(int detectorID) const;
+    int    getExpElementID(int detectorID) const;
 
     //Get momentum upstream/downstream
-    TVector3 getMomentumSt1();
-    TVector3 getMomentumSt3();
-    TVector3 getExpMomentum(double z);
+    TVector3 getMomentumSt1() const;
+    TVector3 getMomentumSt3() const;
+    TVector3 getExpMomentum(double z) const;
 
     //Get the i-th signed hit
     SignedHit getSignedHit(int index);
 
     //Kernal function to calculate chi square for minimizer
     double Eval(const double* par);
+    double Eval4(const double* par);
     double calcChisq();
 
     //Add dummy hits
@@ -187,8 +188,8 @@ public:
     int getCharge() const;
 
     //Get the slope and intersection in station 1
-    void getXZInfoInSt1(double& tx_st1, double& x0_st1);
-    void getXZErrorInSt1(double& err_tx_st1, double& err_x0_st1);
+    void getXZInfoInSt1(double& tx_st1, double& x0_st1) const;
+    void getXZErrorInSt1(double& err_tx_st1, double& err_x0_st1) const;
 
     //For sorting tracklet list
     bool operator<(const Tracklet& elem) const;
@@ -213,9 +214,9 @@ public:
     int stationID;
 
     //Number of hits
-    int nXHits;
-    int nUHits;
-    int nVHits;
+    mutable int nXHits;
+    mutable int nUHits;
+    mutable int nVHits;
 
     //Chi square
     double chisq;

--- a/simulation/g4detectors/PHG4BlockSteppingAction.cc
+++ b/simulation/g4detectors/PHG4BlockSteppingAction.cc
@@ -86,6 +86,7 @@ bool PHG4BlockSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
     }
     G4StepPoint* prePoint = aStep->GetPreStepPoint();
     G4StepPoint* postPoint = aStep->GetPostStepPoint();
+    G4ThreeVector track_mom = aTrack->GetMomentum();
     //       cout << "track id " << aTrack->GetTrackID() << endl;
     //       cout << "time prepoint: " << prePoint->GetGlobalTime() << endl;
     //       cout << "time postpoint: " << postPoint->GetGlobalTime() << endl;
@@ -97,17 +98,17 @@ bool PHG4BlockSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
     {
       if (prepointstatus == fPostStepDoItProc && savepoststepstatus == fGeomBoundary)
       {
-	cout << GetName() << ": New Hit for  " << endl;
-	cout << "prestep status: " << PHG4StepStatusDecode::GetStepStatus(prePoint->GetStepStatus())
-	     << ", poststep status: " << PHG4StepStatusDecode::GetStepStatus(postPoint->GetStepStatus())
-	     << ", last pre step status: " << PHG4StepStatusDecode::GetStepStatus(saveprestepstatus)
-	     << ", last post step status: " << PHG4StepStatusDecode::GetStepStatus(savepoststepstatus) << endl;
-	cout << "last track: " << savetrackid
-	     << ", current trackid: " << aTrack->GetTrackID() << endl;
-	cout << "phys pre vol: " << volume->GetName()
-	     << " post vol : " << touchpost->GetVolume()->GetName() << endl;
-	cout << " previous phys pre vol: " << savevolpre->GetName()
-	     << " previous phys post vol: " << savevolpost->GetName() << endl;
+        cout << GetName() << ": New Hit for  " << endl;
+        cout << "prestep status: " << PHG4StepStatusDecode::GetStepStatus(prePoint->GetStepStatus())
+              << ", poststep status: " << PHG4StepStatusDecode::GetStepStatus(postPoint->GetStepStatus())
+              << ", last pre step status: " << PHG4StepStatusDecode::GetStepStatus(saveprestepstatus)
+              << ", last post step status: " << PHG4StepStatusDecode::GetStepStatus(savepoststepstatus) << endl;
+        cout << "last track: " << savetrackid
+              << ", current trackid: " << aTrack->GetTrackID() << endl;
+        cout << "phys pre vol: " << volume->GetName()
+              << " post vol : " << touchpost->GetVolume()->GetName() << endl;
+        cout << " previous phys pre vol: " << savevolpre->GetName()
+              << " previous phys post vol: " << savevolpost->GetName() << endl;
       }
       if (!hit)
       {
@@ -119,7 +120,6 @@ bool PHG4BlockSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
       hit->set_y(0, prePoint->GetPosition().y() / cm);
       hit->set_z(0, prePoint->GetPosition().z() / cm);
       //
-      G4ThreeVector track_mom = aTrack->GetMomentum();
       hit->set_px(0, track_mom.x()/GeV);
       hit->set_py(0, track_mom.y()/GeV);
       hit->set_pz(0, track_mom.z()/GeV);
@@ -184,6 +184,9 @@ bool PHG4BlockSteppingAction::UserSteppingAction(const G4Step* aStep, bool)
     hit->set_x(1, postPoint->GetPosition().x() / cm);
     hit->set_y(1, postPoint->GetPosition().y() / cm);
     hit->set_z(1, postPoint->GetPosition().z() / cm);
+    hit->set_px(1, track_mom.x()/GeV);
+    hit->set_py(1, track_mom.y()/GeV);
+    hit->set_pz(1, track_mom.z()/GeV);
 
     hit->set_t(1, postPoint->GetGlobalTime() / nanosecond);
     //sum up the energy to get total deposited


### PR DESCRIPTION
This change does not introduce any real change, but in general some minor performance twist and code re-structure.
* in GeomSvc  unordered_map instead of map to store the wire position lookup table to achieve o(1) performance
* added more information in the G4Hit useful for EMCal study
* make all member functions const whenever possible in GFMeasurement and Tracklet class
* make GFFitter::processOneTrack return different exit code when encountered different failures to assist debugging

I have tested the change using Fun4Sim program, before and after the change yielded exactly the same output, as expected.

Obviously this PR is not in a hurry, and can be rolled out with the next big update.