### PR TITLE
Switchable geometry info

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -58,8 +58,8 @@ if [ $mode = 'single' ] || [ $mode = 'increment' ]; then
 else # 'all' or 'resume'
   declare -a packages=(
     packages/global_consts
-    packages/db_svc
     framework/phool
+    packages/db_svc
     packages/geom_svc
     framework/ffaobjects
     framework/fun4all

--- a/framework/phool/recoConsts.cc
+++ b/framework/phool/recoConsts.cc
@@ -157,6 +157,7 @@ void recoConsts::set_defaults()
 void recoConsts::init(int runNo, bool verbose)
 {
   //TODO: initialization based on run range
+  set_IntFlag("RUNNUMBER", runNo);
   return;
 }
 

--- a/framework/phool/recoConsts.cc
+++ b/framework/phool/recoConsts.cc
@@ -44,6 +44,8 @@ void recoConsts::set_defaults()
 
   //Following flags control the running mode and must be 
   //set to appropriate values in the configuration set
+  set_IntFlag("RUNNUMBER", 1);
+
   set_BoolFlag("KMAG_ON", true);
   set_BoolFlag("COARSE_MODE", false);
   set_BoolFlag("MC_MODE", false);
@@ -58,8 +60,8 @@ void recoConsts::set_defaults()
   set_CharFlag("AlignmentProp", "$E1039_RESOURCE/alignment/run6/alignment_prop.txt");
   set_CharFlag("Calibration", "$E1039_RESOURCE/alignment/run6/calibration.txt");
 
-  set_CharFlag("MySQLURL", "mysql://e906-db1.fnal.gov:3306");
-  set_CharFlag("Geometry", "user_e1039_geom_plane.param_G9_run5_2");
+  set_CharFlag("DB_SERVER", "DB1");
+  set_CharFlag("DB_USER"  , "seaguest");
 
   set_CharFlag("TRIGGER_Repo", "$TRIGGER_ROOT");
   set_CharFlag("TRIGGER_L1", "67");

--- a/packages/db_svc/DbSvc.cc
+++ b/packages/db_svc/DbSvc.cc
@@ -192,16 +192,15 @@ TSQLStatement* DbSvc::Process(const char* query)
  */
 void DbSvc::SelectServer()
 {
-  if (m_svr_id == AUTO) {
+  if (m_svr_id == AutoSvr) {
     recoConsts* rc = recoConsts::instance();
     string svr = rc->get_CharFlag("DB_SERVER");
-    switch (svr) {
-    case "DB1"  :  m_svr_id = DB1  ;  break;
-    case "DB2"  :  m_svr_id = DB2  ;  break;
-    case "DB3"  :  m_svr_id = DB3  ;  break;
-    case "DB4"  :  m_svr_id = DB4  ;  break;
-    case "LOCAL":  m_svr_id = LOCAL;  break;
-    default:
+    if      (svr == "DB1"  ) m_svr_id = DB1  ;
+    else if (svr == "DB2"  ) m_svr_id = DB2  ;
+    else if (svr == "DB3"  ) m_svr_id = DB3  ;
+    else if (svr == "DB4"  ) m_svr_id = DB4  ;
+    else if (svr == "LOCAL") m_svr_id = LOCAL;
+    else {
       cerr << "!!ERROR!!  DbSvc():  Unsupported DB_SERVER in recoConsts.  Abort.\n";
       exit(1);
     }
@@ -220,21 +219,20 @@ void DbSvc::SelectServer()
 
 void DbSvc::SelectUser()
 {
-  if (m_usr_id == AUTO) {
+  if (m_usr_id == AutoUsr) {
     recoConsts* rc = recoConsts::instance();
     string usr = rc->get_CharFlag("DB_USER");
-    switch (usr) {
-    case "seaguest"  :  m_usr_id = Guest;  break;
-    case "production":  m_usr_id = Prod ;  break;
-    default:
+    if      (usr == "seaguest"  ) m_usr_id = Guest;
+    else if (usr == "production") m_usr_id = Prod ;
+    else {
       cerr << "!!ERROR!!  DbSvc():  Unsupported DB_USER in recoConsts.  Abort.\n";
       exit(1);
     }
   }
 
   if (m_my_cnf.length() == 0) {
-    if (usr_id == Guest) m_my_cnf = "$E1039_RESOURCE/db_conf/guest.cnf";
-    else /* == Prod */   m_my_cnf = "$E1039_RESOURCE/db_conf/prod.cnf";
+    if (m_usr_id == Guest) m_my_cnf = "$E1039_RESOURCE/db_conf/guest.cnf";
+    else /* == Prod */     m_my_cnf = "$E1039_RESOURCE/db_conf/prod.cnf";
   }
   m_my_cnf = ExpandEnvironmentals(m_my_cnf);
   //LogInfo("Using "<< m_my_cnf);

--- a/packages/db_svc/DbSvc.h
+++ b/packages/db_svc/DbSvc.h
@@ -6,10 +6,15 @@
 class TSQLServer;
 class TSQLStatement;
 
+/// Standard interface with SQL database.
+/**
+ * A server and a user can be selected via "DB_SERVER" and "DB_USER" in recoConsts.
+ * But they can be specified if needed, when each DbSvc object is created.
+ */
 class DbSvc {
  public:
-  typedef enum { DB1, DB2, DB3, DB01, UIUC, LITE, LOCAL } SvrId_t;
-  typedef enum { Guest, Prod } UsrId_t;
+  typedef enum { AUTO, DB1, DB2, DB3, DB4, LITE, LOCAL } SvrId_t;
+  typedef enum { AUTO, Guest, Prod } UsrId_t;
   class VarList {
     std::vector<std::string> m_name;
     std::vector<std::string> m_type;
@@ -20,7 +25,7 @@ class DbSvc {
     void Get(const int idx, std::string& name, std::string& type, bool& is_key) const;
   };
 
-  DbSvc(const SvrId_t svr_id=DB1, const UsrId_t usr_id=Guest, const std::string my_cnf="");
+  DbSvc(const SvrId_t svr_id=AUTO, const UsrId_t usr_id=AUTO, const std::string my_cnf="");
   explicit DbSvc(const SvrId_t svr_id, std::string dbfile);  // this is only for sqlite db
   ~DbSvc();
 
@@ -47,6 +52,9 @@ class DbSvc {
   TSQLServer* m_con;
 
   void SelectServer();
+  void SelectUser();
   void ConnectServer();
+  bool FileExist(const std::string fileName);
+  std::string ExpandEnvironmentals( const std::string& input );
 };
 #endif // __DB_SVC_H__

--- a/packages/db_svc/DbSvc.h
+++ b/packages/db_svc/DbSvc.h
@@ -13,8 +13,8 @@ class TSQLStatement;
  */
 class DbSvc {
  public:
-  typedef enum { AUTO, DB1, DB2, DB3, DB4, LITE, LOCAL } SvrId_t;
-  typedef enum { AUTO, Guest, Prod } UsrId_t;
+  typedef enum { AutoSvr, DB1, DB2, DB3, DB4, LITE, LOCAL } SvrId_t;
+  typedef enum { AutoUsr, Guest, Prod } UsrId_t;
   class VarList {
     std::vector<std::string> m_name;
     std::vector<std::string> m_type;
@@ -25,7 +25,7 @@ class DbSvc {
     void Get(const int idx, std::string& name, std::string& type, bool& is_key) const;
   };
 
-  DbSvc(const SvrId_t svr_id=AUTO, const UsrId_t usr_id=AUTO, const std::string my_cnf="");
+  DbSvc(const SvrId_t svr_id=AutoSvr, const UsrId_t usr_id=AutoUsr, const std::string my_cnf="");
   explicit DbSvc(const SvrId_t svr_id, std::string dbfile);  // this is only for sqlite db
   ~DbSvc();
 

--- a/packages/geom_svc/GeomSvc.cxx
+++ b/packages/geom_svc/GeomSvc.cxx
@@ -25,6 +25,8 @@ Created: 10-19-2011
 #include <TRotation.h>
 #include <TMatrixD.h>
 
+#include <phool/recoConsts.h>
+
 #include "GeomParamPlane.h"
 #include "GeomSvc.h"
 
@@ -564,7 +566,12 @@ void GeomSvc::initPlaneDirect() {
 
 void GeomSvc::initPlaneDbSvc() {
   using namespace std;
-  const int run = 1; // todo: need adjustable in the future
+  recoConsts* rc = recoConsts::instance();
+  int run = rc->get_IntFlag("RUNNUMBER");
+  if (run == 0) {
+    run = 1;
+    rc->set_IntFlag("RUNNUMBER", run);
+  }
   cout << "GeomSvc:  Load the plane geometry info via DbSvc for run = " << run << "." << endl;
 
   GeomParamPlane* geom = new GeomParamPlane();

--- a/packages/geom_svc/GeomSvc.cxx
+++ b/packages/geom_svc/GeomSvc.cxx
@@ -409,10 +409,10 @@ void GeomSvc::init()
 }
 
 void GeomSvc::initPlaneDirect() {
-  cerr << "!! ERROR !!\n"
-       << "!! GeomSvc::initPlaneDirect() is called but no longer available.\n"
-       << "!! Probably you have 'GeomSvc::UseDbSvc(false)' in your macro.\n"
-       << "!! Please delete it.  Abort for now." << endl;
+  std::cerr << "!! ERROR !!\n"
+            << "!! GeomSvc::initPlaneDirect() is called but no longer available.\n"
+            << "!! Probably you have 'GeomSvc::UseDbSvc(false)' in your macro.\n"
+            << "!! Please delete it.  Abort for now." << std::endl;
   exit(1);
 }
 

--- a/packages/geom_svc/GeomSvc.cxx
+++ b/packages/geom_svc/GeomSvc.cxx
@@ -376,10 +376,13 @@ void GeomSvc::init()
     if (use_dbsvc) initPlaneDbSvc();
     else           initPlaneDirect();
 
-    /////Here starts the user-defined part
-    //load alignment parameterss
+    // Alignment and calibration
     calibration_loaded = false;
-    if(!rc->get_BoolFlag("OnlineAlignment") && (!rc->get_BoolFlag("IdealGeom")))
+    if(rc->get_BoolFlag("OnlineAlignment"))
+    {
+      loadOnlineAlignment(rc->get_CharFlag("AlignmentMille"));
+    }
+    else if(!rc->get_BoolFlag("IdealGeom"))
     {
         loadAlignment("NULL", rc->get_CharFlag("AlignmentHodo"), rc->get_CharFlag("AlignmentProp"));
         loadMilleAlignment(rc->get_CharFlag("AlignmentMille"));
@@ -406,172 +409,16 @@ void GeomSvc::init()
 }
 
 void GeomSvc::initPlaneDirect() {
-    using namespace std;
-
-    ///Initialize the geometrical variables which should be from MySQL database
-    //Connect server
-    TSQLServer* con = TSQLServer::Connect(rc->get_CharFlag("MySQLURL").c_str(), "seaguest","qqbar2mu+mu-");
-
-    //Make query to Planes table
-    char query[300];
-    const char* buf_planes = "SELECT detectorName,spacing,cellWidth,overlap,numElements,angleFromVert,"
-                             "xPrimeOffset,x0,y0,z0,planeWidth,planeHeight,theta_x,theta_y,theta_z from %s.Planes WHERE"
-                             " detectorName LIKE 'D%%' OR detectorName LIKE 'H__' OR detectorName LIKE 'H____' OR "
-                             "detectorName LIKE 'P____'";
-    sprintf(query, buf_planes, rc->get_CharFlag("Geometry").c_str());
-    TSQLResult* res = con->Query(query);
-
-    unsigned int nRows = res->GetRowCount();
-    int dummy = 0;
-    for(unsigned int i = 0; i < nRows; ++i)
-    {
-        TSQLRow* row = res->Next();
-        std::string detectorName(row->GetField(0));
-        toLocalDetectorName(detectorName, dummy);
-
-        int detectorID = map_detectorID[detectorName];
-        planes[detectorID].detectorID = detectorID;
-        planes[detectorID].detectorName = detectorName;
-        planes[detectorID].spacing = atof(row->GetField(1));
-        planes[detectorID].cellWidth = atof(row->GetField(2));
-        planes[detectorID].overlap = atof(row->GetField(3));
-        planes[detectorID].angleFromVert = atof(row->GetField(5));
-        planes[detectorID].xoffset = atof(row->GetField(6));
-        planes[detectorID].thetaX = atof(row->GetField(12));
-        planes[detectorID].thetaY = atof(row->GetField(13));
-        planes[detectorID].thetaZ = atof(row->GetField(14));
-
-        //Following items need to be sumed or averaged over all modules
-        planes[detectorID].nElements += atoi(row->GetField(4));
-        double x0_i = atof(row->GetField(7));
-        double y0_i = atof(row->GetField(8));
-        double z0_i = atof(row->GetField(9));
-        double width_i = atof(row->GetField(10));
-        double height_i = atof(row->GetField(11));
-
-        double x1_i = x0_i - 0.5*width_i;
-        double x2_i = x0_i + 0.5*width_i;
-        double y1_i = y0_i - 0.5*height_i;
-        double y2_i = y0_i + 0.5*height_i;
-
-        planes[detectorID].x0 += x0_i;
-        planes[detectorID].y0 += y0_i;
-        planes[detectorID].z0 += z0_i;
-        if(planes[detectorID].x1 > x1_i) planes[detectorID].x1 = x1_i;
-        if(planes[detectorID].x2 < x2_i) planes[detectorID].x2 = x2_i;
-        if(planes[detectorID].y1 > y1_i) planes[detectorID].y1 = y1_i;
-        if(planes[detectorID].y2 < y2_i) planes[detectorID].y2 = y2_i;
-
-        //Calculated value
-        planes[detectorID].resolution = planes[detectorID].cellWidth/sqrt(12.);
-        planes[detectorID].update();
-
-        //Set the plane type
-        if(detectorName.find("X") != string::npos || detectorName.find("T") != string::npos || detectorName.find("B") != string::npos)
-        {
-            planes[detectorID].planeType = 1;
-        }
-        else if((detectorName.find("U") != string::npos || detectorName.find("V") != string::npos) && planes[detectorID].angleFromVert > 0)
-        {
-            planes[detectorID].planeType = 2;
-        }
-        else if((detectorName.find("U") != string::npos || detectorName.find("V") != string::npos) && planes[detectorID].angleFromVert < 0)
-        {
-            planes[detectorID].planeType = 3;
-        }
-        else if(detectorName.find("Y") != string::npos || detectorName.find("L") != string::npos || detectorName.find("R") != string::npos)
-        {
-            planes[detectorID].planeType = 4;
-        }
-
-        delete row;
-    }
-    delete res;
-
-    //For prop. tube only, average over 9 modules
-    for(int i = nChamberPlanes+nHodoPlanes+1; i <= nChamberPlanes+nHodoPlanes+nPropPlanes; i++)
-    {
-        planes[i].x0 = planes[i].x0/9.;
-        planes[i].y0 = planes[i].y0/9.;
-        planes[i].z0 = planes[i].z0/9.;
-
-        planes[i].update();
-    }
-
-    //Set the depth of the plane for Geant4 simulation simplification
-    for(int i = 1; i <= nChamberPlanes+nHodoPlanes+nPropPlanes+nDarkPhotonPlanes; ++i)
-    {
-        if(i <= nChamberPlanes)  //For drift chambers the depth equals the wire spacing
-        {
-            planes[i].z1 = planes[i].z0 - planes[i].cellWidth/2.;
-            planes[i].z2 = planes[i].z0 + planes[i].cellWidth/2.;
-        }
-        else if(i <= nChamberPlanes+nHodoPlanes) //For hodos the depth is hard-coded
-        {
-            planes[i].z1 = planes[i].z0 - 0.635/2.;
-            planes[i].z2 = planes[i].z0 + 0.635/2.;
-        }
-        else if(i <= nChamberPlanes+nHodoPlanes+nPropPlanes) //For prop. tubes the depth is defined by the equivalent gas volume
-        {
-            planes[i].z1 = planes[i].z0 - planes[i].cellWidth*TMath::Pi()/8.;
-            planes[i].z2 = planes[i].z0 + planes[i].cellWidth*TMath::Pi()/8.;
-        }
-        else //For dark photon hodos the depth equals the cell width
-        {
-            planes[i].z1 = planes[i].z0 - planes[i].cellWidth/2.;
-            planes[i].z2 = planes[i].z0 + planes[i].cellWidth/2.;
-        }
-    }
-    cout << "GeomSvc: loaded basic spectrometer setup from geometry schema " << rc->get_CharFlag("Geometry") << endl;
-
-    //load the initial value in the planeOffsets table
-    if(rc->get_BoolFlag("OnlineAlignment"))
-    {
-        loadMilleAlignment(rc->get_CharFlag("AlignmentMille"));    //final chance of overwrite resolution numbers in online mode
-        const char* buf_offsets = "SELECT detectorName,deltaX,deltaY,deltaZ,rotateAboutZ FROM %s.PlaneOffsets WHERE"
-                                  " detectorName LIKE 'D%%' OR detectorName LIKE 'H__' OR detectorName LIKE 'H____' OR detectorName LIKE 'P____'";
-        sprintf(query, buf_offsets, rc->get_CharFlag("Geometry").c_str());
-        res = con->Query(query);
-
-        nRows = res->GetRowCount();
-        if(nRows >= nChamberPlanes) cout << "GeomSvc: loaded chamber alignment parameters from database: " << rc->get_CharFlag("Geometry") << endl;
-        for(unsigned int i = 0; i < nRows; ++i)
-        {
-            TSQLRow* row = res->Next();
-            string detectorName(row->GetField(0));
-            toLocalDetectorName(detectorName, dummy);
-
-            int detectorID = map_detectorID[detectorName];
-            if(detectorID > nChamberPlanes) // ?? WTF?
-            {
-                delete row;
-                continue;
-            }
-
-            planes[detectorID].deltaX = atof(row->GetField(1));
-            planes[detectorID].deltaY = atof(row->GetField(2));
-            planes[detectorID].deltaZ = atof(row->GetField(3));
-            planes[detectorID].rotZ = atof(row->GetField(4));
-
-            planes[detectorID].update();
-            planes[detectorID].deltaW = planes[detectorID].getW(planes[detectorID].deltaX, planes[detectorID].deltaY);
-
-            delete row;
-        }
-        delete res;
-    }
-
-    delete con;
+  cerr << "!! ERROR !!\n"
+       << "!! GeomSvc::initPlaneDirect() is called but no longer available.\n"
+       << "!! Probably you have 'GeomSvc::UseDbSvc(false)' in your macro.\n"
+       << "!! Please delete it.  Abort for now." << endl;
+  exit(1);
 }
 
 void GeomSvc::initPlaneDbSvc() {
   using namespace std;
-  recoConsts* rc = recoConsts::instance();
-  int run = rc->get_IntFlag("RUNNUMBER");
-  if (run == 0) {
-    run = 1;
-    rc->set_IntFlag("RUNNUMBER", run);
-  }
+  int run = recoConsts::instance()->get_IntFlag("RUNNUMBER");
   cout << "GeomSvc:  Load the plane geometry info via DbSvc for run = " << run << "." << endl;
 
   GeomParamPlane* geom = new GeomParamPlane();
@@ -955,6 +802,51 @@ double GeomSvc::getDCA(int detectorID, int elementID, double tx, double ty, doub
     TVector3 norm = trkdir.Cross(wiredir);
     norm.SetMag(1.);
     return (ep1 - trkp0).Dot(norm);
+}
+
+/// Load parameters used in the online-alignment mode.
+/**
+ * The major part of this function is not implemented yet because we are 
+ * not sure if we store the alignment parameters in DB table.  We might 
+ * use the text file ("align_mille.txt") during the online-alignment mode.
+ */
+void GeomSvc::loadOnlineAlignment(const std::string& alignmentFile_mille)
+{
+  loadMilleAlignment(alignmentFile_mille);    //final chance of overwrite resolution numbers in online mode
+
+  //TSQLServer* con = TSQLServer::Connect(rc->get_CharFlag("MySQLURL").c_str(), "seaguest","qqbar2mu+mu-");
+  //char query[300];
+  //const char* buf_offsets = "SELECT detectorName,deltaX,deltaY,deltaZ,rotateAboutZ FROM %s.PlaneOffsets WHERE"
+  //  " detectorName LIKE 'D%%' OR detectorName LIKE 'H__' OR detectorName LIKE 'H____' OR detectorName LIKE 'P____'";
+  //sprintf(query, buf_offsets, rc->get_CharFlag("Geometry").c_str());
+  //TSQLResult* res = con->Query(query);
+  //unsigned int nRows = res->GetRowCount();
+  //if(nRows >= nChamberPlanes) cout << "GeomSvc: loaded chamber alignment parameters from database: " << rc->get_CharFlag("Geometry") << endl;
+  //for(unsigned int i = 0; i < nRows; ++i)
+  //{
+  //  TSQLRow* row = res->Next();
+  //  string detectorName(row->GetField(0));
+  //  toLocalDetectorName(detectorName, dummy);
+  //  
+  //  int detectorID = map_detectorID[detectorName];
+  //  if(detectorID > nChamberPlanes) // ?? WTF?
+  //  {
+  //    delete row;
+  //    continue;
+  //  }
+  //  
+  //  planes[detectorID].deltaX = atof(row->GetField(1));
+  //  planes[detectorID].deltaY = atof(row->GetField(2));
+  //  planes[detectorID].deltaZ = atof(row->GetField(3));
+  //  planes[detectorID].rotZ = atof(row->GetField(4));
+  //  
+  //  planes[detectorID].update();
+  //  planes[detectorID].deltaW = planes[detectorID].getW(planes[detectorID].deltaX, planes[detectorID].deltaY);
+  //  
+  //  delete row;
+  //}
+  //delete res;
+  //delete con;
 }
 
 void GeomSvc::loadAlignment(const std::string& alignmentFile_chamber, const std::string& alignmentFile_hodo, const std::string& alignmentFile_prop)

--- a/packages/geom_svc/GeomSvc.h
+++ b/packages/geom_svc/GeomSvc.h
@@ -139,6 +139,7 @@ public:
     void initPlaneDbSvc();
     void initWireLUT();
     void loadCalibration(const std::string& calibrateFile);
+    void loadOnlineAlignment(const std::string& alignmentFile_mille);
     void loadAlignment(const std::string& alignmentFile_chamber, const std::string& alignmentFile_hodo, const std::string& alignmentFile_prop);
     void loadMilleAlignment(const std::string& alignmentFile_mille);
 

--- a/packages/geom_svc/macros/UploadCalibParam.C
+++ b/packages/geom_svc/macros/UploadCalibParam.C
@@ -9,7 +9,6 @@ R__LOAD_LIBRARY(geom_svc)
 
 int UploadCalibParam(const std::string type="xt_curve", const std::string map_id="e906run28740")
 {
-  gSystem->Load("libgeom_svc.so");
   CalibParamBase* map;
   if      (type == "xt_curve"     ) map = new CalibParamXT();
   else if (type == "intime_taiwan") map = new CalibParamInTimeTaiwan();
@@ -29,7 +28,6 @@ int UploadCalibParam(const std::string type="xt_curve", const std::string map_id
 
 int CheckCalibParam(const std::string type="xt_curve", const int run=25000)
 {
-  gSystem->Load("libgeom_svc.so");
   CalibParamBase* map;
   if      (type == "xt_curve"     ) map = new CalibParamXT();
   else if (type == "intime_taiwan") map = new CalibParamInTimeTaiwan();

--- a/packages/geom_svc/macros/UploadChanMap.C
+++ b/packages/geom_svc/macros/UploadChanMap.C
@@ -9,7 +9,6 @@ R__LOAD_LIBRARY(geom_svc)
 
 int UploadChanMap(const std::string type="taiwan", const std::string map_id="2019091301")
 {
-  gSystem->Load("libgeom_svc.so");
   ChanMapBase* map;
   if      (type == "taiwan") map = new ChanMapTaiwan();
   else if (type == "v1495" ) map = new ChanMapV1495 ();
@@ -29,7 +28,6 @@ int UploadChanMap(const std::string type="taiwan", const std::string map_id="201
 
 int CheckChanMap(const std::string type="taiwan", const int run=25000)
 {
-  gSystem->Load("libgeom_svc.so");
   ChanMapBase* map;
   if      (type == "taiwan") map = new ChanMapTaiwan();
   else if (type == "v1495" ) map = new ChanMapV1495 ();
@@ -48,7 +46,6 @@ int CheckChanMap(const std::string type="taiwan", const int run=25000)
 /// Test function to make a channel mapping by hand.
 int MakeChanMap()
 {
-  gSystem->Load("libgeom_svc.so");
   ChanMapTaiwan map;
 
   /// roc, board chan, det, ele

--- a/packages/geom_svc/macros/UploadGeomParam.C
+++ b/packages/geom_svc/macros/UploadGeomParam.C
@@ -9,7 +9,6 @@ R__LOAD_LIBRARY(geom_svc)
 
 int UploadGeomParam(const std::string map_id="G9_run5_2")
 {
-  gSystem->Load("geom_svc.so");
   GeomParamPlane map;
   map.SetMapIDbyFile(map_id);
   map.ReadFromFile();
@@ -22,7 +21,6 @@ int UploadGeomParam(const std::string map_id="G9_run5_2")
 
 int CheckGeomParam(const int run=25000)
 {
-  gSystem->Load("libgeom_svc.so");
   GeomParamPlane map;
   map.SetMapIDbyDB(run);
   map.ReadFromDB();


### PR DESCRIPTION
This PR makes the geometry info switchable.  I needed this switch when confirming that the track position dependence of the sagitta ratio observed by Dinupa was caused by the plane tilt angle.  It will be needed when we have multiple versions of the geometry info in the future.  The default geometry hasn't changed.

I first added three constants to `recoConsts`; `RUNNUMBER`, `DB_SERVER` and `DB_USER`.  I then modified `DbSvc`, which now uses `DB_SERVER` and `DB_USER` by default to select the server and the user of DB.  I also modified `GeomSvc` so that `initPlaneDbSvc()` now reads a run number from `RUNNUMBER` and initializes the plane position for the run (via `GeomParamPlane`).

The plane position per run range is given in `e1039-resource/geom/plane/run_range.tsv`.  It has not changed for the default run number (i.e. `G9_run5_2` for RUNNUMBER = 1).  An ideal plane position (which has no plane tilt angle) was newly created for runs 90000-99999.  Thus user can select the ideal geometry by adding the following lines to `Fun4Sim.C` for example;
```
  recoConsts *rc = recoConsts::instance();
  rc->init(90000); // dummy run number for zero-plane-angle geometry
  rc->set_BoolFlag("IdealGeom", true);
```
