### PR TITLE
Simulation constants and chamber realization

### DIFF
--- a/framework/phool/PHFlag.cc
+++ b/framework/phool/PHFlag.cc
@@ -358,33 +358,33 @@ void PHFlag::WriteToFile(const string &name)
   map<string, int>::const_iterator intiter;
   for (intiter = intflag.begin(); intiter != intflag.end(); ++intiter)
   {
-    outFile << "I" << intiter->first << "\t" << intiter->second << endl;
+    outFile << "I\t" << intiter->first << "\t" << intiter->second << endl;
   }
 
   map<string, float>::const_iterator floatiter;
   for (floatiter = floatflag.begin(); floatiter != floatflag.end(); ++floatiter)
   {
-    outFile << "F" << floatiter->first << "\t" << floatiter->second << endl;
+    outFile << "F\t" << floatiter->first << "\t" << floatiter->second << endl;
   }
 
   int oldprecision = outFile.precision(15);
   map<string, double>::const_iterator doubleiter;
   for (doubleiter = doubleflag.begin(); doubleiter != doubleflag.end(); ++doubleiter)
   {
-    outFile << "D" << doubleiter->first << "\t" << doubleiter->second << endl;
+    outFile << "D\t" << doubleiter->first << "\t" << doubleiter->second << endl;
   }
   outFile.precision(oldprecision);
 
   map<string, string>::const_iterator chariter;
   for (chariter = charflag.begin(); chariter != charflag.end(); ++chariter)
   {
-    outFile << "C" << chariter->first << "\t" << chariter->second << endl;
+    outFile << "C\t" << chariter->first << "\t" << chariter->second << endl;
   }
 
   map<string, bool>::const_iterator booliter;
   for (booliter = boolflag.begin(); booliter != boolflag.end(); ++booliter)
   {
-    outFile << "B" << booliter->first << "\t" << booliter->second << endl;
+    outFile << "B\t" << booliter->first << "\t" << booliter->second << endl;
   }
 
   outFile.close();

--- a/generators/PHPythia8/PHPythia8.C
+++ b/generators/PHPythia8/PHPythia8.C
@@ -7,6 +7,7 @@
 #include <phhepmc/PHHepMCGenEventMap.h>
 
 #include <fun4all/Fun4AllReturnCodes.h>
+#include <phool/recoConsts.h>
 #include <phool/PHCompositeNode.h>
 #include <phool/PHIODataNode.h>
 #include <phool/PHRandomSeed.h>
@@ -110,6 +111,8 @@ int PHPythia8::End(PHCompositeNode *topNode)
 {
   if (verbosity >= VERBOSITY_MORE) cout << "PHPythia8::End - I'm here!" << endl;
 
+  recoConsts::instance()->set_IntFlag("PYTHIA8_EVENT_COUNT", _eventcount);
+
   if (verbosity >= VERBOSITY_SOME)
   {
     //-* dump out closing info (cross-sections, etc)
@@ -154,6 +157,8 @@ int PHPythia8::read_config(const char *cfg_file)
   }
 
   _pythia->readFile(_configFile.c_str());
+
+  recoConsts::instance()->set_CharFlag("PYTHIA8_CONFIG_FILE", _configFile);
 
   return Fun4AllReturnCodes::EVENT_OK;
 }

--- a/packages/dptrigger/DPTriggerAnalyzer.cxx
+++ b/packages/dptrigger/DPTriggerAnalyzer.cxx
@@ -5,6 +5,7 @@
 #include <geom_svc/GeomSvc.h>
 #include <fun4all/Fun4AllBase.h>
 #include <fun4all/Fun4AllReturnCodes.h>
+#include <phool/recoConsts.h>
 #include <phool/PHNodeIterator.h>
 #include <phool/PHCompositeNode.h>
 #include <phool/PHIODataNode.h>
