### PR TITLE
Absolute cross sections of J/psi and psi' by E906 legacy generator and more

### DIFF
--- a/framework/fun4all/SubsysReco.h
+++ b/framework/fun4all/SubsysReco.h
@@ -33,7 +33,7 @@ class SubsysReco: public Fun4AllBase
   /// Called at the end of each run.
   virtual int EndRun(const int /*runnumber*/) {return 0;}
 
-  /** Called during initialization.
+  /** Called during initialization, i.e. registered via Fun4AllServer::registerSubsystem().
       Typically this is where you can book histograms, and e.g.
       register them to Fun4AllServer (so they can be output to file
       using Fun4AllServer::dumpHistos() method).

--- a/generators/E906LegacyGen/SQPrimaryParticleGen.C
+++ b/generators/E906LegacyGen/SQPrimaryParticleGen.C
@@ -217,7 +217,7 @@ int SQPrimaryParticleGen::process_event(PHCompositeNode* topNode)
 }
 
 //=====================DrellYan=====================================
-/// Calculate the Drell-Yan cross section, d^2sigma/dM*dxF in nb/GeV
+/// Calculate the Drell-Yan cross section, d^2sigma/dM*dxF in pb/GeV
 double SQPrimaryParticleGen::CrossSectionDrellYan(const double mass, const double xF, const double x1, const double x2, const double pARatio)
 {
   double zOverA = pARatio;
@@ -256,8 +256,8 @@ double SQPrimaryParticleGen::CrossSectionDrellYan(const double mass, const doubl
   // hbarc_squared is in MeV*mm^2, given by Geant4.
   const double xsec_const = 8.0 / 9.0 * pi * pow(CLHEP::fine_structure_const, 2) * CLHEP::hbarc_squared;
   
-  // Cross section in nb/GeV
-  return xsec_pdf * xsec_kfactor * xsec_phsp * xsec_limit * xsec_const * (CLHEP::mm2/CLHEP::nanobarn) / (CLHEP::MeV/CLHEP::GeV);
+  // Cross section in pb/GeV
+  return xsec_pdf * xsec_kfactor * xsec_phsp * xsec_limit * xsec_const * (CLHEP::mm2/CLHEP::picobarn) / (CLHEP::MeV/CLHEP::GeV);
 }
 
 /// Calculate the Drell-Yan cross section, given only mass, xF and pARatio
@@ -276,7 +276,7 @@ double SQPrimaryParticleGen::CrossSectionDrellYan(const double mass, const doubl
   return CrossSectionDrellYan(dim_mass, dim_xF, dim_x1, dim_x2, pARatio);
 }
 
-/// Calculate the cross section for J/psi vs xF in nb.  Return "BR*sigma(xF)".
+/// Calculate the cross section for J/psi vs xF in pb.  Return "BR*sigma(xF)".
 /**
  * The cross section is parameterized as "BR*sigma = A * exp(-(xF/W)^2/2) / (sqrt(2*pi)*W)".
  * The "A" term includes the sqrt(s) dependence.
@@ -285,13 +285,13 @@ double SQPrimaryParticleGen::CrossSectionDrellYan(const double mass, const doubl
  */
 double SQPrimaryParticleGen::CrossSectionJPsi(const double xF)
 {
-  const double A = 1464*TMath::Exp(-16.66*DPGEN::mjpsi/DPGEN::sqrts); // Taken from Tab. 1 of PRD52_1307
+  const double A = 1.464e6*TMath::Exp(-16.66*DPGEN::mjpsi/DPGEN::sqrts); // Taken from Tab. 1 of PRD52_1307
   const double W = 0.2398; // Jpsi xf gaussian width. Taken from where?
   const double BR = 0.0594; // Branching ratio of J/psi -> mumu.  Seen above Fig. 4 of PRD52_1307.
   return BR * A * TMath::Exp(-xF*xF/W/W/2) / (DPGEN::sqrt2pi * W);
 }
 
