### PR TITLE
New formula for tracklet charge and change in decoding v1495 data

### DIFF
--- a/interface_main/SQMCEvent_v1.cxx
+++ b/interface_main/SQMCEvent_v1.cxx
@@ -5,7 +5,7 @@ using namespace std;
 SQMCEvent_v1::SQMCEvent_v1()
   : _proc_id(0)
   , _xsec(.0)
-  , _weight(.0)
+  , _weight(1.0)
 {
   for (int ii = 0; ii < 4; ii++) {
     _par_id [ii] = 0;

--- a/online/decoder_maindaq/MainDaqParser.cc
+++ b/online/decoder_maindaq/MainDaqParser.cc
@@ -608,7 +608,10 @@ int MainDaqParser::ProcessPhysFlush(int* words)
     
     idx++; // go to next position to get ROCID
     int rocID = get_hex_bits (words[idx], 5, 2);
-    if (rocID > 32) {
+    if (rocID == 25) { // Skip this ROC temporarily, during development of CRL code
+      idx = idx_roc_end;
+      continue; // Move to next ROC
+    } else if (rocID > 32) {
       dec_err.SetFlushError(true);
       cerr << "ERROR: rocID > 32." << endl;
       ret = -1;

--- a/packages/db_svc/DbSvc.cc
+++ b/packages/db_svc/DbSvc.cc
@@ -249,7 +249,10 @@ void DbSvc::ConnectServer()
   
   for (int i_try = 0; i_try < 5; i_try++) { // The connection sometimes fails even with "reconnect=1".  Thus let's try it 5 times.
     m_con = TMySQLServer::Connect(url.c_str(), 0, 0); // User and password must be given in my.cnf, not here.
-    if (m_con && m_con->IsConnected()) return; // OK
+    if (m_con && m_con->IsConnected()) {
+      if (i_try > 0) cout << "DbSvc::ConnectServer():  Succeeded at i_try=" << i_try << "." << endl;
+      return; // OK
+    }
     sleep(10);
   }
 

--- a/packages/reco/interface/FastTracklet.cxx
+++ b/packages/reco/interface/FastTracklet.cxx
@@ -732,9 +732,19 @@ double Tracklet::getMomentum() const
     return p;
 }
 
+/// Return the charge (+1 or -1) of this tracklet.
+/**
+ * This function should be as simple as possible, in order to reduce the
+ * computation time.  Therefore the condition of the charge determination
+ * uses only "x0" and "tx" (at St. 2+3).  The formula was obtained 
+ * practically by the study in DocDB 9505.  This function is valid for both 
+ * the parallel and anti-parallel FMag+KMag polarity combination.  But it 
+ * is _not_ guaranteed to be valid when the FMag and/or KMag field strength
+ * is changed largely.
+ */
 int Tracklet::getCharge() const
 {
-	return x0*KMAGSTR > tx ? 1 : -1;
+    return -3e-3 * copysign(1.0, FMAGSTR) * x0 < tx  ?  +1  :  -1;
 }
 
 void Tracklet::getXZInfoInSt1(double& tx_st1, double& x0_st1) const


### PR DESCRIPTION
This PR includes four small changes.

1. The formula used in `FastTracklet::getCharge()` was modified in order to handle the anti-parallel magnet polarity.  It has been studied in DocDB 9505 and is explained in the Doxygen-style comment on the function.
2. The Main DAQ decoder temporarily skips the data from V1495 boards, because the data format is being changed because of the upgrade for the buffered readout.  After the upgrade is completed, the decoder will be modified again for the new data format.
3. The event weight in `SQMCEvent` is set to 1 by default.
4. `DbSvc` prints out a message when it retries a DB connection, for debugging purpose.

I have confirmed that the updated code can be built fine and is running fine for the online decoding.  The new charge formula has been tested by Forhad as explained in DocDB 9505.