@@ -139,6 +140,7 @@ int DPTriggerAnalyzer::Init(PHCompositeNode *topNode)
   string line = "";
   std::ifstream fin(gSystem->ExpandPathName(_road_set_file_name.c_str()), std::ifstream::in);
   if (fin.is_open()) {
+    recoConsts::instance()->set_CharFlag("TRIGGER_EMU_L1", _road_set_file_name);
     while (getline(fin, line)) {
       stringstream ss(line);
 

--- a/packages/geom_svc/CMakeLists.txt
+++ b/packages/geom_svc/CMakeLists.txt
@@ -35,7 +35,7 @@ execute_process(COMMAND root-config --libs   OUTPUT_VARIABLE ROOT_LINK    OUTPUT
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${ROOT_CFLAGS}")
 set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS}")
 add_library(geom_svc SHARED ${sources} ${dicts})
-target_link_libraries(geom_svc -ldb_svc ${ROOT_LINK})
+target_link_libraries(geom_svc -ldb_svc -lphool ${ROOT_LINK})
 
 message(${CMAKE_PROJECT_NAME} " will be installed to " ${CMAKE_INSTALL_PREFIX})
 

--- a/packages/geom_svc/CalibParamXT.cc
+++ b/packages/geom_svc/CalibParamXT.cc
@@ -21,6 +21,8 @@ CalibParamXT::~CalibParamXT()
 {
   for (Map_t::iterator it = m_map_t2x .begin(); it != m_map_t2x .end(); it++) delete it->second;
   for (Map_t::iterator it = m_map_t2dx.begin(); it != m_map_t2dx.end(); it++) delete it->second;
+  for (Map_t::iterator it = m_map_x2t .begin(); it != m_map_x2t .end(); it++) delete it->second;
+  for (Map_t::iterator it = m_map_x2dt.begin(); it != m_map_x2dt.end(); it++) delete it->second;
 }
 
 int CalibParamXT::ReadFileCont(LineList& lines)
@@ -31,9 +33,10 @@ int CalibParamXT::ReadFileCont(LineList& lines)
     iss.clear(); // clear any error flags
     iss.str(*it);
     string det;
-    double t, x, dx;
+    double t, x, dt, dx;
     if (! (iss >> det >> t >> x >> dx)) continue;
-    Add(det, t, x, dx);
+    dt = dx * t / x; // Temporary solution!
+    Add(det, t, x, dt, dx);
     nn++;
   }
   return nn;
@@ -61,7 +64,8 @@ void CalibParamXT::ReadDbTable(DbSvc& db)
     double t        = stmt->GetDouble(2);
     double x        = stmt->GetDouble(3);
     double dx       = stmt->GetDouble(4);
-    Add(det_name, det, t, x, dx);
+    double dt = dx * t / x; // Temporary solution!
+    Add(det_name, det, t, x, dt, dx);
   }
   delete stmt;
 }
