### PR TITLE
Update on PHG4SimpleEventGenerator

### DIFF
--- a/framework/phool/recoConsts.cc
+++ b/framework/phool/recoConsts.cc
@@ -88,8 +88,8 @@ void recoConsts::set_defaults()
 
   set_DoubleFlag("X_BEAM", 0.);
   set_DoubleFlag("Y_BEAM", 0.);
-  set_DoubleFlag("SIGX_BEAM", 2.);
-  set_DoubleFlag("SIGY_BEAM", 2.);
+  set_DoubleFlag("SIGX_BEAM", 0.3);
+  set_DoubleFlag("SIGY_BEAM", 0.3);
 
   set_DoubleFlag("X0_TARGET", 0.);
   set_DoubleFlag("Y0_TARGET", 0.);

--- a/generators/E906LegacyGen/SQPrimaryParticleGen.C
+++ b/generators/E906LegacyGen/SQPrimaryParticleGen.C
@@ -142,47 +142,46 @@ int SQPrimaryParticleGen::Init(PHCompositeNode* topNode)
 int SQPrimaryParticleGen::InitRun(PHCompositeNode* topNode)
 { 
   gRandom->SetSeed(PHRandomSeed());
+
+  PHNodeIterator iter( topNode );
+  PHCompositeNode *dstNode = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "DST"));
+  if (!dstNode) {
+    cout << PHWHERE << "DST Node missing.  ABORTRUN." << endl;
+    return Fun4AllReturnCodes::ABORTRUN;
+  }
   ineve = findNode::getClass<PHG4InEvent>(topNode,"PHG4INEVENT");
   if (!ineve) {
-    PHNodeIterator iter( topNode );
-    PHCompositeNode *dstNode;
-    dstNode = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "DST"));
-      
     ineve = new PHG4InEvent();
-    PHDataNode<PHObject> *newNode = new PHDataNode<PHObject>(ineve, "PHG4INEVENT", "PHObject");
-    dstNode->addNode(newNode);
+    dstNode->addNode(new PHDataNode<PHObject>(ineve, "PHG4INEVENT", "PHObject"));
+  }
+  _evt = findNode::getClass<SQEvent>(topNode, "SQEvent");
+  if (! _evt) {
+    _evt = new SQEvent_v1();
+    dstNode->addNode(new PHIODataNode<PHObject>(_evt, "SQEvent", "PHObject"));
+  }
+  _mcevt = findNode::getClass<SQMCEvent>(topNode, "SQMCEvent");
+  if (! _mcevt) {
+    _mcevt = new SQMCEvent_v1();
+    dstNode->addNode(new PHIODataNode<PHObject>(_mcevt, "SQMCEvent", "PHObject"));
+  }
+  _vec_dim = findNode::getClass<SQDimuonVector>(topNode, "SQTruthDimuonVector");
+  if (! _vec_dim) {
+    _vec_dim = new SQDimuonVector_v1();
+    dstNode->addNode(new PHIODataNode<PHObject>(_vec_dim, "SQTruthDimuonVector", "PHObject"));
+  }
 
-    _evt = findNode::getClass<SQEvent>(topNode, "SQEvent");
-    if (! _evt) {
-      _evt = new SQEvent_v1();
-      dstNode->addNode(new PHIODataNode<PHObject>(_evt, "SQEvent", "PHObject"));
-    }
-
-    _mcevt = findNode::getClass<SQMCEvent>(topNode, "SQMCEvent");
-    if (! _mcevt) {
-      _mcevt = new SQMCEvent_v1();
-      dstNode->addNode(new PHIODataNode<PHObject>(_mcevt, "SQMCEvent", "PHObject"));
-    }
-
-    _vec_dim = findNode::getClass<SQDimuonVector>(topNode, "SQTruthDimuonVector");
-    if (! _vec_dim) {
-      _vec_dim = new SQDimuonVector_v1();
-      dstNode->addNode(new PHIODataNode<PHObject>(_vec_dim, "SQTruthDimuonVector", "PHObject"));
-    }
-
-    PHCompositeNode *runNode = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "RUN"));
-    if (!runNode) {
-      cout << PHWHERE << "RUN Node missing.  ABORTRUN." << endl;
-      return Fun4AllReturnCodes::ABORTRUN;
-    }
-    _integral_node = findNode::getClass<PHGenIntegral>(runNode, "PHGenIntegral");
-    if (!_integral_node) {
-      _integral_node = new PHGenIntegralv1("By SQPrimaryParticleGen");
-      runNode->addNode(new PHIODataNode<PHObject>(_integral_node, "PHGenIntegral", "PHObject"));
-    } else {
-      cout << PHWHERE << "PHGenIntegral Node exists.  Unexpected.  ABORTRUN." << endl;
-      return Fun4AllReturnCodes::ABORTRUN;
-    }
+  PHCompositeNode *runNode = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "RUN"));
+  if (!runNode) {
+    cout << PHWHERE << "RUN Node missing.  ABORTRUN." << endl;
+    return Fun4AllReturnCodes::ABORTRUN;
+  }
+  _integral_node = findNode::getClass<PHGenIntegral>(runNode, "PHGenIntegral");
+  if (!_integral_node) {
+    _integral_node = new PHGenIntegralv1("By SQPrimaryParticleGen");
+    runNode->addNode(new PHIODataNode<PHObject>(_integral_node, "PHGenIntegral", "PHObject"));
+  } else {
+    cout << PHWHERE << "PHGenIntegral Node exists.  Unexpected.  ABORTRUN." << endl;
+    return Fun4AllReturnCodes::ABORTRUN;
   }
 
   _vertexGen->InitRun(topNode);

