### PR TITLE
Handling of geometry and SRecEvent node in SQReco and VertexFit

### DIFF
--- a/packages/reco/interface/SRecEvent.cxx
+++ b/packages/reco/interface/SRecEvent.cxx
@@ -689,14 +689,13 @@ SRecEvent::SRecEvent()
 
 void SRecEvent::setRawEvent(SRawEvent *rawEvent)
 {
+    clear();
     setEventInfo(rawEvent);
 
     for(Int_t i = 0; i < rawEvent->getNHitsAll(); i++)
     {
         fLocalID.insert(std::map<Int_t, Int_t>::value_type(rawEvent->getHit(i).index, i));
     }
-
-    fAllTracks.clear();
 }
 
 void SRecEvent::setEventInfo(SRawEvent* rawEvent)
@@ -733,4 +732,22 @@ void SRecEvent::clear()
     fDimuons.clear();
 
     fRecStatus = 0;
+}
+
+void SRecEvent::clearTracks()
+{
+    fAllTracks.clear();
+    fLocalID.clear();
+    fRecStatus = 0;
+}
+
+/// Clear the dimuon list.
+/**
+ * It should be called when only the vertexing is re-done.
+ * But probably `fRecStatus` will be messed up.
+ * We had better separate `fRecStatus` into `fRecStatusTracking` and `fRecStatusVertexing`.
+ */
+void SRecEvent::clearDimuons()
+{
+    fDimuons.clear();
 }

--- a/packages/reco/interface/SRecEvent.h
+++ b/packages/reco/interface/SRecEvent.h
@@ -463,6 +463,8 @@ public:
 
     ///Clear everything
     void clear();
+    void clearTracks();
+    void clearDimuons();
 
 private:
     ///Reconstruction status

--- a/packages/reco/ktracker/SQReco.cxx
+++ b/packages/reco/ktracker/SQReco.cxx
@@ -609,10 +609,12 @@ int SQReco::MakeNodes(PHCompositeNode* topNode)
 
   if(_legacy_rec_container)
   {
-    _recEvent = new SRecEvent();
-    PHIODataNode<PHObject>* recEventNode = new PHIODataNode<PHObject>(_recEvent, "SRecEvent", "PHObject");
-    eventNode->addNode(recEventNode);
-    if(Verbosity() >= Fun4AllBase::VERBOSITY_SOME) LogInfo("DST/SRecEvent Added");
+    _recEvent = findNode::getClass<SRecEvent>(topNode, "SRecEvent"); // Could exist when the tracking is re-done.
+    if(!_recEvent) {
+      _recEvent = new SRecEvent();
+      eventNode->addNode(new PHIODataNode<PHObject>(_recEvent, "SRecEvent", "PHObject"));
+      if(Verbosity() >= Fun4AllBase::VERBOSITY_SOME) LogInfo("DST/SRecEvent Added");
+    }
   }
   else
   {

--- a/packages/reco/ktracker/SQReco.cxx
+++ b/packages/reco/ktracker/SQReco.cxx
@@ -73,6 +73,7 @@ SQReco::SQReco(const std::string& name):
   _rawEvent(nullptr),
   _recEvent(nullptr),
   _recTrackVec(nullptr),
+  _use_geom_io_node(false),
   _geom_file_name(""),
   _t_geo_manager(nullptr)
 {
@@ -203,18 +204,36 @@ int SQReco::InitGeom(PHCompositeNode* topNode)
     }
   }
 
-  PHGeomTGeo* dstGeom = PHGeomUtility::GetGeomTGeoNode(topNode, true); //hacky way to bypass PHGeoUtility's lack of exception throwing
-  if(!dstGeom->isValid())
+  if (_geom_file_name != "")
   {
-    if(_geom_file_name == "") return Fun4AllReturnCodes::ABORTEVENT;
-
     if(Verbosity() > 1) std::cout << "SQReco::InitGeom - create geom from " << _geom_file_name << std::endl;
+    if (_use_geom_io_node)
+    {
+      std::cout << "SQReco::InitGeom - Both 'geom_file_name' and 'use_geom_io_node' are active.  Use only one." << std::endl;
+      return Fun4AllReturnCodes::ABORTEVENT;
+    }
     int ret = PHGeomUtility::ImportGeomFile(topNode, _geom_file_name);
     if(ret != Fun4AllReturnCodes::EVENT_OK) return ret;
   }