-/// Calculate the cross section for psi' vs xF in nb.
+/// Calculate the cross section for psi' vs xF in pb.
 /**
  * It just returns the cross section of J/psi scaled by the psi'-to-J/psi ratio, "psipscale".
  * "psipscale" was taken from line 5 in page 1313 of PRD52_1307, 
@@ -416,13 +416,14 @@ int SQPrimaryParticleGen::read_config(const char *cfg_file)
  * Reference: G. Moerno et.al. Phys. Rev D43:2815-2836, 1991
  * 
  * The pT and theta distributions generated are affected by the value of `_DrellYanGen`.
+ * The formula of pTmaxSq is discussed in DocDB 9292.
  */
 bool SQPrimaryParticleGen::generateDimuon(double mass, double xF)
 {
     double pz = xF*(DPGEN::sqrts - mass*mass/DPGEN::sqrts)/2.;
     
-    double pTmaxSq = (DPGEN::s*DPGEN::s*(1. - xF*xF) - 2.*DPGEN::s*mass*mass + mass*mass*mass*mass)/DPGEN::s/4.;
-  
+    //double pTmaxSq = (DPGEN::s*DPGEN::s*(1. - xF*xF) - 2.*DPGEN::s*mass*mass + mass*mass*mass*mass)/DPGEN::s/4.;
+    double pTmaxSq = (DPGEN::s / 4) * (1 - mass*mass/DPGEN::s)*(1 - mass*mass/DPGEN::s) * (1 - xF*xF);
     if(pTmaxSq < 0.)
     {
       cout << PHWHERE << "pTmaxSq < 0." << endl;

--- a/generators/E906LegacyGen/SQPrimaryParticleGen.h
+++ b/generators/E906LegacyGen/SQPrimaryParticleGen.h
@@ -54,6 +54,7 @@ public:
     
     int Init(PHCompositeNode* topNode);
     int InitRun(PHCompositeNode* topNode);
+    int End(PHCompositeNode* topNode);
     int process_event(PHCompositeNode* topNode);
     //void GeneratePrimaries(G4Event* anEvent);
 
@@ -69,7 +70,7 @@ public:
     //@}
 
     //!Dimuon phase space generator
-     bool generateDimuon(double mass, double xF);
+    bool generateDimuon(double mass, double xF);
 
     //swith for the generators; Abi
     //@
@@ -78,6 +79,8 @@ public:
     void enableDrellYanGen(){_DrellYanGen = true;}
     void enableJPsiGen(){_JPsiGen = true;}
     void enablePsipGen(){_PsipGen = true;}
+
+    void set_pdfset(const std::string pdfset) { m_pdfset = pdfset; }
 
     void set_pT0DY    (const double val) { _pT0DY     = val; }
     void set_pTpowDY  (const double val) { _pTpowDY   = val; }
@@ -133,7 +136,8 @@ public:
     TGenPhaseSpace phaseGen;
 
     //!PDFs
-    LHAPDF::PDF* pdf;
+    std::string  _pdfset;
+    LHAPDF::PDF* _pdf;
 
     // Parameters (being moved from DPGEN)
     double _pT0DY;

--- a/generators/E906LegacyGen/SQPrimaryParticleGen.h
+++ b/generators/E906LegacyGen/SQPrimaryParticleGen.h
@@ -102,6 +102,8 @@ public:
 
     double CrossSectionDrellYan(const double mass, const double xF, const double pARatio);
     double CrossSectionDrellYan(const double mass, const double xF, const double x1, const double x2, const double pARatio);
+    double CrossSectionJPsi(const double xF);
+    double CrossSectionPsip(const double xF);
 
  private:
     bool _PythiaGen;

--- a/generators/E906LegacyGen/SQPrimaryParticleGen.h
+++ b/generators/E906LegacyGen/SQPrimaryParticleGen.h
@@ -80,7 +80,7 @@ public:
     void enableJPsiGen(){_JPsiGen = true;}
     void enablePsipGen(){_PsipGen = true;}
 
-    void set_pdfset(const std::string pdfset) { m_pdfset = pdfset; }
+    void set_pdfset(const std::string name) { _pdfset = name; }
 
     void set_pT0DY    (const double val) { _pT0DY     = val; }
     void set_pTpowDY  (const double val) { _pTpowDY   = val; }

--- a/generators/E906LegacyGen/macros/CheckParticleGenDrellYan.C
+++ b/generators/E906LegacyGen/macros/CheckParticleGenDrellYan.C
@@ -1,8 +1,8 @@
 R__LOAD_LIBRARY(libSQPrimaryGen)
 using namespace std;
 
-/// Macro to check the cross-section value computed by SQPrimaryParticleGen.
-int CheckParticleGen()
+/// Macro to check the cross-section value of D-Y computed by SQPrimaryParticleGen.
+int CheckParticleGenDrellYan()
 {
   const double xF       = 0.3;
   const int    n_mass   = 20;

--- a/generators/E906LegacyGen/macros/CheckParticleGenDrellYan.C
+++ b/generators/E906LegacyGen/macros/CheckParticleGenDrellYan.C
@@ -29,7 +29,7 @@ int CheckParticleGenDrellYan()
   ofs.close();
 
   ostringstream oss;
-  oss << "Drell-Yan @ x_{F} = " << xF << ";Mass (GeV);M^{3} d^{2}#sigma/dMdx_{F} (nb GeV^{2})";
+  oss << "Drell-Yan @ x_{F} = " << xF << ";Mass (GeV);M^{3} d^{2}#sigma/dMdx_{F} (pb GeV^{2})";
   gr->SetTitle(oss.str().c_str());
   gr->SetLineWidth(2);
   gr->SetMarkerStyle(8);

--- a/generators/E906LegacyGen/macros/CheckParticleGenJPsi.C
+++ b/generators/E906LegacyGen/macros/CheckParticleGenJPsi.C
@@ -1,0 +1,39 @@
+R__LOAD_LIBRARY(libSQPrimaryGen)
+using namespace std;
+
+/// Macro to check the cross-section value of J/psi computed by SQPrimaryParticleGen.
+int CheckParticleGenJPsi()
+{
+  const int    n_xF   = 11;
+  const double xF_min = -0.1;
+  const double xF_max =  0.9;
+  const char* fn_plot = "xsec_gen_jpsi.png";
+  const char* fn_text = "xsec_gen_jpsi.txt";
+
+  TGraph* gr = new TGraph();
+  ofstream ofs(fn_text);
+
+  SQPrimaryParticleGen* gen = new SQPrimaryParticleGen();
+  gen->enableJPsiGen();
+
+  for (int i_xF = 0; i_xF < n_xF; i_xF++) {
+    double xF = xF_min + (xF_max - xF_min) * i_xF / (n_xF-1);
+    double xsec = gen->CrossSectionJPsi(xF);
+    gr->SetPoint(i_xF, xF, xsec);
+    ofs << xF << "\t" << xsec << "\n";
+  }
+
+  ofs.close();
+
+  gr->SetTitle("J/#psi #rightarrow #mu^{+}#mu^{-};x_{F};BR d#sigma/dx_{F} (nb)");
+  gr->SetLineWidth(2);
+  gr->SetMarkerStyle(8);
+
+  TCanvas* c1 = new TCanvas("c1", "");
+  c1->SetLogy();
+  c1->SetGrid();
+  gr->Draw("APC");
+  c1->SaveAs(fn_plot);
+
+  return 0;
+}

--- a/generators/E906LegacyGen/macros/CheckParticleGenJPsi.C
+++ b/generators/E906LegacyGen/macros/CheckParticleGenJPsi.C
@@ -25,7 +25,7 @@ int CheckParticleGenJPsi()
 
   ofs.close();
 
-  gr->SetTitle("J/#psi #rightarrow #mu^{+}#mu^{-};x_{F};BR d#sigma/dx_{F} (nb)");
+  gr->SetTitle("J/#psi #rightarrow #mu^{+}#mu^{-};x_{F};BR d#sigma/dx_{F} (pb)");
   gr->SetLineWidth(2);
   gr->SetMarkerStyle(8);
 

--- a/generators/E906LegacyVtxGen/SQPrimaryVertexGen.C
+++ b/generators/E906LegacyVtxGen/SQPrimaryVertexGen.C
@@ -73,7 +73,6 @@ SQPrimaryVertexGen::SQPrimaryVertexGen():
   inited(false),
   topNode(nullptr),
   targetOnlyMode(false),
-  dumpOnlyMode(false),
   material_mode("All"),
   z_start(Z_MIN),
   z_stop (Z_MAX)
@@ -124,22 +123,24 @@ void SQPrimaryVertexGen::init()
   //If inited from a root file, then skip this step, so that it can be used independent of the Fun4All
   if(geoManager == nullptr) geoManager = PHGeomUtility::GetTGeoManager(topNode);
 
-  // initialize target/dump only mode
+  // initialize special material modes
   if(rc->get_BoolFlag("TARGETONLY"))
   {
-    set_targetOnlyMode();
+    rc->set_CharFlag("VTX_GEN_MATERIAL_MODE", "Target");
+    std::cout << "Warning: TARGETONLY will be obsolete soon.  Use VTX_GEN_MATERIAL_MODE instead." << std::endl;
   }
   else if(rc->get_BoolFlag("DUMPONLY"))
   {
-    set_dumpOnlyMode();
+    rc->set_CharFlag("VTX_GEN_MATERIAL_MODE", "Dump");
+    std::cout << "Warning: DUMPONLY will be obsolete soon.  Use VTX_GEN_MATERIAL_MODE instead." << std::endl;
   }
-
   if (rc->FlagExist("VTX_GEN_MATERIAL_MODE")) {
     material_mode = rc->get_CharFlag("VTX_GEN_MATERIAL_MODE");
     if (material_mode == "All") {
       ; // Do nothing
     } else if (material_mode == "Target") {
       FindMaterialRange(z_start, z_stop, "Target");
+      targetOnlyMode = true;
     } else if (material_mode == "Dump") {
       FindMaterialRange(z_start, z_stop, "fmag_body", 10, 10); // Any (x, y) outside the dump hole.
     } else if (material_mode == "TargetDumpGap") {
@@ -213,22 +214,6 @@ void SQPrimaryVertexGen::FindMaterialRange(double& z1, double& z2, const std::st
     std::cout << "SQPrimaryVertexGen::FindMaterialRange():  Failed.  Wrong material name?  Abort." << std::endl;
     exit(1);
   }
-}
-
-void SQPrimaryVertexGen::set_targetOnlyMode()
-{
-  targetOnlyMode = true;
-  //z_start = -304;
-  //z_stop  = -296;
-  FindMaterialRange(z_start, z_stop, "Target");
-}
-
-void SQPrimaryVertexGen::set_dumpOnlyMode() 
-{
-  dumpOnlyMode = true;
-  //z_start = -100.;
-  //z_stop = 503.;
-  FindMaterialRange(z_start, z_stop, "fmag_body");
 }
 
 void SQPrimaryVertexGen::fillMaterialProfile(MaterialProfile* prof, double xvtx, double yvtx)

--- a/generators/E906LegacyVtxGen/SQPrimaryVertexGen.C
+++ b/generators/E906LegacyVtxGen/SQPrimaryVertexGen.C
@@ -74,8 +74,9 @@ SQPrimaryVertexGen::SQPrimaryVertexGen():
   topNode(nullptr),
   targetOnlyMode(false),
   dumpOnlyMode(false),
-  z_start(-800.),
-  z_stop(503.)
+  material_mode("All"),
+  z_start(Z_MIN),
+  z_stop (Z_MAX)
 {
 }
 
@@ -133,6 +134,28 @@ void SQPrimaryVertexGen::init()
     set_dumpOnlyMode();
   }
 
+  if (rc->FlagExist("VTX_GEN_MATERIAL_MODE")) {
+    material_mode = rc->get_CharFlag("VTX_GEN_MATERIAL_MODE");
+    if (material_mode == "All") {
+      ; // Do nothing
+    } else if (material_mode == "Target") {
+      FindMaterialRange(z_start, z_stop, "Target");
+    } else if (material_mode == "Dump") {
+      FindMaterialRange(z_start, z_stop, "fmag_body", 10, 10); // Any (x, y) outside the dump hole.
+    } else if (material_mode == "TargetDumpGap") {
+      double z_tmp;
+      FindMaterialRange(z_tmp , z_start, "Target"   );
+      FindMaterialRange(z_stop, z_tmp  , "fmag_body");
+    } else if (material_mode == "Manual") {
+      z_start = rc->get_DoubleFlag("VTX_GEN_Z_START");
+      z_stop  = rc->get_DoubleFlag("VTX_GEN_Z_STOP" );
+    } else {
+      std::cout << "SQPrimaryVertexGen::init():  '" << material_mode << "' is not supported.  Abort." << std::endl;
+      exit(1);
+    }
+  }
+  std::cout << "SQPrimaryVertexGen::init(): mode = " << material_mode << ", z = " << z_start << "..." << z_stop << "." << std::endl;  
+
   //Read the default 
   defaultMatProf = new MaterialProfile;
   fillMaterialProfile(defaultMatProf, targetX0, targetY0);
@@ -140,35 +163,15 @@ void SQPrimaryVertexGen::init()
   inited = true;
 }
 
-void SQPrimaryVertexGen::set_targetOnlyMode()
+void SQPrimaryVertexGen::FindMaterialBoundaries(const double xpos, const double ypos, const double z_min, const double z_max, int& n_b, double* z_b)
 {
-  targetOnlyMode = true;
-  z_start = -304;
-  z_stop  = -296;
-}
-
-void SQPrimaryVertexGen::set_dumpOnlyMode() 
-{
-  dumpOnlyMode = true;
-  z_start = -100.;
-  z_stop = 503.;
-}
-
-void SQPrimaryVertexGen::fillMaterialProfile(MaterialProfile* prof, double xvtx, double yvtx)
-{
-  //std::cout << xvtx << "  " << yvtx << std::endl;
-  //retrieve the z position of all geometry boundaries
-  recoConsts* rc = recoConsts::instance();
-
-  double z[100];
-  int nBoundaries = 0;
-
-  double eps = 1.E-6;
-  double z_curr = z_start;  //not beyond collimator(z= -602.36 cm, lenth=121.92 cm) @Abi //-500.;
-  z[0] = z_curr;
-  while(z_curr < z_stop)
+  n_b = 0;
+  const double eps = 1.E-6;
+  double z_curr = z_min;  //not beyond collimator(z= -602.36 cm, lenth=121.92 cm) @Abi //-500.;
+  z_b[0] = z_curr;
+  while(z_curr < z_max)
   {
-    geoManager->IsSameLocation(xvtx, yvtx, z_curr, true);
+    geoManager->IsSameLocation(xpos, ypos, z_curr, true);
     geoManager->SetCurrentDirection(0., 0., 1.);
 
     TGeoNode* node = geoManager->FindNextBoundary(600.);
@@ -177,13 +180,65 @@ void SQPrimaryVertexGen::fillMaterialProfile(MaterialProfile* prof, double xvtx,
     if(z_step > eps)
     {
       z_curr += z_step;
-      z[++nBoundaries] = z_curr; 
+      z_b[++n_b] = z_curr;
     }
     else
     {
       z_curr += eps;
     }
   }
+}
+
+void SQPrimaryVertexGen::FindMaterialRange(double& z1, double& z2, const std::string name, const double xpos, const double ypos)
+{
+  int n_b;
+  double z_b[100];
+  FindMaterialBoundaries(xpos, ypos, Z_MIN, Z_MAX, n_b, z_b);
+
+  z1 = Z_MAX;
+  z2 = Z_MIN;
+  for (int i_b = 0; i_b < n_b; ++i_b) {
+    double z_lo = z_b[i_b  ];
+    double z_hi = z_b[i_b+1];
+    TGeoVolume* vol = geoManager->FindNode(xpos, ypos, (z_lo+z_hi)/2)->GetVolume();
+    TString vol_mat  = vol->GetMaterial()->GetName();
+    TString vol_name = vol->GetName();
+    std::cout << "  S " << vol_name << "   " << vol_mat << "   " << z_lo << "..." << z_hi << "   " << z_hi-z_lo << std::endl;
+    if (vol_name.Contains(name.c_str())) {
+      if (z_lo < z1) z1 = z_lo;
+      if (z_hi > z2) z2 = z_hi;
+    }
+  }
+  if (z1 > z2) {
+    std::cout << "SQPrimaryVertexGen::FindMaterialRange():  Failed.  Wrong material name?  Abort." << std::endl;
+    exit(1);
+  }
+}
+
+void SQPrimaryVertexGen::set_targetOnlyMode()
+{
+  targetOnlyMode = true;
+  //z_start = -304;
+  //z_stop  = -296;
+  FindMaterialRange(z_start, z_stop, "Target");
+}
+
+void SQPrimaryVertexGen::set_dumpOnlyMode() 
+{
+  dumpOnlyMode = true;
+  //z_start = -100.;
+  //z_stop = 503.;
+  FindMaterialRange(z_start, z_stop, "fmag_body");
+}
+
+void SQPrimaryVertexGen::fillMaterialProfile(MaterialProfile* prof, double xvtx, double yvtx)
+{
+  //std::cout << xvtx << "  " << yvtx << std::endl;
+  //retrieve the z position of all geometry boundaries
+
+  double z[100];
+  int nBoundaries = 0;
+  FindMaterialBoundaries(xvtx, yvtx, z_start, z_stop, nBoundaries, z);
 
   //use the z boundaries to create interactibles
   for(int i = 0; i < nBoundaries; ++i)

--- a/generators/E906LegacyVtxGen/SQPrimaryVertexGen.C
+++ b/generators/E906LegacyVtxGen/SQPrimaryVertexGen.C
@@ -202,9 +202,9 @@ void SQPrimaryVertexGen::FindMaterialRange(double& z1, double& z2, const std::st
     double z_lo = z_b[i_b  ];
     double z_hi = z_b[i_b+1];
     TGeoVolume* vol = geoManager->FindNode(xpos, ypos, (z_lo+z_hi)/2)->GetVolume();
-    TString vol_mat  = vol->GetMaterial()->GetName();
     TString vol_name = vol->GetName();
-    std::cout << "  S " << vol_name << "   " << vol_mat << "   " << z_lo << "..." << z_hi << "   " << z_hi-z_lo << std::endl;
+    //TString vol_mat  = vol->GetMaterial()->GetName();
+    //std::cout << "  " << vol_name << "   " << vol_mat << "   " << z_lo << "..." << z_hi << "   " << z_hi-z_lo << std::endl;
     if (vol_name.Contains(name.c_str())) {
       if (z_lo < z1) z1 = z_lo;
       if (z_hi > z2) z2 = z_hi;
@@ -218,9 +218,6 @@ void SQPrimaryVertexGen::FindMaterialRange(double& z1, double& z2, const std::st
 
 void SQPrimaryVertexGen::fillMaterialProfile(MaterialProfile* prof, double xvtx, double yvtx)
 {
-  //std::cout << xvtx << "  " << yvtx << std::endl;
-  //retrieve the z position of all geometry boundaries
-
   double z[100];
   int nBoundaries = 0;
   FindMaterialBoundaries(xvtx, yvtx, z_start, z_stop, nBoundaries, z);
@@ -243,14 +240,8 @@ void SQPrimaryVertexGen::fillMaterialProfile(MaterialProfile* prof, double xvtx,
 
   //calculate all related properties
   prof->calcProb();
-
-  // for(int i = 0; i < prof->nPieces; ++i)
-  // {
-  //   std::cout << prof->interactables[i] << std::endl;
-  // }
-  // return 0;
+  // for(int i = 0; i < prof->nPieces; ++i) std::cout << prof->interactables[i] << std::endl;
 }
-
 
 TVector3 SQPrimaryVertexGen::generateVertex()
 {

--- a/generators/E906LegacyVtxGen/SQPrimaryVertexGen.C
+++ b/generators/E906LegacyVtxGen/SQPrimaryVertexGen.C
@@ -315,7 +315,7 @@ double SQPrimaryVertexGen::funcBeamProfile(double* val, double* par)
   double y_nr = (y - y_c)/y_s; // normalized relative y
   double r2_nr = x_nr*x_nr + y_nr*y_nr;
   double r_nr  = sqrt(r2_nr);
-  if(r_nr < r_boun*r_boun) {
+  if(r_nr < r_boun) {
     return exp(-0.5*r2_nr);
   } else { // >= r_boun
     return exp(-0.5*r_boun*r_boun)*r_boun/r_nr;

--- a/generators/E906LegacyVtxGen/SQPrimaryVertexGen.h
+++ b/generators/E906LegacyVtxGen/SQPrimaryVertexGen.h
@@ -35,6 +35,9 @@ public:
 
 class SQPrimaryVertexGen
 {
+  static constexpr double Z_MIN = -800.0;
+  static constexpr double Z_MAX =  503.0;
+
 public:
   SQPrimaryVertexGen();
   ~SQPrimaryVertexGen();
@@ -69,6 +72,12 @@ private:
   //! Real initialization - should not be called directly
   void init();
 
+  //! Find the z-boundaries of all materials at (xpos, ypos, z_min...z_max).
+  void FindMaterialBoundaries(const double xpos, const double ypos, const double z_min, const double z_max, int& n_b, double* z_b);
+
+  //! Find the z-range of the material given.
+  void FindMaterialRange(double& z1, double& z2, const std::string name, const double xpos=0, const double ypos=0);
+
   //! Default material profile - pre-calculated and used for protons within the target acceptance
   MaterialProfile* defaultMatProf;
   
@@ -100,6 +109,7 @@ private:
   //! flag for using target and dump only
   bool targetOnlyMode;
   bool dumpOnlyMode;
+  std::string material_mode;
 
   //! Start/Stop position for Z search
   double z_start;

--- a/generators/E906LegacyVtxGen/SQPrimaryVertexGen.h
+++ b/generators/E906LegacyVtxGen/SQPrimaryVertexGen.h
@@ -19,6 +19,10 @@
 
 class PHCompositeNode;
 
+/// Class to hold the profile of materials at a (x, y) beam position.
+/**
+ * Only used by `SQPrimaryVertexGen` internally.
+ */
 class MaterialProfile
 {
 public:
@@ -33,6 +37,25 @@ public:
   std::vector<SQBeamlineObject> interactables;
 };
 
+/// Class to generate the event vertex, based on the beam profile and the target+spectrometer materials given.
+/**
+ * This class is used inside the event generators like `SQPrimaryParticleGen`.
+ * User need not instantiate (i.e. new) this class explicitly.
+ *
+ * The beam profile in (x, y) is Gaussian at r<3*sigma and 1/r at r>=3*sigma.
+ *
+ * User can control the beam profile and the materials by changing the following `recoConsts` flags.
+ *  - `X0_TARGET`, `Y0_TARGET` ... The center location of the target material.
+ *  - `RX_TARGET`, `RY_TARGET` ... The radius of the target material.
+ *  - `X_BEAM`, `Y_BEAM`       ... The center location of the beam.
+ *  - `SIGX_BEAM`, `SIGY_BEAM` ... The Gaussian width of the beam.
+ *  - `VTX_GEN_MATERIAL_MODE`  ... Mode to enable only a part of materials.
+ *    - `All`           ... Enable all materials (default).
+ *    - `Target`        ... Enable only the target material.
+ *    - `Dump`          ... Enable only the dump material.
+ *    - `TargetDumpGap` ... Enable only the air gap between the target and the dump.
+ *    - `Manual`        ... Enable only a z-range specified via `VTX_GEN_Z_START` and `VTX_GEN_Z_STOP`.
+ */
 class SQPrimaryVertexGen
 {
   static constexpr double Z_MIN = -800.0;
@@ -64,10 +87,6 @@ public:
   //! beam profile function
   static double funcBeamProfile(double* val, double* par);
   
-  //! setting target/fmag only function
-  void set_targetOnlyMode();
-  void set_dumpOnlyMode();
-
 private:
   //! Real initialization - should not be called directly
   void init();
@@ -108,7 +127,6 @@ private:
 
   //! flag for using target and dump only
   bool targetOnlyMode;
-  bool dumpOnlyMode;
   std::string material_mode;
 
   //! Start/Stop position for Z search

--- a/online/onlmonserver/OnlMonV1495.cc
+++ b/online/onlmonserver/OnlMonV1495.cc
@@ -177,6 +177,7 @@ int OnlMonV1495::DrawMonitor()
   pad0->Divide(2, N_DET);
   for (int i_det = 0; i_det < N_DET; i_det++) {
     TVirtualPad* pad01 = pad0->cd(2*i_det+1);
+    pad01->SetGrid();
     h1_ele[i_det]->SetLineColor(kBlack);
     h1_ele[i_det]->Draw();
     h1_ele_in[i_det]->SetLineColor(kBlue);

--- a/packages/UtilAna/UtilBeam.cc
+++ b/packages/UtilAna/UtilBeam.cc
@@ -38,12 +38,12 @@ void UtilBeam::ListOfRfValues(int& n_value, int*& list_values)
 /**
  * This function uses an array of "double", instead of "int".
  * It is suitable for the constructors of the TH1 classes.
- * ```
+ * @code
  * int num_inte;
  * double* list_inte;
  * UtilBeam::ListOfRfValues(num_inte, list_inte);
  * TH1* h1_rf_inte = new TH1D("h1_rf_inte", "", num_inte - 1, list_inte);
- * ```
+ * @endcode
  */
 void UtilBeam::ListOfRfValues(int& n_value, double*& list_values)
 {

--- a/packages/db_svc/DbSvc.cc
+++ b/packages/db_svc/DbSvc.cc
@@ -245,13 +245,16 @@ void DbSvc::ConnectServer()
 {
   ostringstream oss;
   oss << "mysql://" << m_svr << "/?timeout=120&reconnect=1&cnf_file=" << m_my_cnf;
-
-  /// User and password must be given in my.cnf, not here.
-  m_con = TMySQLServer::Connect(oss.str().c_str(), 0, 0);
-  if (! (m_con && m_con->IsConnected())) {
-    cerr << "!!ERROR!!  DbSvc::ConnectServer():  Failed.  Abort." << endl;
-    exit(1);
+  string url = oss.str();
+  
+  for (int i_try = 0; i_try < 5; i_try++) { // The connection sometimes fails even with "reconnect=1".  Thus let's try it 5 times.
+    m_con = TMySQLServer::Connect(url.c_str(), 0, 0); // User and password must be given in my.cnf, not here.
+    if (m_con && m_con->IsConnected()) return; // OK
+    sleep(10);
   }
+
+  cerr << "!!ERROR!!  DbSvc::ConnectServer():  Failed.  Abort." << endl;
+  exit(1);
 }
 
 bool DbSvc::FileExist(const std::string fileName)

--- a/packages/geom_svc/GeomSvc.cxx
+++ b/packages/geom_svc/GeomSvc.cxx
@@ -418,11 +418,14 @@ void GeomSvc::initPlaneDirect() {
 
 void GeomSvc::initPlaneDbSvc() {
   using namespace std;
-  int run = recoConsts::instance()->get_IntFlag("RUNNUMBER");
-  cout << "GeomSvc:  Load the plane geometry info via DbSvc for run = " << run << "." << endl;
+  recoConsts* rc = recoConsts::instance();
+  int run = rc->get_IntFlag("RUNNUMBER");
+  cout << "GeomSvc:  Load the plane geometry info for run = " << run << "." << endl;
 
   GeomParamPlane* geom = new GeomParamPlane();
   geom->SetMapIDbyDB(run);
+  rc->get_CharFlag("GeomPlane", geom->GetMapID());
+
   geom->ReadFromDB();
   int dummy = 0;
   for (int ii = 0; ii < geom->GetNumPlanes(); ii++) {

--- a/simulation/g4dst/SQGeomAcc.h
+++ b/simulation/g4dst/SQGeomAcc.h
@@ -7,13 +7,13 @@ class SQHitVector;
 /// An SubsysReco module to skip a simulated event in which a muon or a muon pair doesn't pass through the geometric acceptance.
 /**
  * Typical usage:
- * ```
+ * @code
  *   SQGeomAcc* geom_acc = new SQGeomAcc();
  *   geom_acc->SetMuonMode(SQGeomAcc::PAIR_TBBT);
  *   geom_acc->SetPlaneMode(SQGeomAcc::HODO_CHAM);
  *   geom_acc->SetNumOfH1EdgeElementsExcluded(4); // 0 by default
  *   se->registerSubsystem(geom_acc);
- * ```
+ * @endcode
  *
  * This module must be registered after `SQDigitizer` since it uses SQHits.
  * All the available modes are listed and explained in the sections of `MuonMode_t` and `PlaneMode_t`.

--- a/simulation/g4dst/SQGeomAccLoose.h
+++ b/simulation/g4dst/SQGeomAccLoose.h
@@ -7,11 +7,11 @@ class PHG4HitContainer;
 /// An SubsysReco module to skip a simulated event in which a muon or a muon pair doesn't pass through the _rough_ geometric acceptance.
 /**
  * Typical usage:
- * ```
+ * @code
  *   SQGeomAccLoose* geom_acc = new SQGeomAccLoose();
  *   geom_acc->SetNumParticlesPerEvent(2); // or 1 for single events
  *   se->registerSubsystem(geom_acc);
- * ```
+ * @endcode
  *
  * This module can/should be registered before `SQDigitizer` for better process speed.
  * The geometric acceptance required by this module is _rough_, because 


### PR DESCRIPTION
The primary update in this PR is that the E906 legacy generator now properly sets the absolute scale of the J/psi and psi' cross sections.  Attached is a plot of the J/psi cross section, drawn by a new test macro (`CheckParticleGenJPsi.C`).
![xsec_gen_jpsi](https://user-images.githubusercontent.com/41366345/125509831-8fa14cf1-946a-4db0-b821-c9ade71fb478.png)

I changed the cross-section unit from nb to pb returned by `SQPrimaryParticleGen` since pb is used by PYTHIA8.

I made `SQPrimaryParticleGen` and others output more parameters to `recoConsts`.

I also modified `DbSvc` so that it now tries the DB connection 5 times at max, because we saw the connection sometimes fails in the online decoding and the grid job.