### PR TITLE
DSTs per spill group and longer MySQL connection timeout

### DIFF
--- a/online/macros/Fun4MainDaq.C
+++ b/online/macros/Fun4MainDaq.C
@@ -91,6 +91,10 @@ int Fun4MainDaq(const int run=46, const int nevent=0, const bool is_online=false
   Fun4AllDstOutputManager *out = new Fun4AllDstOutputManager("DSTOUT", fn_out);
   se->registerOutputManager(out);
 
+  Fun4AllSpillDstOutputManager *out2 = new Fun4AllSpillDstOutputManager(UtilOnline::GetDstFileDir(), "DSTOUT2");
+  out2->SetSpillStep(100);
+  se->registerOutputManager(out2);
+
   if (use_evt_disp) {
     se->registerSubsystem(new EvtDispFilter(1000, 1)); // (step, max per spill)
 
@@ -98,10 +102,10 @@ int Fun4MainDaq(const int run=46, const int nevent=0, const bool is_online=false
     oss << "/data2/e1039/onlmon/evt_disp";
     gSystem->mkdir(oss.str().c_str(), true);
     oss << "/run_" << setfill('0') << setw(6) << run << "_evt_disp.root";
-    Fun4AllDstOutputManager *out2 = new Fun4AllDstOutputManager("DSTOUT2", oss.str());
-    out2->EnableRealTimeSave();
-    out2->AddEventSelector("EvtDispFilter");
-    se->registerOutputManager(out2);
+    Fun4AllDstOutputManager *out3 = new Fun4AllDstOutputManager("DSTOUT3", oss.str());
+    out3->EnableRealTimeSave();
+    out3->AddEventSelector("EvtDispFilter");
+    se->registerOutputManager(out3);
   }
 
   se->run(nevent);

--- a/packages/db_svc/DbSvc.cc
+++ b/packages/db_svc/DbSvc.cc
@@ -232,7 +232,7 @@ void DbSvc::SelectServer()
 void DbSvc::ConnectServer()
 {
   ostringstream oss;
-  oss << "mysql://" << m_svr << "/?reconnect=1&cnf_file=" << m_my_cnf;
+  oss << "mysql://" << m_svr << "/?timeout=120&reconnect=1&cnf_file=" << m_my_cnf;
 
   /// User and password must be given in my.cnf, not here.
   m_con = TMySQLServer::Connect(oss.str().c_str(), 0, 0);


### PR DESCRIPTION
Two small updates are included.  (1) `Fun4AllSpillDstOutputManager`, which outputs one DST file per spill group, is enabled in the online decoder.  The number of spills per DST is set to 100 now.  (2) The connection timeout was made longer (from 10 to 120 sec) in order to hopefully resolve the error in DbSvc::ConnectServer().

I cannot assure that the DbSvc error has been really resolved because the error was rare (0 in 10,000 trials) even without this update.  I expect to check it in the coming practical uses (simulation, decoding, etc.).

The updates are simple, and I have confirmed that the updated code can be compiled and run fine.  Thus I think Abi can just take a look and merge.