+  else if (_use_geom_io_node)
+  {
+    if(Verbosity() > 1) std::cout << "SQReco::InitGeom - use geom from RUN node tree." << std::endl;
+    PHGeomTGeo* node = PHGeomUtility::LoadFromIONode(topNode);
+    if (! node)
+    {
+      std::cout << "SQReco::InitGeom - Failed at loading the GEOMETRY_IO node." << std::endl;
+      return Fun4AllReturnCodes::ABORTEVENT;
+    }
+  }
   else
   {
-    if(Verbosity() > 1) std::cout << "SQReco::InitGeom - use geom from NodeTree." << std::endl;
+    if(Verbosity() > 1) std::cout << "SQReco::InitGeom - use geom from PAR node tree." << std::endl;
+    PHGeomTGeo* dstGeom = PHGeomUtility::GetGeomTGeoNode(topNode, true); //hacky way to bypass PHGeoUtility's lack of exception throwing
+    if(!dstGeom->isValid())
+    {
+      std::cout << "SQReco::InitGeom - Failed at loading the GEOMETRY node." << std::endl;
+      return Fun4AllReturnCodes::ABORTEVENT;
+    }
   }
 
   _t_geo_manager = PHGeomUtility::GetTGeoManager(topNode);

--- a/packages/reco/ktracker/SQReco.h
+++ b/packages/reco/ktracker/SQReco.h
@@ -59,6 +59,9 @@ public:
   const TString& get_eval_file_name() const { return _eval_file_name; }
   void set_eval_file_name(const TString& evalFileName) { _eval_file_name = evalFileName; }
 
+  bool use_geom_io_node() const  { return _use_geom_io_node; }
+  void use_geom_io_node(const bool val) { _use_geom_io_node = val; }
+
   const std::string& get_geom_file_name() const { return _geom_file_name; }
   void set_geom_file_name(const std::string& geomFileName) { _geom_file_name = geomFileName; }
 
@@ -137,6 +140,7 @@ private:
   SRecEvent* _recEvent;
   SQTrackVector* _recTrackVec;
 
+  bool _use_geom_io_node;
   std::string  _geom_file_name;
   TGeoManager* _t_geo_manager;
 };

--- a/packages/reco/ktracker/VertexFit.cxx
+++ b/packages/reco/ktracker/VertexFit.cxx
@@ -184,7 +184,9 @@ int VertexFit::InitRun(PHCompositeNode* topNode) {
 
 int VertexFit::process_event(PHCompositeNode* topNode) {
 
-  _recEvent->identify();
+  if(verbosity > 0) _recEvent->identify();
+
+  _recEvent->clearDimuons(); // In case the vertexing is re-done.
 
   int ret = -99;
   try {

--- a/script/setup-install.sh
+++ b/script/setup-install.sh
@@ -27,6 +27,8 @@ elif [ "X$1" = 'Xauto' ] ; then
     DIR_INST=$(readlink -f $DIR_SCRIPT/../../core-inst)
 elif [ "X$1" = 'Xonline' ] ; then
     DIR_INST=/data2/e1039/core/new
+elif [ "X$1" = 'Xosg-user' ] ; then
+    DIR_INST=/e906/app/software/osg/users/$USER/e1039/core
 else
     DIR_INST=$(readlink -m "$1")
 fi


### PR DESCRIPTION
This PR will change the handling of the geometry and the SRecEvent node in `SQReco` and `VertexFit`.  The change enables us to run the event reconstruction twice or more, using DST file as input.

1. Geometry:
`PHGeomUtility` is able to read the geometry info from an existing DST file (i.e. the `PHGeomIOTGeo` node named `RUN.GEOMETRY_IO`), instead of reading the one created by `PHG4Reco` in `Fun4Sim.C` (i.e. the `PHGeomTGeo` node named `PAR.GEOMETRY`).  I modified `SQReco` so that it tries to read `RUN.GEOMETRY_IO` when `use_geom_io_node(true)` is called.  Using this feature, we need not build `PHG4Reco` in `Fun4Sim.C` but can use the identical geometry stored in an input DST file.

2. SRecEvent node:
I modified `SQReco` and `VertexFit` so that they clear tracks and/or dimuons in `SRecEvent` at the beginning of `process_event()`.  Tracks and dimuons could exist when the input DST file has been already reconstructed.  We sometimes run the reconstruction twice or more.  For example I run it before and after the hit embedding in order to evaluate the effect of embedded hits.

I have confirmed that the updated code runs fine in my hit-embedding study.  I will explain the study at the meeting tomorrow, so we can talk about this PR together.
