### PR TITLE
Optionally build the station-1 and 2 long track with KMAG off

### DIFF
--- a/packages/reco/interface/FastTracklet.cxx
+++ b/packages/reco/interface/FastTracklet.cxx
@@ -543,8 +543,9 @@ int Tracklet::isValid() const
         }
 
         //Number of hits cut after removing bad hits
-        for(int i = 1; i < 3; ++i)
+        for(int i = 0; i < 3; ++i)
         {
+            if(nRealHits[i][0] == 0 && nRealHits[i][1] == 0 && nRealHits[i][2] == 0) continue;
             if(nRealHits[i][0] < 1 || nRealHits[i][1] < 1 || nRealHits[i][2] < 1) return 0;
             if(nRealHits[i][0] + nRealHits[i][1] + nRealHits[i][2] < 4) return 0;
         }
@@ -552,9 +553,6 @@ int Tracklet::isValid() const
         //for global tracks only -- TODO: may need to set a new station-1 cut
         if(stationID == nStations)
         {
-            if(nRealHits[0][0] < 1 || nRealHits[0][1] < 1 || nRealHits[0][2] < 1) return 0;
-            if(nRealHits[0][0] + nRealHits[0][1] + nRealHits[0][2] < 4) return 0;
-
             if(prob < PROB_TIGHT) return 0;
             if(KMAG_ON)
             {
@@ -580,14 +578,6 @@ double Tracklet::getProb() const
 
     return TMath::Prob(chisq, ndf);
     //return -chisq/ndf;
-}
-
-double Tracklet::getMomProb() const
-{
-    double weights[40] = {0, 0, 3.1292e-05, 0.00203877, 0.0147764, 0.0417885, 0.08536, 0.152212, 0.250242, 0.322011, 0.327125, 0.275443, 0.220316, 0.189932, 0.162112, 0.131674, 0.100102, 0.0736696, 0.0510353, 0.0364215, 0.0233914, 0.0152907, 0.00992716, 0.00601322, 0.00382757, 0.00239005, 0.00137169, 0.000768309, 0.000413311, 0.00019659, 8.31216e-05, 2.77721e-05, 7.93826e-06, 7.45884e-07, 2.57648e-08, 0, 6.00088e-09, 0, 0, 0};
-    int index = int(1./invP/2.5);
-
-    return (index >= 0 && index < 40) ? (weights[index] < 1.E-5 ? 1.E-5 : weights[index]) : 1.E-5;
 }
 
 TVector3 Tracklet::getExpMomentum(double z) const

--- a/packages/reco/interface/FastTracklet.h
+++ b/packages/reco/interface/FastTracklet.h
@@ -150,9 +150,6 @@ public:
     //Get the probabilities
     double getProb() const;
 
-    //Get the momentum probabilities
-    double getMomProb() const;
-
     //Get the chi square
     double getChisq() const { return chisq; }
 

--- a/packages/reco/ktracker/KalmanFastTracking.cxx
+++ b/packages/reco/ktracker/KalmanFastTracking.cxx
@@ -439,6 +439,7 @@ int KalmanFastTracking::setRawEvent(SRawEvent* event_input)
 
     //Initialize tracklet lists
     for(int i = 0; i < 5; i++) trackletsInSt[i].clear();
+    if(enable_front_partial)   trackletsInSt[5].clear();
     stracks.clear();
 
     //pre-tracking cuts
@@ -507,7 +508,6 @@ int KalmanFastTracking::setRawEvent(SRawEvent* event_input)
 
     if(enable_front_partial)
     {
-        trackletsInSt[5].clear();
         buildFrontPartialTracks();
     }
 

--- a/packages/reco/ktracker/KalmanFastTracking.h
+++ b/packages/reco/ktracker/KalmanFastTracking.h
@@ -34,7 +34,7 @@ class PHTimer;
 class KalmanFastTracking
 {
 public:
-    explicit KalmanFastTracking(const PHField* field, const TGeoManager *geom, bool flag = true);
+    explicit KalmanFastTracking(const PHField* field, const TGeoManager* geom, bool flag = true, bool enableFront = false);
     ~KalmanFastTracking();
 
     //set/get verbosity
@@ -55,6 +55,9 @@ public:
 
     //Build back partial tracks using tracklets in station 2 & 3
     void buildBackPartialTracks();
+
+    //Build front partial tracks using tracklets in station 1 & 2
+    void buildFrontPartialTracks();
 
     //Build global tracks by connecting station 23 tracklets and station 1 tracklets
     void buildGlobalTracks();
@@ -101,7 +104,8 @@ public:
 
     ///Final output
     std::list<Tracklet>& getFinalTracklets() { return trackletsInSt[outputListIdx]; }
-    std::list<Tracklet>& getBackPartials() { return trackletsInSt[3]; }
+    std::list<Tracklet>& getBackPartials()   { return trackletsInSt[3]; }
+    std::list<Tracklet>& getFrontPartials()  { return trackletsInSt[5]; }
     std::list<Tracklet>& getTrackletList(int i) { return trackletsInSt[i]; }
     std::list<SRecTrack>& getSRecTracks() { return stracks; }
     std::list<PropSegment>& getPropSegments(int i) { return propSegs[i]; }
@@ -120,9 +124,9 @@ private:
     SRawEvent* rawEvent;
     std::vector<Hit> hitAll;
 
-    //Tracklets in one event, id = 0, 1, 2 for station 0/1, 2, 3+/-, id = 3 for station 2&3 combined, id = 4 for global tracks
+    //Tracklets in one event, id = 0, 1, 2 for station 0/1, 2, 3+/-, id = 3 for station 2&3 combined, id = 4 for global tracks, id = 5 for station-1&2 combined (only needed for cosmic commissioning)
     //Likewise for the next part
-    std::list<Tracklet> trackletsInSt[5];
+    std::list<Tracklet> trackletsInSt[6];
 
     //Final SRecTrack list
     std::list<SRecTrack> stracks;
@@ -205,6 +209,9 @@ private:
 
     //Flag for enable Kalman fitting
     const bool enable_KF;
+
+    //Flag to enable front partial building
+    bool enable_front_partial;
 
     //Timer
     std::map<std::string, PHTimer*> _timers;

--- a/packages/reco/ktracker/SQReco.cxx
+++ b/packages/reco/ktracker/SQReco.cxx
@@ -444,6 +444,7 @@ int SQReco::process_event(PHCompositeNode* topNode)
       std::list<Tracklet>& eval_tracklets = _fastfinder->getTrackletList(_eval_listIDs[i]);
       for(auto iter = eval_tracklets.begin(); iter != eval_tracklets.end(); ++iter)
       {
+        iter->calcChisq();
         if(is_eval_enabled())
         {
           new((*_tracklets)[nTracklets]) Tracklet(*iter);

--- a/packages/reco/ktracker/SQReco.cxx
+++ b/packages/reco/ktracker/SQReco.cxx
@@ -59,6 +59,7 @@ SQReco::SQReco(const std::string& name):
   _fastfinder(nullptr),
   _eventReducer(nullptr),
   _enable_KF(true),
+  _enable_front_partial(false),
   _kfitter(nullptr),
   _gfitter(nullptr),
   _phfield(nullptr),
@@ -109,10 +110,9 @@ int SQReco::InitRun(PHCompositeNode* topNode)
   if(ret != Fun4AllReturnCodes::EVENT_OK) return ret;
 
   //Init track finding
- // _fastfinder = new KalmanFastTracking(_phfield, _t_geo_manager, false);
-  _fastfinder = new KalmanFastTracking(_phfield, _t_geo_manager, _enable_KF);///Abi (Don't we turn on enable_kF ?)
-
+  _fastfinder = new KalmanFastTracking(_phfield, _t_geo_manager, false, _enable_front_partial);
   _fastfinder->Verbosity(Verbosity());
+  if(_enable_front_partial) add_eval_list(5);
 
   if(_evt_reducer_opt == "none")  //Meaning we disable the event reducer
   {

--- a/packages/reco/ktracker/SQReco.h
+++ b/packages/reco/ktracker/SQReco.h
@@ -71,6 +71,9 @@ public:
   void set_enable_eval_dst(bool enable) { _enable_eval_dst = enable; }
   void add_eval_list(int listID);
 
+  bool is_front_partial_enabled() const { return _enable_front_partial; }
+  void set_enable_front_partial(bool enable) { _enable_front_partial = enable; }
+
   const TString& get_evt_reducer_opt() const { return _evt_reducer_opt; }
   void set_evt_reducer_opt(const TString& opt) { _evt_reducer_opt = opt; }
 
@@ -105,6 +108,8 @@ private:
 
   bool _enable_eval_dst;
   TrackletVector* _tracklet_vector;
+
+  bool _enable_front_partial;
 
   TString _evt_reducer_opt;
   KalmanFastTracking* _fastfinder;


### PR DESCRIPTION
This PR added a function in `KalmanFastTracking` to build the station-1 and 2 long track in pretty much the same way as station-2 and 3 long track is built. The purpose of this feature is to increase the statistics in the cosmic ray commissioning of station-1 since it's very rare to have a global track. 

This feature is by default turned off, and can be enabled by calling `SQReco::set_enable_front_partial(true)`.