--- a/simulation/g4main/CMakeLists.txt
+++ b/simulation/g4main/CMakeLists.txt
@@ -156,7 +156,7 @@ add_library(g4testbench SHARED
 )
 
 target_link_libraries(phg4hit      -lphool -lSubsysReco -lfun4all ${GEANT4_LINK})
-target_link_libraries(g4testbench  -lphfield -lgsl -lgslcblas -lvararray -lHepMC -lphhepmc_io -lxerces-c -lphgeom -lphg4gdml -L./ -lphg4hit -lSQPrimaryVtxGen ${GEANT4_LINK})
+target_link_libraries(g4testbench  -lphfield -lgsl -lgslcblas -lvararray -lHepMC -lphhepmc_io -lxerces-c -lphgeom -lphg4gdml -L./ -lphg4hit -linterface_main -lSQPrimaryVtxGen ${GEANT4_LINK})
 
 install(TARGETS phg4hit     					DESTINATION ${CMAKE_INSTALL_PREFIX}/lib)
 install(TARGETS g4testbench 					DESTINATION ${CMAKE_INSTALL_PREFIX}/lib)

--- a/simulation/g4main/PHG4ParticleGun.h
+++ b/simulation/g4main/PHG4ParticleGun.h
@@ -9,6 +9,11 @@
 class PHG4Particle;
 class SQPrimaryVertexGen;
 
+/// [Obsolete] A simple event generator.
+/**
+ * It generates events that contain a single particle.
+ * You had better use `PHG4SimpleEventGenerator` since it is upward compatible.
+ */
 class PHG4ParticleGun: public PHG4ParticleGeneratorBase
 {
  public:

--- a/simulation/g4main/PHG4SimpleEventGenerator.h
+++ b/simulation/g4main/PHG4SimpleEventGenerator.h
@@ -11,8 +11,11 @@
 
 class PHG4InEvent;
 class PHCompositeNode;
+class SQEvent;
+class SQMCEvent;
 class SQPrimaryVertexGen;
 
+/// Event generator to generate a set of particles under a condition of the vertex and the momentum.
 class PHG4SimpleEventGenerator : public PHG4ParticleGeneratorBase {
 
 public:
@@ -25,6 +28,7 @@ public:
 
   int InitRun(PHCompositeNode *topNode);
   int process_event(PHCompositeNode *topNode);
+  int End(PHCompositeNode *topNode);
 
   //! interface for adding particles by name
   void add_particles(const std::string &name, const unsigned int count);
@@ -114,8 +118,10 @@ private:
   double _px_min, _px_max;
   double _py_min, _py_max;
   double _pz_min, _pz_max;
-
+  int    _eventcount;
   PHG4InEvent* _ineve;
+  SQEvent* _evt; //< An output node
+  SQMCEvent* _mcevt; //< An output node
 
   bool _legacy_vertexgenerator;
   SQPrimaryVertexGen* _vertexGen;


### PR DESCRIPTION
This PR introduces mainly two updates on `PHG4SimpleEventGenerator`.
1. It creates the SQEvent and SQMCEvent nodes.  Particularly the run/spill/event IDs are now meaningful, which were always max. integer.
1. It sets `recoConsts` variables (like `PHG4SEG_EVENT_COUNT`) to record the number of generated events and the event-generator parameters.

There are two more small updates.
1. `SIGX_BEAM` in `recoConsts.cc` was changed to a realistic value (2.0 -> 0.3 cm).  I'd like to make all the values in `recoConsts.cc` realistic and remove the calls of `set_DoubleFlag()` etc. from `Fun4Sim.C`, in order to simplify the macro.  Do you think this course of action fine?
1. A potential problem in `SQPrimaryParticleGen::InitRun()` was fixed.  All the data nodes are now found or created regardless of the result of `if (!ineve)`.

I have confirmed that the update code can be built fine and the output of `PHG4SimpleEventGenerator` is as explained above.