### PR TITLE
No use of ROOT Form()

### DIFF
--- a/packages/db_svc/DbSvc.cc
+++ b/packages/db_svc/DbSvc.cc
@@ -40,7 +40,7 @@ DbSvc::DbSvc(const SvrId_t svr_id, const std::string dbfile)
     return;
   }
 
-  m_svr = Form("sqlite://%s", m_dbfile.c_str());
+  m_svr = "sqlite://" + m_dbfile;
   m_con = new TSQLiteServer(m_svr.c_str());
 }
 

--- a/packages/dptrigger/DPTriggerAnalyzer.cxx
+++ b/packages/dptrigger/DPTriggerAnalyzer.cxx
@@ -80,7 +80,7 @@ TString DPTriggerRoad::getStringID()
   TString sid;
   for(unsigned int i = 0; i < uniqueTrIDs.size(); ++i)
     {
-      sid = sid + Form("%06d", uniqueTrIDs[i]);
+      sid += TString::Format("%06d", uniqueTrIDs[i]);
     }
   
   return sid;

--- a/simulation/g4detectors/SQG4DipoleMagnetDetector.cc
+++ b/simulation/g4detectors/SQG4DipoleMagnetDetector.cc
@@ -62,7 +62,7 @@ void SQG4DipoleMagnetDetector::Construct(G4LogicalVolume* logicWorld)
   std::map<int, G4VSolid*> solids;
 
   /// Read all box shapes from Table SolidBoxes
-  stmt.reset(db_svc->Process(Form("SELECT sID, sName, xLength, yLength, zLength FROM SolidBoxes WHERE sName like '%s%'", vName.c_str())));
+  stmt.reset(db_svc->Process(     "SELECT sID, sName, xLength, yLength, zLength FROM SolidBoxes WHERE sName like '" + vName + "%'"));
   while(stmt->NextResultRow() && (!stmt->IsNull(0)))
   {
     int sID = stmt->GetInt(0);
@@ -84,7 +84,7 @@ void SQG4DipoleMagnetDetector::Construct(G4LogicalVolume* logicWorld)
   }
 
   /// Read all tube shapes from Table SolidTubes
-  stmt.reset(db_svc->Process(Form("SELECT sID, sName, length, radiusMin, radiusMax FROM SolidTubes WHERE sName like '%s%'", vName.c_str())));
+  stmt.reset(db_svc->Process(     "SELECT sID, sName, length, radiusMin, radiusMax FROM SolidTubes WHERE sName like '" + vName + "%'"));
   while(stmt->NextResultRow() && (!stmt->IsNull(0)))
   {
     int sID = stmt->GetInt(0);
@@ -106,7 +106,7 @@ void SQG4DipoleMagnetDetector::Construct(G4LogicalVolume* logicWorld)
   }
 
   /// Perform subtraction using Table SubtractionSolids
-  stmt.reset(db_svc->Process(Form("SELECT sID, sName, shellID, holeID, rotX, rotY, rotZ, posX, posY, posZ FROM SubtractionSolids WHERE sName like '%s%'", vName.c_str())));
+  stmt.reset(db_svc->Process(     "SELECT sID, sName, shellID, holeID, rotX, rotY, rotZ, posX, posY, posZ FROM SubtractionSolids WHERE sName like '" + vName + "%'"));
   while(stmt->NextResultRow() && (!stmt->IsNull(0)))
   {
     int sID = stmt->GetInt(0);
@@ -145,7 +145,7 @@ void SQG4DipoleMagnetDetector::Construct(G4LogicalVolume* logicWorld)
 
   // Create logical volumes using Table LogicalVolumes
   std::map<int, G4LogicalVolume*> logicals;
-  stmt.reset(db_svc->Process(Form("SELECT lvID, lvName, sID, mName FROM LogicalVolumes WHERE lvName like '%s%'", vName.c_str())));
+  stmt.reset(db_svc->Process(     "SELECT lvID, lvName, sID, mName FROM LogicalVolumes WHERE lvName like '" + vName + "%'"));
   while(stmt->NextResultRow() && (!stmt->IsNull(0)))
   {
     int lvID = stmt->GetInt(0);
@@ -177,7 +177,7 @@ void SQG4DipoleMagnetDetector::Construct(G4LogicalVolume* logicWorld)
   int topLVID = -1;
   int topPVID = -1;
   std::string topPVName;
-  stmt.reset(db_svc->Process(Form("SELECT pvID, pvName, lvID FROM PhysicalVolumes WHERE motherID=0 AND depth=1 AND pvName like '%s%'", vName.c_str())));
+  stmt.reset(db_svc->Process(     "SELECT pvID, pvName, lvID FROM PhysicalVolumes WHERE motherID=0 AND depth=1 AND pvName like '" + vName + "%'"));
   while(stmt->NextResultRow())
   {
     ++nTopPV;
@@ -219,7 +219,7 @@ void SQG4DipoleMagnetDetector::Construct(G4LogicalVolume* logicWorld)
   ++lvRefCount[topLVID];
 
   // The rest of the physical volumes
-  stmt.reset(db_svc->Process(Form("SELECT pvName, lvID, motherID, xRel, yRel, zRel, rotX, rotY, rotZ FROM PhysicalVolumes WHERE motherID>0 AND pvName like '%s%'", vName.c_str())));
+  stmt.reset(db_svc->Process(     "SELECT pvName, lvID, motherID, xRel, yRel, zRel, rotX, rotY, rotZ FROM PhysicalVolumes WHERE motherID>0 AND pvName like '" + vName + "%'"));
   while(stmt->NextResultRow() && (!stmt->IsNull(0)))
   {
     //may need to check duplicate pvID?


### PR DESCRIPTION
I'd like to stop using ROOT Form() in the source code.  I have removed only a few uses as examples so far.  If you would agree with this course of action, I will remove all other uses before merging this PR.

I found that the version after PR 108 didn't work fine on a UVA server (Rivanna) due to the following run-time error in `Fun4Sim.C`;
```
SQDipoleMagnet - begin construction of fmag from $E1039_RESOURCE/geometry/magnetic_fields/magnet_geom.db
Error in <TSQLiteServer::Statement>: Code: -1  Msg: no query string specified
```
Interestingly PR 108 hadn't modified `SQG4DipoleMagnetDetector` and it works fine on spinquestgpvm01.

I looked into the code and found that the error occurred when `Form()` was called in `SQG4DipoleMagnetDetector::Construct()`.  The usage in this function is not proper, according to the ROOT Reference Guide; "Don't pass Form() pointers from user code down to ROOT functions";
https://root.cern.ch/doc/master/TString_8cxx.html#a3b5b568376e617c4b5d6a91c7a2b675a
Thus I'd like to stop using this function in e1039-core, in order to avoid a similar trouble in future.  I also think we should not use this kind of global functions.

I'm not sure why the earlier versions worked fine on Rivanna, but just guess that RP 108 dropped a large part of the code (i.e. `g4decayer` and PYTHIA6) and thus the order/location of functions in the binaries changed largely.