@@ -91,15 +95,15 @@ void CalibParamXT::WriteDbTable(DbSvc& db)
 
 void CalibParamXT::Add(
   const std::string det,
-  const double t, const double x, const double dx)
+  const double t, const double x, const double dt, const double dx)
 {
   /// The X-T curve of the prop tubes is given per plane pair in the TSV file (at present), 
   /// namely P1H, P1V, P2V and P2H.  Since CalibParamXT needs one X-T curve per plane,
   /// two X-T curves are being made from one input (ex. P1H1f & P1H1b from P1H).
   /// In the future, the X-T curve is expected to be given per plane, like the drift chamber.
   if (det[0] == 'P' && det.length() == 3) {
-    Add(det + "1f", t, x, dx);
-    Add(det + "1b", t, x, dx);
+    Add(det + "1f", t, x, dt, dx);
+    Add(det + "1b", t, x, dt, dx);
     return;
   }
 
@@ -109,7 +113,7 @@ void CalibParamXT::Add(
   int    ele_new = ele;
   geom->toLocalDetectorName(det_new, ele_new);
   int det_id = geom->getDetectorID(det_new);
-  Add(det, det_id, t, x, dx);
+  Add(det, det_id, t, x, dt, dx);
 
   //if (ele_new != ele) {
   //  cout << "!WARNING!  CalibParamXT::Add():  The GeomSvc conversion changed element ID unexpectedly:\n"
@@ -121,31 +125,47 @@ void CalibParamXT::Add(
 
 void CalibParamXT::Add(
   const std::string det_name, const short det_id,
-  const double t, const double x, const double dx)
+  const double t, const double x, const double dt, const double dx)
 {
   ParamItem item;
   item.det_name = det_name;
   item.det      = det_id;
   item.t        = t;
   item.x        = x;
+  item.dt       = dt;
   item.dx       = dx;
   m_list.push_back(item);
   TGraphErrors* gr_t2x;
   TGraphErrors* gr_t2dx;
+  TGraphErrors* gr_x2t;
+  TGraphErrors* gr_x2dt;
   if (m_map_t2x.find(det_id) == m_map_t2x.end()) {
     m_map_t2x [det_id] = gr_t2x  = new TGraphErrors();
     m_map_t2dx[det_id] = gr_t2dx = new TGraphErrors();
+    m_map_x2t [det_id] = gr_x2t  = new TGraphErrors();
+    m_map_x2dt[det_id] = gr_x2dt = new TGraphErrors();
   } else {
     gr_t2x  = m_map_t2x [det_id];
     gr_t2dx = m_map_t2dx[det_id];
+    gr_x2t  = m_map_x2t [det_id];
+    gr_x2dt = m_map_x2dt[det_id];
   }
   int n_pt = gr_t2x->GetN();
   gr_t2x ->SetPoint(n_pt, t, x);
   gr_t2dx->SetPoint(n_pt, t, dx);
   gr_t2x ->SetPointError(n_pt, 0, dx);
+  gr_x2t ->SetPoint(n_pt, x, t);
+  gr_x2dt->SetPoint(n_pt, x, dt);
+  gr_x2t ->SetPointError(n_pt, 0, dt);
 }
 
+/// To be obsolete.  Use `FindT2X()`.
 bool CalibParamXT::Find(const short det, TGraphErrors*& gr_t2x, TGraphErrors*& gr_t2dx)
+{
+  return FindT2X(det, gr_t2x, gr_t2dx);
+}
+
+bool CalibParamXT::FindT2X(const short det, TGraphErrors*& gr_t2x, TGraphErrors*& gr_t2dx)
 {
   if (m_map_t2x.find(det) != m_map_t2x.end()) {
     gr_t2x  = m_map_t2x [det];
@@ -153,6 +173,17 @@ bool CalibParamXT::Find(const short det, TGraphErrors*& gr_t2x, TGraphErrors*& g
     return true;
   }
   gr_t2x = gr_t2dx = 0;
+  return false;
+}
+
+bool CalibParamXT::FindX2T(const short det, TGraphErrors*& gr_x2t, TGraphErrors*& gr_x2dt)
+{
+  if (m_map_x2t.find(det) != m_map_x2t.end()) {
+    gr_x2t  = m_map_x2t [det];
+    gr_x2dt = m_map_x2dt[det];
+    return true;
+  }
+  gr_x2t = gr_x2dt = 0;
   return false;
 }
 

--- a/packages/geom_svc/CalibParamXT.h
+++ b/packages/geom_svc/CalibParamXT.h
@@ -3,12 +3,19 @@
 #include "RunParamBase.h"
 class TGraphErrors;
 
+/// Calibration parameter for chamber X-T relation.
+/**
+ * The present parameter set doesn't include "dt".
+ * Therefore "dt" is set to "dx * t / x" in this class temporarily.
+ * The next parameter set must include "dt".
+ */
 class CalibParamXT : public CalibParamBase {
   struct ParamItem {
     std::string det_name;
     short  det;
     double t;
     double x;
+    double dt;
     double dx;
   };
   typedef std::vector<ParamItem> List_t;
@@ -17,15 +24,19 @@ class CalibParamXT : public CalibParamBase {
   typedef std::map<short, TGraphErrors*> Map_t;
   Map_t m_map_t2x;
   Map_t m_map_t2dx;
+  Map_t m_map_x2t;
+  Map_t m_map_x2dt;
 
  public:
   CalibParamXT();
   virtual ~CalibParamXT();
 
-  void Add(const std::string det     ,                     const double t, const double x, const double dx);
-  void Add(const std::string det_name, const short det_id, const double t, const double x, const double dx);
+  void Add(const std::string det     ,                     const double t, const double x, const double dt, const double dx);
+  void Add(const std::string det_name, const short det_id, const double t, const double x, const double dt, const double dx);
 
-  bool Find(const short det, TGraphErrors*& gr_t2x, TGraphErrors*& gr_t2dx);
+  bool Find   (const short det, TGraphErrors*& gr_t2x, TGraphErrors*& gr_t2dx);
+  bool FindT2X(const short det, TGraphErrors*& gr_t2x, TGraphErrors*& gr_t2dx);
+  bool FindX2T(const short det, TGraphErrors*& gr_x2t, TGraphErrors*& gr_x2dt);
   void Print(std::ostream& os);
 
  protected:

--- a/packages/geom_svc/GeomSvc.cxx
+++ b/packages/geom_svc/GeomSvc.cxx
@@ -977,8 +977,8 @@ void GeomSvc::loadAlignment(const std::string& alignmentFile_chamber, const std:
         for(int i = 1; i <= nChamberPlanes; i += 2)
         {
             double resol = planes[i].resolution > planes[i+1].resolution ? planes[i].resolution : planes[i+1].resolution;
-            planes[i].resolution = resol;
-            planes[i].resolution = resol;
+            planes[i  ].resolution = resol;
+            planes[i+1].resolution = resol;
         }
 
         cout << "GeomSvc: loaded chamber alignment parameters from " << alignmentFile_chamber << endl;

--- a/simulation/g4detectors/CMakeLists.txt
+++ b/simulation/g4detectors/CMakeLists.txt
@@ -121,6 +121,8 @@ add_library(g4detectors SHARED
   PHG4BlockSubsystem_Dict.cc
   ${PROJECT_SOURCE_DIR}/SQDigitizer.cc
   SQDigitizer_Dict.cc
+  ${PROJECT_SOURCE_DIR}/SQChamberRealization.cc
+  SQChamberRealization_Dict.cc
   ${PROJECT_SOURCE_DIR}/PHG4ConeDetector.cc
   ${PROJECT_SOURCE_DIR}/PHG4ConeRegionSteppingAction.cc
   ${PROJECT_SOURCE_DIR}/PHG4ConeSteppingAction.cc
@@ -226,6 +228,7 @@ file(GLOB dist_headers
   PHG4ParametersContainer.h
   PHG4StepStatusDecode.h
   SQDigitizer.h
+  SQChamberRealization.h
 )
 
 install(FILES ${dist_headers} DESTINATION ${CMAKE_INSTALL_PREFIX}/include/${CMAKE_PROJECT_NAME}/)

--- a/simulation/g4detectors/SQChamberRealization.cc
+++ b/simulation/g4detectors/SQChamberRealization.cc
@@ -1,0 +1,134 @@
+#include <TRandom.h>
+#include <TGraphErrors.h>
+#include <interface_main/SQRun.h>
+#include <interface_main/SQHitVector.h>
+#include <fun4all/Fun4AllReturnCodes.h>
+#include <phool/PHNodeIterator.h>
+#include <phool/PHCompositeNode.h>
+#include <phool/PHIODataNode.h>
+#include <phool/getClass.h>
+#include <phool/recoConsts.h>
+#include <geom_svc/GeomSvc.h>
+#include <geom_svc/CalibParamXT.h>
+#include <geom_svc/CalibParamInTimeTaiwan.h>
+#include "SQChamberRealization.h"
+using namespace std;
+
+SQChamberRealization::SQChamberRealization(const std::string& name)
+  : SubsysReco(name)
+  , m_eff_d0 (1.)
+  , m_eff_d1 (1.)
+  , m_eff_d2 (1.)
+  , m_eff_d3p(1.)
+  , m_eff_d3m(1.)
+  , m_eff_p1x(1.)
+  , m_eff_p1y(1.)
+  , m_eff_p2x(1.)
+  , m_eff_p2y(1.)
+  , m_cal_xt (0)
+  , m_cal_int(0)
+  , m_run    (0)
+  , m_hit_vec(0)
+{
+  ;
+}
+
+SQChamberRealization::~SQChamberRealization() 
+{
+  if (m_cal_xt ) delete m_cal_xt ;
+  if (m_cal_int) delete m_cal_int;
+}
+
+int SQChamberRealization::Init(PHCompositeNode *topNode)
+{
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int SQChamberRealization::InitRun(PHCompositeNode* topNode) 
+{
+  PHNodeIterator iter(topNode);
+  m_run = findNode::getClass<SQRun>(topNode, "SQRun");
+  if (!m_run) {
+    cerr << Name() << "SQRun node missing.  Abort." << endl;
+    return Fun4AllReturnCodes::ABORTRUN;
+  }
+  m_hit_vec = findNode::getClass<SQHitVector>(topNode, "SQHitVector");
+  if (!m_hit_vec) {
+    cerr << Name() << "SQHitVector node missing.  Abort." << endl;
+    return Fun4AllReturnCodes::ABORTRUN;
+  }
+
+  m_cal_xt = new CalibParamXT();
+  m_cal_xt->SetMapIDbyDB(m_run->get_run_id());
+  m_cal_xt->ReadFromDB();
+  recoConsts::instance()->set_CharFlag("CHAM_REAL_XT", m_cal_xt->GetMapID());
+
+  m_cal_int = new CalibParamInTimeTaiwan();
+  m_cal_int->SetMapIDbyDB(m_run->get_run_id());
+  m_cal_int->ReadFromDB();
+  recoConsts::instance()->set_CharFlag("CHAM_REAL_INTIME", m_cal_int->GetMapID());
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int SQChamberRealization::process_event(PHCompositeNode* topNode) 
+{
+  for (SQHitVector::Iter it = m_hit_vec->begin(); it != m_hit_vec->end(); it++) {
+    SQHit* hit = *it;
+    int    det_id   = hit->get_detector_id();
+    string det_name = GeomSvc::instance()->getDetectorName(det_id);
+
+    bool is_eff = true;
+    if      (det_name.substr(0, 2) == "D0" ) is_eff = (gRandom->Rndm() < m_eff_d0 );
+    else if (det_name.substr(0, 2) == "D1" ) is_eff = (gRandom->Rndm() < m_eff_d1 );
+    else if (det_name.substr(0, 2) == "D2" ) is_eff = (gRandom->Rndm() < m_eff_d2 );
+    else if (det_name.substr(0, 3) == "D3p") is_eff = (gRandom->Rndm() < m_eff_d3p);
+    else if (det_name.substr(0, 3) == "P1X") is_eff = (gRandom->Rndm() < m_eff_p1x);
+    else if (det_name.substr(0, 3) == "P1Y") is_eff = (gRandom->Rndm() < m_eff_p1y);
+    else if (det_name.substr(0, 3) == "P2X") is_eff = (gRandom->Rndm() < m_eff_p2x);
+    else if (det_name.substr(0, 3) == "P2Y") is_eff = (gRandom->Rndm() < m_eff_p2y);
+    hit->set_in_time(is_eff); // Temporary solution!!
+
+    TGraphErrors* gr_x2t;
+    TGraphErrors* gr_x2dt;
+    if (m_cal_xt->FindX2T(det_id, gr_x2t, gr_x2dt)) {
+      int    ele_id  = hit->get_element_id();
+      double dist    = hit->get_drift_distance();
+      double mean_t  = gr_x2t ->Eval(dist);
+      double width_t = gr_x2dt->Eval(dist);
+      double drift_time = -1;
+      while (drift_time < 0) drift_time = gRandom->Gaus(mean_t, width_t);
+
+      double t0 = 0;
+      double center_int, width_int;
+      if (m_cal_int->Find(det_id, ele_id, center_int, width_int)) t0 = center_int + width_int / 2;
+      float tdc_time = t0 - drift_time;
+
+      hit->set_tdc_time(tdc_time);
+    }
+  }
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int SQChamberRealization::End(PHCompositeNode *topNode)
+{
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+void SQChamberRealization::SetChamEff(const double eff_d0, const double eff_d1, const double eff_d2, const double eff_d3p, const double eff_d3m)
+{
+  m_eff_d0  = eff_d0;
+  m_eff_d1  = eff_d1;
+  m_eff_d2  = eff_d2;
+  m_eff_d3p = eff_d3p;
+  m_eff_d3m = eff_d3m;
+}
+
+void SQChamberRealization::SetPropTubeEff(const double eff_p1x, const double eff_p1y, const double eff_p2x, const double eff_p2y)
+{
+  m_eff_p1x = eff_p1x;
+  m_eff_p1y = eff_p1y;
+  m_eff_p2x = eff_p2x;
+  m_eff_p2y = eff_p2y;
+}

--- a/simulation/g4detectors/SQChamberRealization.h
+++ b/simulation/g4detectors/SQChamberRealization.h
@@ -1,0 +1,52 @@
+#ifndef SQChamberRealization_H
+#define SQChamberRealization_H
+#include <fun4all/SubsysReco.h>
+class CalibParamXT;
+class CalibParamInTimeTaiwan;
+class SQRun;
+class SQHitVector;
+
+/// SubsysReco module to do the detector realization for chamber and prop tube.
+/**
+ * This module simulates the detection efficiency and the time/distance resolution.
+ * 
+ * The in-time flag of one SQHit object is set to 'false' when the hit is regarded as inefficient.
+ * We might better have another flag like 'is_efficient' in future.
+ *
+ * The drift distance of one SQHit object is converted to its TDC time,
+ * by using the X-T relation and the T0 value given by CalibParamXT and CalibParamInTimeTaiwan.
+ * User has to use (i.e. register) `CalibXT` to derive the (realistic) drift distance from the TDC time,
+ * because this module does _not_ modify the drift distance itself.
+ */
+class SQChamberRealization: public SubsysReco
+{
+public:
+  SQChamberRealization(const std::string& name = "SQChamberRealization");
+  virtual ~SQChamberRealization();
+
+  int Init(PHCompositeNode* topNode);
+  int InitRun(PHCompositeNode* topNode);
+  int process_event(PHCompositeNode* topNode);
+  int End(PHCompositeNode* topNode);
+
+  void SetChamEff(const double eff_d0, const double eff_d1, const double eff_d2, const double eff_d3p, const double eff_d3m);
+  void SetPropTubeEff(const double eff_p1x, const double eff_p1y, const double eff_p2x, const double eff_p2y);
+
+private:
+  double m_eff_d0;
+  double m_eff_d1;
+  double m_eff_d2;
+  double m_eff_d3p;
+  double m_eff_d3m;
+  double m_eff_p1x;
+  double m_eff_p1y;
+  double m_eff_p2x;
+  double m_eff_p2y;
+  CalibParamXT* m_cal_xt;
+  CalibParamInTimeTaiwan* m_cal_int;
+
+  SQRun*       m_run;
+  SQHitVector* m_hit_vec;
+};
+
+#endif

--- a/simulation/g4detectors/SQChamberRealizationLinkDef.h
+++ b/simulation/g4detectors/SQChamberRealizationLinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class SQChamberRealization-!;
+
+#endif /* __CINT__ */

--- a/simulation/g4detectors/SQDigitizer.cc
+++ b/simulation/g4detectors/SQDigitizer.cc
@@ -47,8 +47,6 @@ int SQDigitizer::Init(PHCompositeNode *topNode)
     detIDByName[detName] = i;
   }
 
-  //TODO: Load the detector realization setup
-
   return Fun4AllReturnCodes::EVENT_OK;
 }
 #endif
@@ -287,10 +285,4 @@ void SQDigitizer::digitizeEMCal(const std::string& detName)
     iter->second.set_hit_id(digits->size());
     digits->push_back(&(iter->second));
   }
-}
-
-bool SQDigitizer::realize(SQHit& dHit)
-{
-  //TODO: implement efficiency and calibration smearing
-  return true;
 }

--- a/simulation/g4detectors/SQDigitizer.h
+++ b/simulation/g4detectors/SQDigitizer.h
@@ -42,9 +42,6 @@ public:
   //!digitize the emcal hits
   void digitizeEMCal(const std::string& detName);
 
-  //!realization process 
-  bool realize(SQHit& dHit);
-
   //!Get the trigger level by detectorID
   int getTriggerLv(int detectorID) { return p_geomSvc->getTriggerLv(detectorID); }
 

--- a/simulation/g4main/PHG4TruthSubsystem.cc
+++ b/simulation/g4main/PHG4TruthSubsystem.cc
@@ -11,8 +11,10 @@
 
 #include "PHG4InEvent.h"
 
+#include <interface_main/SQRun_v1.h>
 #include <fun4all/Fun4AllReturnCodes.h>
 #include <phool/getClass.h>
+#include <phool/recoConsts.h>
 
 #include <Geant4/G4ParticleTable.hh>
 #include <Geant4/G4ParticleDefinition.hh>
@@ -37,6 +39,26 @@ int PHG4TruthSubsystem::InitRun( PHCompositeNode* topNode )
 {
 
   PHNodeIterator iter( topNode );
+
+  PHCompositeNode* runNode = static_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "RUN"));
+  if (!runNode) {
+    runNode = new PHCompositeNode("RUN");
+    topNode->addNode(runNode);
+  }
+
+  SQRun* sqrun = findNode::getClass<SQRun>(topNode, "SQRun");
+  if (!sqrun) {
+    sqrun = new SQRun_v1();
+    runNode->addNode(new PHIODataNode<PHObject>(sqrun, "SQRun", "PHObject"));
+  }
+  recoConsts* rc = recoConsts::instance();
+  int run = rc->get_IntFlag("RUNNUMBER");
+  if (run == 0) {
+    run = 1;
+    rc->set_IntFlag("RUNNUMBER", run);
+  }
+  sqrun->set_run_id(run);
+
   PHCompositeNode *dstNode = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "DST" ));
 
   // create truth information container

--- a/simulation/g4main/PHG4TruthSubsystem.cc
+++ b/simulation/g4main/PHG4TruthSubsystem.cc
@@ -51,13 +51,8 @@ int PHG4TruthSubsystem::InitRun( PHCompositeNode* topNode )
     sqrun = new SQRun_v1();
     runNode->addNode(new PHIODataNode<PHObject>(sqrun, "SQRun", "PHObject"));
   }
-  recoConsts* rc = recoConsts::instance();
-  int run = rc->get_IntFlag("RUNNUMBER");
-  if (run == 0) {
-    run = 1;
-    rc->set_IntFlag("RUNNUMBER", run);
-  }
-  sqrun->set_run_id(run);
+  int run_id = recoConsts::instance()->get_IntFlag("RUNNUMBER");
+  sqrun->set_run_id(run_id);
 
   PHCompositeNode *dstNode = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "DST" ));
 


### PR DESCRIPTION
Two topics are included in this PR.

1. Management of simulation constants.  
I'm thinking a method of properly managing all simulation parameters, as presented in DocDB 9331.  The method proposed in this PR is to simply make use of `recoConsts`.  As a demonstration, I put several lines in `PHPythia8` etc. that add parameters to `recoConsts`.  The contents of `recoConsts` are expected to be written to a TSV file at the end of `Fun4Sim.C` etc. via `rc->WriteToFile("recoConsts.tsv")`.  If you are fine with this method, I will be adding more lines in a future.

2. Implementation of chamber realization.
I made a new SubsysReco module, `SQChamberRealization`.  Here I would propose to have this module outside `SQDigitizer`, because the chamber realization is sometimes re-done with different parameters.  I added the drift-time resolution (`dt`) to the X-T parameter set (which is stored in `CalibParamXT`), since the realization needed it when computing the smeared drift time from the drift distance.  I also modified `PHG4TruthSubsystem` in order to create the SQRun node and set a run number in it, since the realization should depend on run number.  Note that the current X-T parameter set is just a copy of the last E906 one.

I confirmed that a low chamber efficiency results in a low track reconstruction rate quantitatively, using `e1039-analysis/SimChainDev/Fun4Sim.C` as follows;
```
  SQChamberRealization* cham_real = new SQChamberRealization();
  cham_real->SetChamEff(0.5, 0.5, 0.5, 0.5, 0.5);
  se->registerSubsystem(cham_real);

...

reco->set_evt_reducer_opt("o");
```



