### PR TITLE
More accurate/flexible requirement of geometric acceptance

### DIFF
--- a/packages/UtilAna/UtilDimuon.cc
+++ b/packages/UtilAna/UtilDimuon.cc
@@ -21,6 +21,7 @@ SQDimuon* UtilDimuon::FindDimuonByID(const SQDimuonVector* vec, const int id_dim
   return 0;
 }
 
+/// OBSOLETE: Use `CalcVar()` instead.
 void UtilDimuon::GetX1X2(const SQDimuon* dim, double& x1, double& x2)
 {
   const double M_P    = 0.938;
@@ -33,6 +34,7 @@ void UtilDimuon::GetX1X2(const SQDimuon* dim, double& x1, double& x2)
   x2 = (p_beam  *p_sum)/(p_beam  *p_cms);
 }
 
+/// OBSOLETE: Use `CalcVar()` instead.
 void UtilDimuon::GetX1X2(const SQDimuon* dim, float& x1, float& x2)
 {
   double x1d, x2d;
@@ -41,6 +43,7 @@ void UtilDimuon::GetX1X2(const SQDimuon* dim, float& x1, float& x2)
   x2 = x2d;
 }
 
+/// OBSOLETE: Use `CalcVar()` instead.
 double UtilDimuon::GetX1(const SQDimuon* dim)
 {
   double x1, x2;
@@ -48,6 +51,7 @@ double UtilDimuon::GetX1(const SQDimuon* dim)
   return x1;
 }
 
+/// OBSOLETE: Use `CalcVar()` instead.
 double UtilDimuon::GetX2(const SQDimuon* dim)
 {
   double x1, x2;
@@ -59,22 +63,24 @@ double UtilDimuon::GetX2(const SQDimuon* dim)
 /**
  * Typical usage:
  * @code
- *   double mass, pT, x1, x2, xF, costh, phi;
- *   UtilDimuon::CalcVar(dim, mass, pT, x1, x2, xF, costh, phi);
+ *   double mass, pT, x1, x2, xF;
+ *   UtilDimuon::CalcVar(dim, mass, pT, x1, x2, xF);
  * @endcode
- *
- * The costh and phi values are of the Collins-Soper frame.
- * Please look into this function to check the formulae used.
- * The formulae were taken from SQMCDimuon::calcVariable() on 2020-11-05.
  */
-void UtilDimuon::CalcVar(const SQDimuon* dim, double& mass, double& pT, double& x1, double& x2, double& xF, double& costh, double& phi)
+void UtilDimuon::CalcVar(const SQDimuon* dim, double& mass, double& pT, double& x1, double& x2, double& xF)
 {
-  CalcVar(dim->get_mom_pos(), dim->get_mom_neg(),
-          mass, pT, x1, x2, xF, costh, phi);
+  CalcVar(dim->get_mom_pos(), dim->get_mom_neg(), mass, pT, x1, x2, xF);
 }
 
 /// Calculate the key kinematic variables of dimuon.
-void UtilDimuon::CalcVar(const TLorentzVector& p_pos, const TLorentzVector& p_neg, double& mass, double& pT, double& x1, double& x2, double& xF, double& costh, double& phi)
+/**
+ * Typical usage:
+ * @code
+ *   double mass, pT, x1, x2, xF;
+ *   UtilDimuon::CalcVar(mom_pos, mom_neg, mass, pT, x1, x2, xF);
+ * @endcode
+ */
+void UtilDimuon::CalcVar(const TLorentzVector& p_pos, const TLorentzVector& p_neg, double& mass, double& pT, double& x1, double& x2, double& xF)
 {
   const Double_t mp = 0.938;
   const Double_t ebeam = 120.;
@@ -92,8 +98,90 @@ void UtilDimuon::CalcVar(const TLorentzVector& p_pos, const TLorentzVector& p_ne
   Double_t sqrts = p_cms.M();
   TVector3 bv_cms = p_cms.BoostVector();
   p_sum.Boost(-bv_cms);
-
   xF = 2 * p_sum.Pz() / sqrts / (1 - pow(mass,2) / s);
-  costh = 2 * (p_neg.E() * p_pos.Pz() - p_pos.E() * p_neg.Pz()) / mass / TMath::Sqrt(pow(mass,2) + pow(pT,2));
-  phi = TMath::ATan(2*TMath::Sqrt(pow(mass,2) + pow(pT,2)) / mass * (p_neg.Px()*p_pos.Py() - p_pos.Px()*p_neg.Py()) / (p_pos.Px()*p_pos.Px() - p_neg.Px()*p_neg.Px() + p_pos.Py()*p_pos.Py() - p_neg.Py()*p_neg.Py()));
 }
+
+/// OBSOLETE:  Use `CalcVar(dim, mass, pT, x1, x2, xF)` and `Lab2CollinsSoper(dim, costh, phi)` instead.
+/**
+ * Typical usage:
+ * @code
+ *   double mass, pT, x1, x2, xF, costh, phi;
+ *   UtilDimuon::CalcVar(dim, mass, pT, x1, x2, xF, costh, phi);
+ * @endcode
+ */
+void UtilDimuon::CalcVar(const SQDimuon* dim, double& mass, double& pT, double& x1, double& x2, double& xF, double& costh, double& phi)
+{
+  CalcVar(dim->get_mom_pos(), dim->get_mom_neg(), mass, pT, x1, x2, xF, costh, phi);
+}
+
+/// OBSOLETE:  Use `CalcVar(dim, mass, pT, x1, x2, xF)` and `Lab2CollinsSoper(dim, costh, phi)` instead.
+void UtilDimuon::CalcVar(const TLorentzVector& p_pos, const TLorentzVector& p_neg, double& mass, double& pT, double& x1, double& x2, double& xF, double& costh, double& phi)
+{
+  CalcVar(p_pos, p_neg, mass, pT, x1, x2, xF);
+  Lab2CollinsSoper(p_pos.Vect(), p_neg.Vect(), costh, phi);
+}
+
+/// Convert the momenta of muon pair from Lab frame to Collins-Soper frame.
+void UtilDimuon::Lab2CollinsSoper(const SQDimuon* dim, double& costh, double& phi)
+{
+  Lab2CollinsSoper(dim->get_mom_pos().Vect(), dim->get_mom_neg().Vect(), costh, phi);
+}
+
+/// Convert the momenta of muon pair from Lab frame to Collins-Soper frame.
+void UtilDimuon::Lab2CollinsSoper(const TVector3& p1, const TVector3& p2, double& costh, double& phi)
+{
+  Lab2CollinsSoper(p1.X(), p1.Y(), p1.Z(),  p2.X(), p2.Y(), p2.Z(),  costh, phi);
+}
+
+/// Convert the momenta of muon pair from Lab frame to Collins-Soper frame.
+/** 
+ * The code was written originally by Suguru Tamamushi.
+ * Only the cos(theta) and phi are returned at present.
+ */
+void UtilDimuon::Lab2CollinsSoper(const double px1, const double py1, const double pz1,
+                      const double px2, const double py2, const double pz2, double& costh, double& phi)
+{
+  const double m_mu = 0.1056;
+  TLorentzVector mom1;
+  TLorentzVector mom2;
+  mom1.SetXYZM(px1, py1, pz1, m_mu); //Momentum of muon 1 at Laboratory Frame
+  mom2.SetXYZM(px2, py2, pz2, m_mu); //Momentum of muon 2 at Laboratory Frame
+  
+  //Lorentz Boost to Hadron Rest Frame
+  const double m_p  = 0.938;
+  const double E_p  = 120.0;
+  const double p_p  = sqrt(E_p*E_p - m_p*m_p);
+  const double beta = p_p/E_p;
+  mom1.Boost(0,0,-beta);  //mom1.Pz is now boosted
+  mom2.Boost(0,0,-beta);  //mom2.Pz is now boosted
+
+  //Calculate costheta
+  TLorentzVector Q = mom1 + mom2;
+  double k1p = mom1.E() + mom1.Pz();
+  double k2p = mom2.E() + mom2.Pz();
+  double k1m = mom1.E() - mom1.Pz();
+  double k2m = mom2.E() - mom2.Pz();
+  costh = 1.0/Q.M()/sqrt(Q*Q + Q.Px()*Q.Px() + Q.Py()*Q.Py())*(k1p*k2m - k1m*k2p);
+
+  //Calculate tanphi
+  TVector3 Delta(mom1.Px() - mom2.Px(), mom1.Py() - mom2.Py(), mom1.Pz() - mom2.Pz());
+  TVector3 Q3(Q.Px(),Q.Py(),Q.Pz());
+  TVector3 PA(0, 0, p_p);
+  TVector3 R = PA.Cross(Q3);
+  TVector3 RHat = R.Unit();
+  TVector3 QT = Q3;
+  QT.SetZ(0);
+  double tanphi = sqrt(Q*Q + Q.Px()*Q.Px() + Q.Py()*Q.Py()) / Q.M() * (Delta.X()*RHat.X() + Delta.Y()*RHat.Y()) / (Delta.X()*QT.Unit().X() + Delta.Y()*QT.Unit().Y());
+
+  //Calculate Phi Quadrant
+  double sinth = sin( acos(costh) );
+  double sinphi = (Delta.X()*RHat.X() + Delta.Y()*RHat.Y())/(Q.M()*sinth);
+
+  //Calculate Phi
+  phi = atan(tanphi);
+  if      (tanphi >= 0 && sinphi >= 0) {;} // phi  = phi;}
+  else if (tanphi <  0 && sinphi >  0) {phi +=   TMath::Pi();}
+  else if (tanphi >  0 && sinphi <  0) {phi +=   TMath::Pi();}
+  else if (tanphi <  0 && sinphi <  0) {phi += 2*TMath::Pi();}
+}
+

--- a/packages/UtilAna/UtilDimuon.h
+++ b/packages/UtilAna/UtilDimuon.h
@@ -2,6 +2,7 @@
 #define _UTIL_DIMUON__H_
 class SQDimuon;
 class SQDimuonVector;
+class TVector3;
 class TLorentzVector;
 
 namespace UtilDimuon {
@@ -12,8 +13,16 @@ namespace UtilDimuon {
   double GetX1(const SQDimuon* dim);
   double GetX2(const SQDimuon* dim);
 
+  void CalcVar(const SQDimuon* dim, double& mass, double& pT, double& x1, double& x2, double& xF);
+  void CalcVar(const TLorentzVector& p_pos, const TLorentzVector& p_neg, double& mass, double& pT, double& x1, double& x2, double& xF);
+
   void CalcVar(const SQDimuon* dim, double& mass, double& pT, double& x1, double& x2, double& xF, double& costh, double& phi);
   void CalcVar(const TLorentzVector& p_pos, const TLorentzVector& p_neg, double& mass, double& pT, double& x1, double& x2, double& xF, double& costh, double& phi);
+
+  void Lab2CollinsSoper(const SQDimuon* dim, double& costh, double& phi);
+  void Lab2CollinsSoper(const TVector3& p1, const TVector3& p2, double& costh, double& phi);
+  void Lab2CollinsSoper(const double px1, const double py1, const double pz1,
+                        const double px2, const double py2, const double pz2, double& costh, double& phi);
 }
 
 #endif /* _UTIL_DIMUON__H_ */

--- a/simulation/g4dst/CMakeLists.txt
+++ b/simulation/g4dst/CMakeLists.txt
@@ -43,15 +43,3 @@ if (ROOT_VER GREATER 5)
    add_custom_target(install_pcm ALL COMMAND mkdir -p ${CMAKE_INSTALL_PREFIX}/lib COMMAND cp -up *_rdict.pcm ${CMAKE_INSTALL_PREFIX}/lib)
    add_dependencies(install_pcm g4dst)
 endif()
-
-#add_library(g4dst SHARED
-#  g4dst.C
-#)
-#
-#add_custom_command(
-#  OUTPUT g4dst.C
-#  COMMAND echo
-#  ARGS "//*** this is a generated empty file. Do not commit, do not edit" > g4dst.C
-#)
-#
-#target_link_libraries(g4dst -lphg4hit -lg4detectors_io -lphgeom_io -lphhepmc_io -lphfield_io)

--- a/simulation/g4dst/LinkDef.h
+++ b/simulation/g4dst/LinkDef.h
@@ -4,6 +4,7 @@
 #pragma link off all global;
 
 #pragma link C++ class TruthNodeMaker-!;
-#pragma link C++ class RequireParticlesInAcc-!;
+#pragma link C++ class SQGeomAcc-!;
+#pragma link C++ class SQGeomAccLoose-!;
 
 #endif

--- a/simulation/g4dst/SQGeomAcc.cc
+++ b/simulation/g4dst/SQGeomAcc.cc
@@ -1,0 +1,119 @@
+#include <iomanip>
+#include <algorithm>
+#include <interface_main/SQHitVector.h>
+#include <fun4all/Fun4AllReturnCodes.h>
+#include <phool/PHNodeIterator.h>
+#include <phool/PHIODataNode.h>
+#include <phool/getClass.h>
+#include <geom_svc/GeomSvc.h>
+#include "SQGeomAcc.h"
+using namespace std;
+
+SQGeomAcc::SQGeomAcc(const string& name)
+  : SubsysReco  (name)
+  , m_mode_muon (UNDEF_MUON)
+  , m_mode_plane(UNDEF_PLANE)
+  , m_vec_hit   (0)
+{
+  ;
+}
+
+SQGeomAcc::~SQGeomAcc()
+{
+  ;
+}
+
+int SQGeomAcc::Init(PHCompositeNode* topNode)
+{
+  if (m_mode_muon == UNDEF_MUON) {
+    cout << Name() << ": The muon mode is not selected.  Abort." << endl;
+    exit(1);
+  }
+  if (m_mode_plane == UNDEF_PLANE) {
+    cout << Name() << ": The plane mode is not selected.  Abort." << endl;
+    exit(1);
+  }
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int SQGeomAcc::InitRun(PHCompositeNode* topNode)
+{
+  m_vec_hit = findNode::getClass<SQHitVector>(topNode, "SQHitVector");
+  if(!m_vec_hit) {
+    cerr << Name() << ":  Failed at getting SQHitVector.  Abort." << endl;
+    return Fun4AllReturnCodes::ABORTEVENT;
+  }
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int SQGeomAcc::process_event(PHCompositeNode* topNode)
+{
+  /// Prepare a set of detector planes used to define the geometric acceptance.
+  /// Planes are selected by their names for convenience and convert names to IDs for process speed.
+  const vector<string> list_hodo_top_name = { "H1T", "H2T", "H3T", "H4T" };
+  const vector<string> list_hodo_bot_name = { "H1B", "H2B", "H3B", "H4B" };
+  const vector<string> list_cham_top_name = { "D0X", "D2X", "D3pX" };
+  const vector<string> list_cham_bot_name = { "D0X", "D2X", "D3mX" };
+  static vector<int> list_top_id;
+  static vector<int> list_bot_id;
+  if (list_top_id.size() == 0) { // Initialize
+    if (m_mode_plane == HODO || m_mode_plane == HODO_CHAM) { // Add hodoscope planes
+      for (unsigned int ii = 0; ii < list_hodo_top_name.size(); ii++) list_top_id.push_back(GetDetId(list_hodo_top_name[ii]));
+      for (unsigned int ii = 0; ii < list_hodo_bot_name.size(); ii++) list_bot_id.push_back(GetDetId(list_hodo_bot_name[ii]));
+    }
+    if (m_mode_plane == CHAM || m_mode_plane == HODO_CHAM) { // Add chamber planes
+      for (unsigned int ii = 0; ii < list_cham_top_name.size(); ii++) list_top_id.push_back(GetDetId(list_cham_top_name[ii]));
+      for (unsigned int ii = 0; ii < list_cham_bot_name.size(); ii++) list_bot_id.push_back(GetDetId(list_cham_bot_name[ii]));
+    }
+  }
+
+  /// Extract and arrange the contents of SQHitVector.
+  /// What we need here is a list of planes having hits per true track.
+  map< int, vector<int> > map_vec_det_id; // [track ID] -> vector<detector ID>
+  for (SQHitVector::ConstIter it = m_vec_hit->begin(); it != m_vec_hit->end(); it++) {
+    SQHit* hit = *it;
+    map_vec_det_id[ hit->get_track_id() ].push_back( hit->get_detector_id() );
+  }
+
+  /// Check if each true track has a hit on all required planes and count up such tracks
+  int n_trk_top = 0; // N of tracks that make hits on all top planes
+  int n_trk_bot = 0; // N of tracks that make hits on all bottom planes
+  for (map< int, vector<int> >::iterator it = map_vec_det_id.begin(); it != map_vec_det_id.end(); it++) {
+    if (FindDetIdSet(it->second, list_top_id)) n_trk_top++;
+    if (FindDetIdSet(it->second, list_bot_id)) n_trk_bot++;
+  }
+
+  return ( (m_mode_muon == SINGLE    &&  n_trk_top + n_trk_bot >= 1)
+        || (m_mode_muon == SINGLE_T  &&  n_trk_top             >= 1)
+        || (m_mode_muon == SINGLE_B  &&              n_trk_bot >= 1)
+        || (m_mode_muon == PAIR      &&  n_trk_top + n_trk_bot >= 2)
+        || (m_mode_muon == PAIR_TBBT &&  n_trk_top >= 1 && n_trk_bot >= 1 )
+        || (m_mode_muon == PAIR_TTBB && (n_trk_top >= 2 || n_trk_bot >= 2))
+    ) ? Fun4AllReturnCodes::EVENT_OK : Fun4AllReturnCodes::ABORTEVENT;
+}
+
+int SQGeomAcc::End(PHCompositeNode* topNode)
+{
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+/// Return the detector ID for `det_name` after assuring that the detector ID is valid (i.e. non-zero).
+int SQGeomAcc::GetDetId(const std::string& det_name)
+{
+  int det_id = GeomSvc::instance()->getDetectorID(det_name);
+  if (det_id <= 0) {
+    cout << PHWHERE << ": No detector ID found for '" << det_name << "'.  Abort." << endl;
+    exit(1);
+  }
+  return det_id;
+}
+
+/// Return 'true' if `vec_det_id_all` contains _all_ elements of `vec_det_id_want`.
+bool SQGeomAcc::FindDetIdSet(const std::vector<int>& vec_det_id_all, const std::vector<int>& vec_det_id_want)
+{
+  for (unsigned int ii = 0; ii < vec_det_id_want.size(); ii++) {
+    int det_id = vec_det_id_want[ii];
+    if (find(vec_det_id_all.begin(), vec_det_id_all.end(), det_id) == vec_det_id_all.end()) return false;
+  }
+  return true;
+}

--- a/simulation/g4dst/SQGeomAcc.h
+++ b/simulation/g4dst/SQGeomAcc.h
@@ -1,0 +1,59 @@
+#ifndef _SQ_GEOM_ACC__H_
+#define _SQ_GEOM_ACC__H_
+#include <map>
+#include <fun4all/SubsysReco.h>
+class SQHitVector;
+
+/// An SubsysReco module to skip a simulated event in which a muon or a muon pair doesn't pass through the geometric acceptance.
+/**
+ * Typical usage:
+ * ```
+ *   SQGeomAcc* geom_acc = new SQGeomAcc();
+ *   geom_acc->SetMuonMode(SQGeomAcc::PAIR_TBBT);
+ *   geom_acc->SetPlaneMode(SQGeomAcc::HODO_CHAM);
+ *   se->registerSubsystem(geom_acc);
+ * ```
+ *
+ * All the available modes are listed and explained in the sections of `MuonMode_t` and `PlaneMode_t`.
+ * This module must be registered after `SQDigitizer` since it uses SQHits.
+ */
+class SQGeomAcc: public SubsysReco {
+ public:
+  typedef enum {
+    UNDEF_MUON, 
+    SINGLE,    //< Require one muon at either top or bottom half
+    SINGLE_T,  //< Require one muon at top half
+    SINGLE_B,  //< Require one muon at bottom half
+    PAIR,      //< Require two muons at any halves
+    PAIR_TBBT, //< Require two muons at T+B or B+T halves
+    PAIR_TTBB, //< Require two muons at T+T or B+B halves
+  } MuonMode_t;
+  typedef enum {
+    UNDEF_PLANE, 
+    HODO,      //< Use the hodoscope acceptance
+    CHAM,      //< Use the chamber acceptance
+    HODO_CHAM, //< Use the hodoscope+chamber acceptance
+  } PlaneMode_t;
+
+ private:
+  MuonMode_t   m_mode_muon;
+  PlaneMode_t  m_mode_plane;
+  SQHitVector* m_vec_hit;
+
+ public:
+  SQGeomAcc(const std::string& name = "SQGeomAcc");
+  virtual ~SQGeomAcc();
+  int Init(PHCompositeNode *topNode);
+  int InitRun(PHCompositeNode *topNode);
+  int process_event(PHCompositeNode *topNode);
+  int End(PHCompositeNode *topNode);
+
+  void SetMuonMode (MuonMode_t  mode) { m_mode_muon  = mode; }
+  void SetPlaneMode(PlaneMode_t mode) { m_mode_plane = mode; }
+
+ private:
+  int  GetDetId(const std::string& det_name);
+  bool FindDetIdSet(const std::vector<int>& vec_det_id_all, const std::vector<int>& vec_det_id_want);
+};
+
+#endif /* _SQ_GEOM_ACC__H_ */

--- a/simulation/g4dst/SQGeomAcc.h
+++ b/simulation/g4dst/SQGeomAcc.h
@@ -11,11 +11,22 @@ class SQHitVector;
  *   SQGeomAcc* geom_acc = new SQGeomAcc();
  *   geom_acc->SetMuonMode(SQGeomAcc::PAIR_TBBT);
  *   geom_acc->SetPlaneMode(SQGeomAcc::HODO_CHAM);
+ *   geom_acc->SetNumOfH1EdgeElementsExcluded(4); // 0 by default
  *   se->registerSubsystem(geom_acc);
  * ```
  *
- * All the available modes are listed and explained in the sections of `MuonMode_t` and `PlaneMode_t`.
  * This module must be registered after `SQDigitizer` since it uses SQHits.
+ * All the available modes are listed and explained in the sections of `MuonMode_t` and `PlaneMode_t`.
+ * Elements at the left and right edges of H1T and H1B can be excluded via `SetNumOfH1EdgeElementsExcluded()`,
+ * where the four elements at each edge are planned to be excluded from the trigger logic.
+ *
+ * The chamber acceptance is defined by D0X, D2X, D3pX and D3mX (not Xp, U, Up, V nor Vp).
+ * This definition should be simple and sufficient in terms of the "geometric" acceptance. 
+ * D0U/V and D2U/V are identical to D0X and D2X in the plane size.
+ * U/V of D3p/m are larger than X but the X-U-V overlapping region is almost identical to X.
+ *
+ * The effect of detection/reconstruction inefficiencies is not considered by this module.
+ * It can/should be studied with other modules, like `SQChamberRealization` and `SQReco`.
  */
 class SQGeomAcc: public SubsysReco {
  public:
@@ -38,6 +49,7 @@ class SQGeomAcc: public SubsysReco {
  private:
   MuonMode_t   m_mode_muon;
   PlaneMode_t  m_mode_plane;
+  unsigned int m_n_ele_h1_ex; //< N of H1T/B elements excluded
   SQHitVector* m_vec_hit;
 
  public:
@@ -50,6 +62,7 @@ class SQGeomAcc: public SubsysReco {
 
   void SetMuonMode (MuonMode_t  mode) { m_mode_muon  = mode; }
   void SetPlaneMode(PlaneMode_t mode) { m_mode_plane = mode; }
+  void SetNumOfH1EdgeElementsExcluded(const unsigned int num) { m_n_ele_h1_ex = num; }
 
  private:
   int  GetDetId(const std::string& det_name);

--- a/simulation/g4dst/SQGeomAccLoose.cc
+++ b/simulation/g4dst/SQGeomAccLoose.cc
@@ -6,10 +6,10 @@
 #include <phool/PHNodeIterator.h>
 #include <phool/PHIODataNode.h>
 #include <phool/getClass.h>
-#include "RequireParticlesInAcc.h"
+#include "SQGeomAccLoose.h"
 using namespace std;
 
-RequireParticlesInAcc::RequireParticlesInAcc(const string& name)
+SQGeomAccLoose::SQGeomAccLoose(const string& name)
   : SubsysReco(name)
   , m_npl_per_par(4)
   , m_npar_per_evt(2)
@@ -17,24 +17,35 @@ RequireParticlesInAcc::RequireParticlesInAcc(const string& name)
   ;
 }
 
-RequireParticlesInAcc::~RequireParticlesInAcc()
+SQGeomAccLoose::~SQGeomAccLoose()
 {
   ;
 }
 
-int RequireParticlesInAcc::Init(PHCompositeNode* topNode)
+int SQGeomAccLoose::Init(PHCompositeNode* topNode)
 {
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-int RequireParticlesInAcc::InitRun(PHCompositeNode* topNode)
+int SQGeomAccLoose::InitRun(PHCompositeNode* topNode)
 {
-  int ret = GetNodes(topNode);
-  if (ret != Fun4AllReturnCodes::EVENT_OK) return ret;
+  g4hc_h1t  = findNode::getClass<PHG4HitContainer>(topNode, "G4HIT_H1T");
+  g4hc_h1b  = findNode::getClass<PHG4HitContainer>(topNode, "G4HIT_H1B");
+  g4hc_h2t  = findNode::getClass<PHG4HitContainer>(topNode, "G4HIT_H2T");
+  g4hc_h2b  = findNode::getClass<PHG4HitContainer>(topNode, "G4HIT_H2B");
+  g4hc_h3t  = findNode::getClass<PHG4HitContainer>(topNode, "G4HIT_H3T");
+  g4hc_h3b  = findNode::getClass<PHG4HitContainer>(topNode, "G4HIT_H3B");
+  g4hc_h4t  = findNode::getClass<PHG4HitContainer>(topNode, "G4HIT_H4T");
+  g4hc_h4b  = findNode::getClass<PHG4HitContainer>(topNode, "G4HIT_H4B");
+
+  if (!g4hc_h1t || !g4hc_h1b || !g4hc_h2t || !g4hc_h2b ||
+      !g4hc_h3t || !g4hc_h3b || !g4hc_h4t || !g4hc_h4b   ) {
+    return Fun4AllReturnCodes::ABORTEVENT;
+  }
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-int RequireParticlesInAcc::process_event(PHCompositeNode* topNode)
+int SQGeomAccLoose::process_event(PHCompositeNode* topNode)
 {
   /// Make lists of particle IDs
   vector<int> vec_id_h1 = ExtractParticleID(g4hc_h1t, g4hc_h1b);
@@ -58,30 +69,12 @@ int RequireParticlesInAcc::process_event(PHCompositeNode* topNode)
   return n_par_ok >= m_npar_per_evt ? Fun4AllReturnCodes::EVENT_OK : Fun4AllReturnCodes::ABORTEVENT;
 }
 
-int RequireParticlesInAcc::End(PHCompositeNode* topNode)
+int SQGeomAccLoose::End(PHCompositeNode* topNode)
 {
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-int RequireParticlesInAcc::GetNodes(PHCompositeNode* topNode)
-{
-  g4hc_h1t  = findNode::getClass<PHG4HitContainer>(topNode, "G4HIT_H1T");
-  g4hc_h1b  = findNode::getClass<PHG4HitContainer>(topNode, "G4HIT_H1B");
-  g4hc_h2t  = findNode::getClass<PHG4HitContainer>(topNode, "G4HIT_H2T");
-  g4hc_h2b  = findNode::getClass<PHG4HitContainer>(topNode, "G4HIT_H2B");
-  g4hc_h3t  = findNode::getClass<PHG4HitContainer>(topNode, "G4HIT_H3T");
-  g4hc_h3b  = findNode::getClass<PHG4HitContainer>(topNode, "G4HIT_H3B");
-  g4hc_h4t  = findNode::getClass<PHG4HitContainer>(topNode, "G4HIT_H4T");
-  g4hc_h4b  = findNode::getClass<PHG4HitContainer>(topNode, "G4HIT_H4B");
-
-  if (!g4hc_h1t || !g4hc_h1b || !g4hc_h2t || !g4hc_h2b ||
-      !g4hc_h3t || !g4hc_h3b || !g4hc_h4t || !g4hc_h4b   ) {
-    return Fun4AllReturnCodes::ABORTEVENT;
-  }
-  return Fun4AllReturnCodes::EVENT_OK;
-}
-
-void RequireParticlesInAcc::ExtractParticleID(const PHG4HitContainer* g4hc, vector<int>& vec_par_id)
+void SQGeomAccLoose::ExtractParticleID(const PHG4HitContainer* g4hc, vector<int>& vec_par_id)
 {
   PHG4HitContainer::ConstRange range = g4hc->getHits();
   for (PHG4HitContainer::ConstIterator it = range.first; it != range.second; it++) {
@@ -90,7 +83,7 @@ void RequireParticlesInAcc::ExtractParticleID(const PHG4HitContainer* g4hc, vect
   }
 }
 
-vector<int> RequireParticlesInAcc::ExtractParticleID(const PHG4HitContainer* g4hc_t, const PHG4HitContainer* g4hc_b)
+vector<int> SQGeomAccLoose::ExtractParticleID(const PHG4HitContainer* g4hc_t, const PHG4HitContainer* g4hc_b)
 {
   vector<int> vec;
   ExtractParticleID(g4hc_t, vec);
@@ -100,7 +93,7 @@ vector<int> RequireParticlesInAcc::ExtractParticleID(const PHG4HitContainer* g4h
   return vec;
 }
 
-void RequireParticlesInAcc::CountHitPlanesPerParticle(const vector<int> vec_id, map<int, int>& map_nhit)
+void SQGeomAccLoose::CountHitPlanesPerParticle(const vector<int> vec_id, map<int, int>& map_nhit)
 {
   for (vector<int>::const_iterator it = vec_id.begin(); it != vec_id.end(); it++) {
     int id = *it;

--- a/simulation/g4dst/SQGeomAccLoose.h
+++ b/simulation/g4dst/SQGeomAccLoose.h
@@ -1,11 +1,25 @@
-#ifndef _REQUIRE_PARTICLES_IN_ACC__H_
-#define _REQUIRE_PARTICLES_IN_ACC__H_
+#ifndef _SQ_GEOM_ACC_LOOSE__H_
+#define _SQ_GEOM_ACC_LOOSE__H_
 #include <map>
 #include <fun4all/SubsysReco.h>
 class PHG4HitContainer;
 
-/// An SubsysReco module to select in-acceptance events.
-class RequireParticlesInAcc: public SubsysReco {
+/// An SubsysReco module to skip a simulated event in which a muon or a muon pair doesn't pass through the _rough_ geometric acceptance.
+/**
+ * Typical usage:
+ * ```
+ *   SQGeomAccLoose* geom_acc = new SQGeomAccLoose();
+ *   geom_acc->SetNumParticlesPerEvent(2); // or 1 for single events
+ *   se->registerSubsystem(geom_acc);
+ * ```
+ *
+ * This module can/should be registered before `SQDigitizer` for better process speed.
+ * The geometric acceptance required by this module is _rough_, because 
+ *     - The chamber acceptance is not included and
+ *     - The hodoscope plane area is defined by the Geant4 volume and thus larger than its real size.
+ * You have to use `SQGeomAcc` when you need accurate and/or flexible geometric acceptance.
+ */
+class SQGeomAccLoose: public SubsysReco {
   int m_npl_per_par; //< Min number of hit planes per particle in order to regard particle good.
   int m_npar_per_evt; //< Min number of particles per event in order to regard event good.
 
@@ -19,8 +33,8 @@ class RequireParticlesInAcc: public SubsysReco {
   PHG4HitContainer *g4hc_h4b;
 
  public:
-  RequireParticlesInAcc(const std::string& name = "ACCEPTANCE");
-  virtual ~RequireParticlesInAcc();
+  SQGeomAccLoose(const std::string& name = "SQGeomAccLoose");
+  virtual ~SQGeomAccLoose();
   int Init(PHCompositeNode *topNode);
   int InitRun(PHCompositeNode *topNode);
   int process_event(PHCompositeNode *topNode);
@@ -30,10 +44,9 @@ class RequireParticlesInAcc: public SubsysReco {
   void SetNumParticlesPerEvent   (const int val) { m_npar_per_evt = val; }
 
  private:
-  int GetNodes(PHCompositeNode *topNode);
   void ExtractParticleID(const PHG4HitContainer* g4hc, std::vector<int>& vec_par_id);
   std::vector<int> ExtractParticleID(const PHG4HitContainer* g4hc_t, const PHG4HitContainer* g4hc_b);
   void CountHitPlanesPerParticle(const std::vector<int> vec_id, std::map<int, int>& map_nhit);
 };
 
-#endif /* _REQUIRE_PARTICLES_IN_ACC__H_ */
+#endif /* _SQ_GEOM_ACC_LOOSE__H_ */


### PR DESCRIPTION
This PR is to add a new SubsysReco module, `SQGeomAcc`, which is a more accurate/flexible version of `RequireParticlesInAcc`.

`SQGeomAcc` has a mode for muon condition.  The mode can be `SINGLE`, `SINGLE_T` (muon at top), `PAIR`, `PAIR_TBBT` (pair at T+B or B+T), etc.  `SQGeomAcc` also has a mode for planes that define the acceptance.  The mode can be either `HODO`, `CHAM` or `HODO_CHAM` (both).

`SQGeomAcc` uses `SQHit` to judge whether a track hits a plane, where `RequireParticlesInAcc` uses `G4Hit`.  Therefore `SQGeomAcc` is more accurate about the acceptance boundary, although it is slower since the digitization has to be always carried out.  `RequireParticlesInAcc` was renamed to `SQGeomAccLoose`.  It might be still useful since it is faster but might be deleted in future.

I modified `e1039-analysis/SimChainDev/Fun4Sim.C` to make use of `SQGeomAcc`, which is commented out by default.  I used it and confirmed that `SQReco` reconstructed one or two muons in almost all accepted events when the `HODO_CHAM` mode and the `SINGLE` or `PAIR` mode were selected.
