### PR TITLE
Spill-by-spill SRawEvent output for online reconstruction

### DIFF
--- a/online/macros/Fun4MainDaq.C
+++ b/online/macros/Fun4MainDaq.C
@@ -4,6 +4,7 @@ R__LOAD_LIBRARY(libinterface_main)
 R__LOAD_LIBRARY(libdecoder_maindaq)
 R__LOAD_LIBRARY(libonlmonserver)
 R__LOAD_LIBRARY(libpheve_modules)
+R__LOAD_LIBRARY(libktracker)
 #endif
 
 int Fun4MainDaq(const int run=46, const int nevent=0, const bool is_online=false)
@@ -84,25 +85,29 @@ int Fun4MainDaq(const int run=46, const int nevent=0, const bool is_online=false
     se->registerSubsystem(new OnlMonProp (OnlMonProp::P2));
   }
 
-  Fun4AllDstOutputManager *out = new Fun4AllDstOutputManager("DSTOUT", fn_out);
-  se->registerOutputManager(out);
+  Fun4AllDstOutputManager *om_dst = new Fun4AllDstOutputManager("DSTOUT", fn_out);
+  se->registerOutputManager(om_dst);
 
-  Fun4AllSpillDstOutputManager *out2 = new Fun4AllSpillDstOutputManager(UtilOnline::GetDstFileDir(), "DSTOUT2");
-  out2->SetSpillStep(100);
-  se->registerOutputManager(out2);
+  Fun4AllSpillDstOutputManager *om_spdst = new Fun4AllSpillDstOutputManager(UtilOnline::GetDstFileDir(), "SPILLDSTOUT");
+  om_spdst->SetSpillStep(100);
+  se->registerOutputManager(om_spdst);
 
   if (use_evt_disp) {
     se->registerSubsystem(new EvtDispFilter(1000, 1)); // (step, max per spill)
 
     oss.str("");
-    oss << "/data2/e1039/onlmon/evt_disp";
+    oss << "/data2/e1039/online/evt_disp";
     gSystem->mkdir(oss.str().c_str(), true);
     oss << "/run_" << setfill('0') << setw(6) << run << "_evt_disp.root";
-    Fun4AllDstOutputManager *out3 = new Fun4AllDstOutputManager("DSTOUT3", oss.str());
-    out3->EnableRealTimeSave();
-    out3->AddEventSelector("EvtDispFilter");
-    se->registerOutputManager(out3);
+    Fun4AllDstOutputManager *om_eddst = new Fun4AllDstOutputManager("EDDST", oss.str());
+    om_eddst->EnableRealTimeSave();
+    om_eddst->AddEventSelector("EvtDispFilter");
+    se->registerOutputManager(om_eddst);
   }
+
+  Fun4AllSRawEventOutputManager *om_sraw = new Fun4AllSRawEventOutputManager("/data2/e1039/online");
+  om_sraw->Verbosity(10);
+  se->registerOutputManager(om_sraw);
 
   se->run(nevent);
   se->End();

--- a/packages/Display/README.md
+++ b/packages/Display/README.md
@@ -27,7 +27,7 @@ It contains only sampled events (typically a few events per spill)
 and its tree header is updated every event (via TTree::AutoSave())
 so that it is readable even when being written.
 It is managed by `Fun4AllDstOutputManager` named `DSTOUT2`
-and is saved under `/data2/e1039/onlmon/evt_disp`.
+and is saved under `/data2/e1039/online/evt_disp`.
 The event sampling is controlled by `EvtDispFilter`.
 
 A macro for this input mode is

--- a/packages/Display/interface/PHEventDisplay.cxx
+++ b/packages/Display/interface/PHEventDisplay.cxx
@@ -84,8 +84,8 @@ const char* name = "Projection"
 
   TEveViewer* v; TEveScene* s;
   MakeViewerScene(slot, v, s);
-  v->SetElementName(Form("Viewer - %s",name));
-  s->SetElementName(Form("Scene - %s",name));
+  v->SetElementName(TString::Format("Viewer - %s",name));
+  s->SetElementName(TString::Format("Scene - %s",name));
 
   s->AddElement(element);
 
@@ -124,8 +124,8 @@ const char* name = "Hodo"
 
   TEveViewer* v; TEveScene* s;
   MakeViewerScene(slot, v, s);
-  v->SetElementName(Form("Viewer - %s",name));
-  s->SetElementName(Form("Scene - %s",name));
+  v->SetElementName(TString::Format("Viewer - %s",name));
+  s->SetElementName(TString::Format("Scene - %s",name));
 
   s->AddElement(element);
 
@@ -430,10 +430,10 @@ void PHEventDisplay::draw_default(PHCompositeNode *topNode)
   if (_sqevent) {
     if(verbosity) std::cout<<"PHEventDisplay - SQEvent nodes found."<<std::endl;
     v->DeleteOverlayAnnotations();
-    TGLAnnotation* ann = new TGLAnnotation(v, Form("Run: %d, Spill: %d, Event: %d", _sqevent->get_run_id(), _sqevent->get_spill_id(), _sqevent->get_event_id()), 0.55, 0.95);
+    TGLAnnotation* ann = new TGLAnnotation(v, TString::Format("Run: %d, Spill: %d, Event: %d", _sqevent->get_run_id(), _sqevent->get_spill_id(), _sqevent->get_event_id()), 0.55, 0.95);
     ann->SetTextSize(0.04);
     ann = new TGLAnnotation(v,
-        Form("NIM: {%d, %d, %d, %d, %d}  MATRIX: {%d, %d, %d, %d, %d}",
+        TString::Format("NIM: {%d, %d, %d, %d, %d}  MATRIX: {%d, %d, %d, %d, %d}",
             _sqevent->get_trigger(SQEvent::NIM1),
             _sqevent->get_trigger(SQEvent::NIM2),
             _sqevent->get_trigger(SQEvent::NIM3),

--- a/packages/Display/modules/mTrkEveDisplay.cxx
+++ b/packages/Display/modules/mTrkEveDisplay.cxx
@@ -235,7 +235,7 @@ mTrkEveDisplay::draw_hits()
 
       _hit_wires[det_id]->AddLine(x, y, dx, dy);
 
-      _hit_wires[det_id]->QuadId(new TNamed(Form("%d",elm_id),"element id"));
+      _hit_wires[det_id]->QuadId(new TNamed(TString::Format("%d",elm_id).Data(),"element id"));
 
       if(det_id<31)      _hit_wires[det_id]->DigitColor(kBlue);
       else if(det_id<47) _hit_wires[det_id]->DigitColor(kGreen);

--- a/packages/UtilAna/UtilOnline.cc
+++ b/packages/UtilAna/UtilOnline.cc
@@ -7,7 +7,7 @@ using namespace std;
 std::string UtilOnline::m_dir_end     = "/seaquest/e906daq/coda/data/END";
 std::string UtilOnline::m_dir_coda    = "/localdata/codadata"; // could be "/data3/data/mainDAQ" or "/data2/e1039/codadata".
 std::string UtilOnline::m_dir_dst     = "/data2/e1039/dst";
-std::string UtilOnline::m_dir_eddst   = "/data2/e1039/onlmon/evt_disp";
+std::string UtilOnline::m_dir_eddst   = "/data2/e1039/online/evt_disp";
 std::string UtilOnline::m_dir_onlmon  = "/data2/e1039/onlmon/plots";
 std::string UtilOnline::m_sch_maindaq = "user_e1039_maindaq";
 

--- a/packages/reco/interface/SRawEvent.h
+++ b/packages/reco/interface/SRawEvent.h
@@ -221,6 +221,8 @@ public:
 
     ///only empty the hit list, leave other information untouched
     void empty() { fAllHits.clear(); fTriggerHits.clear(); }
+    void emptyHits() { fAllHits.clear(); }
+    void emptyTriggerHits() { fTriggerHits.clear(); }
 
     ///Print for debugging purposes
     void print (std::ostream& os = std::cout) const;

--- a/packages/reco/ktracker/Fun4AllSRawEventOutputManager.cxx
+++ b/packages/reco/ktracker/Fun4AllSRawEventOutputManager.cxx
@@ -1,0 +1,146 @@
+#include <cstdlib>
+#include <string>
+#include <iostream>
+#include <iomanip>
+#include <TSystem.h>
+#include <TFile.h>
+#include <TTree.h>
+#include <TSQLServer.h>
+#include <phool/phool.h>
+#include <phool/getClass.h>
+#include <phool/PHNode.h>
+#include <phool/PHNodeIOManager.h>
+#include <phool/PHNodeIterator.h>
+#include <interface_main/SQEvent.h>
+#include <interface_main/SQSpillMap.h>
+#include <interface_main/SQHitVector.h>
+#include <ktracker/SRawEvent.h>
+#include <db_svc/DbSvc.h>
+#include "UtilSRawEvent.h"
+#include "Fun4AllSRawEventOutputManager.h"
+using namespace std;
+
+Fun4AllSRawEventOutputManager::Fun4AllSRawEventOutputManager(const std::string &dir_base, const string &myname)
+  : Fun4AllOutputManager(myname)
+  , m_dir_base(dir_base)
+  , m_tree_name("save")
+  , m_branch_name("rawEvent")
+  , m_file_name("")
+  , m_run_id(0)
+  , m_spill_id(0)
+  , m_file(0)
+  , m_tree(0)
+  , m_sraw(0)
+  , m_evt(0)
+  , m_sp_map(0)
+  , m_hit_vec(0)
+  , m_trig_hit_vec(0)
+{
+  ;
+}
+
+Fun4AllSRawEventOutputManager::~Fun4AllSRawEventOutputManager()
+{
+  CloseFile();
+  if (m_sraw) delete m_sraw;
+}
+
+int Fun4AllSRawEventOutputManager::Write(PHCompositeNode *startNode)
+{
+  if (! m_evt) {
+    m_evt          = findNode::getClass<SQEvent    >(startNode, "SQEvent");
+    m_sp_map       = findNode::getClass<SQSpillMap >(startNode, "SQSpillMap");
+    m_hit_vec      = findNode::getClass<SQHitVector>(startNode, "SQHitVector");
+    m_trig_hit_vec = findNode::getClass<SQHitVector>(startNode, "SQTriggerHitVector");
+    if (!m_evt || !m_hit_vec || !m_trig_hit_vec) {
+      cout << PHWHERE << "Cannot find the SQ data nodes.  Abort." << endl;
+      exit(1);
+    }
+  }
+  int run_id = m_evt->get_run_id();
+  int sp_id  = m_evt->get_spill_id();
+  if (m_run_id != run_id || m_spill_id != sp_id) { // New spill
+    CloseFile();
+    m_run_id   = run_id;
+    m_spill_id = sp_id;
+    OpenFile();
+  }
+  SQSpill* sp = m_sp_map ? m_sp_map->get(sp_id) : 0;
+  UtilSRawEvent::SetEvent     (m_sraw, m_evt);
+  UtilSRawEvent::SetSpill     (m_sraw, sp);
+  UtilSRawEvent::SetHit       (m_sraw, m_hit_vec);
+  UtilSRawEvent::SetTriggerHit(m_sraw, m_trig_hit_vec);
+  m_tree->Fill();
+  return 0;
+}
+
+void Fun4AllSRawEventOutputManager::CloseFile()
+{
+  if (Verbosity() > 0) cout << "Fun4AllSRawEventOutputManager::CloseFile(): run " << m_run_id << ", spill " << m_spill_id << endl;
+  if (! m_file) return;
+  m_file->Write();
+  m_file->Close();
+  delete m_file;
+  m_file = 0;
+  UpdateDBStatus(CLOSE);
+}
+
+void Fun4AllSRawEventOutputManager::OpenFile()
+{
+  if (Verbosity() > 0) cout << "Fun4AllSRawEventOutputManager::OpenFile(): run " << m_run_id << ", spill " << m_spill_id << endl;
+  ostringstream oss;
+  oss << m_dir_base << "/sraw/run_" << setfill('0') << setw(6) << m_run_id;
+  gSystem->mkdir(oss.str().c_str(), true);
+  oss << "/run_" << setw(6) << m_run_id << "_spill_" << setw(9) << m_spill_id << "_sraw.root";
+  m_file_name = oss.str();
+  if (Verbosity() > 9) cout << "  " << m_file_name << endl;
+  m_file = new TFile(m_file_name.c_str(), "RECREATE");
+  if (!m_file->IsOpen()) {
+    cout << PHWHERE << "Could not open " << m_file_name << ".  Abort." << endl;
+    exit(1);
+  }
+  if (!m_sraw) m_sraw = new SRawEvent();
+  m_tree = new TTree(m_tree_name.c_str(), "");
+  m_tree->Branch(m_branch_name.c_str(), &m_sraw);
+  UpdateDBStatus(OPEN);
+}
+
+/// Update the status stored in SQLite DB.
+/**
+ * This function assumes the SQLite DB file exists with the proper table contents.
+ * We have to manually execute the following commands beforehand;
+ * @code
+ * sqlite3 /path/to/data_status.db
+ * create table data_status (
+ *     run_id          INTEGER,
+ *     spill_id        INTEGER,
+ *      utime_deco     INTEGER DEFAULT 0,
+ *     status_deco     INTEGER DEFAULT 0,
+ *      utime_reco_cpu INTEGER DEFAULT 0,
+ *     status_reco_cpu INTEGER DEFAULT 0,
+ *      utime_reco_gpu INTEGER DEFAULT 0,
+ *     status_reco_gpu INTEGER DEFAULT 0,
+ *     UNIQUE(run_id, spill_id)
+ *   );
+ * @endcode
+ */
+void Fun4AllSRawEventOutputManager::UpdateDBStatus(const int status)
+{
+  const char* table_name = "data_status";
+  ostringstream oss;
+  oss << m_dir_base << "/data_status.db";
+  DbSvc db(DbSvc::LITE, oss.str());
+
+  oss.str("");
+  oss << "insert or ignore into " << table_name << " (run_id, spill_id) values (" << m_run_id << ", " << m_spill_id << ")";
+  if (! db.Con()->Exec(oss.str().c_str())) {
+    cerr << "!!ERROR!!  Fun4AllSRawEventOutputManager::UpdateDBStatus()." << endl;
+    return;
+  }
+  oss.str("");
+  oss << "update " << table_name << " set utime_deco = strftime('%s', 'now'), status_deco = " << status << " where run_id = " << m_run_id << " and spill_id = " << m_spill_id;
+  if (! db.Con()->Exec(oss.str().c_str())) {
+    cerr << "!!ERROR!!  Fun4AllSRawEventOutputManager::UpdateDBStatus()." << endl;
+    return;
+  }
+}

--- a/packages/reco/ktracker/Fun4AllSRawEventOutputManager.h
+++ b/packages/reco/ktracker/Fun4AllSRawEventOutputManager.h
@@ -1,0 +1,52 @@
+#ifndef __FUN4ALLSRAWEVENTOUTPUTMANAGER_H__
+#define __FUN4ALLSRAWEVENTOUTPUTMANAGER_H__
+#include <fun4all/Fun4AllOutputManager.h>
+#include <string>
+#include <vector>
+class TFile;
+class TTree;
+class PHCompositeNode;
+class SRawEvent;
+class SQEvent;
+class SQSpillMap;
+class SQHitVector;
+
+class Fun4AllSRawEventOutputManager: public Fun4AllOutputManager
+{
+  typedef enum {
+    UNDEF  = 0,
+    OPEN   = 1,
+    UPDATE = 2,
+    CLOSE  = 3
+  } Status_t;
+  std::string m_dir_base;
+  std::string m_tree_name;
+  std::string m_branch_name;
+  std::string m_file_name;
+  int m_run_id;
+  int m_spill_id;
+  TFile* m_file;
+  TTree* m_tree;
+  SRawEvent* m_sraw;
+  
+  SQEvent* m_evt;
+  SQSpillMap* m_sp_map;
+  SQHitVector* m_hit_vec;
+  SQHitVector* m_trig_hit_vec;
+
+ public:
+  Fun4AllSRawEventOutputManager(const std::string &dir_base, const std::string &myname = "SRAWEVENTOUT");
+  virtual ~Fun4AllSRawEventOutputManager();
+
+  void SetTreeName  (const std::string name) { m_tree_name   = name; }
+  void SetBranchName(const std::string name) { m_branch_name = name; }
+
+  virtual int Write(PHCompositeNode *startNode);
+
+ protected:
+  void CloseFile();
+  void OpenFile();
+  void UpdateDBStatus(const int status);
+};
+
+#endif /* __FUN4ALLSRAWEVENTOUTPUTMANAGER_H__ */

--- a/packages/reco/ktracker/Fun4AllSRawEventOutputManagerLinkDef.h
+++ b/packages/reco/ktracker/Fun4AllSRawEventOutputManagerLinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class Fun4AllSRawEventOutputManager-!;
+
+#endif /* __CINT__ */

--- a/packages/reco/ktracker/SQReco.cxx
+++ b/packages/reco/ktracker/SQReco.cxx
@@ -111,8 +111,7 @@ int SQReco::InitRun(PHCompositeNode* topNode)
   if(ret != Fun4AllReturnCodes::EVENT_OK) return ret;
 
   //Init track finding
- // _fastfinder = new KalmanFastTracking(_phfield, _t_geo_manager, false);
-  _fastfinder = new KalmanFastTracking(_phfield, _t_geo_manager, _enable_KF);///Abi (Don't we turn on enable_kF ?)
+  _fastfinder = new KalmanFastTracking(_phfield, _t_geo_manager, false);
 
   _fastfinder->Verbosity(Verbosity());
 

--- a/packages/reco/ktracker/SQReco.cxx
+++ b/packages/reco/ktracker/SQReco.cxx
@@ -2,6 +2,7 @@
 
 #include "KalmanFastTracking.h"
 #include "EventReducer.h"
+#include "UtilSRawEvent.h"
 
 #include <phfield/PHFieldConfig_v3.h>
 #include <phfield/PHFieldUtility.h>
@@ -258,18 +259,6 @@ int SQReco::updateHitInfo(SRawEvent* sraw_event)
   return 0;
 }
 
-/**
- * Note for pull request.
- * 
- * The translation from SQ* to SRawEvent is useful for other classes
- * (like `Fun4AllSRawEventInputManager`).
- * Therefore I exported the contetns of this function to a new utility namespace, `UtilSRawEvent`.
- * Can I modify this function to make use of `UtilSRawEvent`?
- *
- * `UtilSRawEvent` cannot handle `_m_hitID_idx` and `_m_trghitID_idx`, but
- * they seem not in use at present.
- * Can I remove them??
- */
 SRawEvent* SQReco::BuildSRawEvent() 
 {
   //Needed for E1039 since we switched to a more generic interface
@@ -278,98 +267,23 @@ SRawEvent* SQReco::BuildSRawEvent()
   _m_hitID_idx.clear();
   _m_trghitID_idx.clear();
 
-  int run_id   = 0;
-  int spill_id = 0;
-  int event_id = _event;
-  if(_event_header) 
+  if(!UtilSRawEvent::SetEvent(sraw_event, _event_header))
   {
-    run_id   = _event_header->get_run_id();
-    spill_id = _event_header->get_spill_id();
-    event_id = _event_header->get_event_id();
+    sraw_event->setEventInfo(0, 0, _event); // overwrite event ID
   }
-  sraw_event->setEventInfo(run_id, spill_id, event_id);
-
-  //Trigger setting - either from trigger emulation or TS, default to 0
-  int triggers[10];
-  for(int i = SQEvent::NIM1; i <= SQEvent::MATRIX5; ++i)
-  {
-    if(_event_header)
-      triggers[i] = _event_header->get_trigger(static_cast<SQEvent::TriggerMask>(i));
-    else
-      triggers[i] = 0;
-  }
-  sraw_event->setTriggerBits(triggers);
 
   //Get target position
-  int targetPos = 0;
-  if(_spill_map) 
+  if(_spill_map)
   {
-    SQSpill* spill = _spill_map->get(spill_id);
-    if(spill) 
-    {
-      targetPos = spill->get_target_pos();
-    }
+    UtilSRawEvent::SetSpill(sraw_event, _spill_map->get( sraw_event->getSpillID() ));
   }
-  sraw_event->setTargetPos(1);
 
   //Get beam information - QIE -- not implemented yet
 
   //Get trigger hits - TriggerHit
-  if(_triggerhit_vector) 
-  {
-    for(size_t idx = 0; idx < _triggerhit_vector->size(); ++idx) 
-    {
-      SQHit* sq_hit = _triggerhit_vector->at(idx);
-      _m_trghitID_idx[sq_hit->get_hit_id()] = idx;
+  UtilSRawEvent::SetTriggerHit(sraw_event, _triggerhit_vector, &_m_trghitID_idx);
+  UtilSRawEvent::SetHit       (sraw_event, _hit_vector       , &_m_hitID_idx);
 
-      Hit h;
-      h.index = sq_hit->get_hit_id();
-      h.detectorID = sq_hit->get_detector_id();
-      h.elementID = sq_hit->get_element_id();
-      h.tdcTime = sq_hit->get_tdc_time();
-      h.driftDistance = fabs(sq_hit->get_drift_distance()); //MC L-R info removed here
-      h.pos = sq_hit->get_pos();
-
-      if(sq_hit->is_in_time()) h.setInTime();
-      sraw_event->insertTriggerHit(h);
-    }
-  }
-
-  for(size_t idx = 0; idx < _hit_vector->size(); ++idx) 
-  {
-    SQHit* sq_hit = _hit_vector->at(idx);
-
-    Hit h;
-    h.index = sq_hit->get_hit_id();
-    h.detectorID = sq_hit->get_detector_id();
-    h.elementID = sq_hit->get_element_id();
-    h.tdcTime = sq_hit->get_tdc_time();
-    h.driftDistance = fabs(sq_hit->get_drift_distance()); //MC L-R info removed here
-    h.pos = sq_hit->get_pos();
-
-    if(sq_hit->is_in_time()) h.setInTime();
-    sraw_event->insertHit(h);
-
-    /* We should not need the following code, since all these logic are done in
-    // inside eventreducer
-    //TODO calibration
-    if(p_geomSvc->isCalibrationLoaded())
-    { 
-      if((h.detectorID >= 1 && h.detectorID <= nChamberPlanes) || (h.detectorID >= nChamberPlanes+nHodoPlanes+1))
-      {
-        h.setInTime(p_geomSvc->isInTime(h.detectorID, h.tdcTime));
-        if(h.isInTime()) h.driftDistance = p_geomSvc->getDriftDistance(h.detectorID, h.tdcTime);
-      }
-    }
-
-    // FIXME just for the meeting, figure this out fast!
-    if(!_triggerhit_vector and h.detectorID >= 31 and h.detectorID <= 46) {
-      sraw_event->insertTriggerHit(h);
-    }
-    */
-  }
-
-  sraw_event->reIndex(true);
   return sraw_event;
 }
 

--- a/packages/reco/ktracker/SQReco.cxx
+++ b/packages/reco/ktracker/SQReco.cxx
@@ -258,6 +258,18 @@ int SQReco::updateHitInfo(SRawEvent* sraw_event)
   return 0;
 }
 
+/**
+ * Note for pull request.
+ * 
+ * The translation from SQ* to SRawEvent is useful for other classes
+ * (like `Fun4AllSRawEventInputManager`).
+ * Therefore I exported the contetns of this function to a new utility namespace, `UtilSRawEvent`.
+ * Can I modify this function to make use of `UtilSRawEvent`?
+ *
+ * `UtilSRawEvent` cannot handle `_m_hitID_idx` and `_m_trghitID_idx`, but
+ * they seem not in use at present.
+ * Can I remove them??
+ */
 SRawEvent* SQReco::BuildSRawEvent() 
 {
   //Needed for E1039 since we switched to a more generic interface

--- a/packages/reco/ktracker/TriggerAnalyzer.cxx
+++ b/packages/reco/ktracker/TriggerAnalyzer.cxx
@@ -62,10 +62,10 @@ bool TriggerAnalyzer::init()
     int H3BID = p_geomSvc->getDetectorID("H3B");
     int H4BID = p_geomSvc->getDetectorID("H4B");
 
-    std::string roadsPT = Form("%s/firmware/roads/L1/%s/roads_plus_top.txt", rc->get_CharFlag("TRIGGER_REPO").c_str(), rc->get_CharFlag("TRIGGER_L1").c_str());
-    std::string roadsPB = Form("%s/firmware/roads/L1/%s/roads_plus_bottom.txt", rc->get_CharFlag("TRIGGER_REPO").c_str(), rc->get_CharFlag("TRIGGER_L1").c_str());
-    std::string roadsMT = Form("%s/firmware/roads/L1/%s/roads_minus_top.txt", rc->get_CharFlag("TRIGGER_REPO").c_str(), rc->get_CharFlag("TRIGGER_L1").c_str());
-    std::string roadsMB = Form("%s/firmware/roads/L1/%s/roads_minus_bottom.txt", rc->get_CharFlag("TRIGGER_REPO").c_str(), rc->get_CharFlag("TRIGGER_L1").c_str());
+    std::string roadsPT = rc->get_CharFlag("TRIGGER_REPO") + "/firmware/roads/L1/" + rc->get_CharFlag("TRIGGER_L1") + "/roads_plus_top.txt";
+    std::string roadsPB = rc->get_CharFlag("TRIGGER_REPO") + "/firmware/roads/L1/" + rc->get_CharFlag("TRIGGER_L1") + "/roads_plus_bottom.txt";
+    std::string roadsMT = rc->get_CharFlag("TRIGGER_REPO") + "/firmware/roads/L1/" + rc->get_CharFlag("TRIGGER_L1") + "/roads_minus_top.txt";
+    std::string roadsMB = rc->get_CharFlag("TRIGGER_REPO") + "/firmware/roads/L1/" + rc->get_CharFlag("TRIGGER_L1") + "/roads_minus_bottom.txt";
 
     std::string fileNames[4] = {roadsPT, roadsPB, roadsMT, roadsMB};
     char buffer[300];

--- a/packages/reco/ktracker/UtilSRawEvent.cxx
+++ b/packages/reco/ktracker/UtilSRawEvent.cxx
@@ -1,0 +1,90 @@
+//#include <iomanip>
+#include <phool/phool.h>
+#include <interface_main/SQEvent.h>
+#include <interface_main/SQSpillMap.h>
+#include <interface_main/SQHitVector.h>
+#include <ktracker/SRawEvent.h>
+#include "UtilSRawEvent.h"
+using namespace std;
+
+void UtilSRawEvent::SetEvent(SRawEvent* sraw, const SQEvent* evt, const bool do_assert)
+{
+  if (!evt) {
+    if (do_assert) {
+      cout << PHWHERE << ": SQEvent == 0.  Abort." << endl;
+      exit(1);
+    }
+    return;
+  }
+  int run_id   = evt->get_run_id();
+  int spill_id = evt->get_spill_id();
+  int event_id = evt->get_event_id();
+  sraw->setEventInfo(run_id, spill_id, event_id);
+
+  int triggers[10];
+  for(int i = SQEvent::NIM1; i <= SQEvent::MATRIX5; ++i) {
+    triggers[i] = evt->get_trigger(static_cast<SQEvent::TriggerMask>(i));
+  }
+  sraw->setTriggerBits(triggers);
+}
+
+void UtilSRawEvent::SetSpill(SRawEvent* sraw, const SQSpill* sp, const bool do_assert)
+{
+  if (!sp) {
+    if (do_assert) {
+      cout << PHWHERE << ": SQSpill == 0.  Abort." << endl;
+      exit(1);
+    }
+    return;
+  }
+  sraw->setTargetPos(sp->get_target_pos());
+}
+
+void UtilSRawEvent::SetHit(SRawEvent* sraw, const SQHitVector* hit_vec, const bool do_assert)
+{
+  sraw->emptyHits();
+  if (!hit_vec) {
+    if (do_assert) {
+      cout << PHWHERE << ": SQHitVector == 0.  Abort." << endl;
+      exit(1);
+    }
+    return;
+  }
+  for(size_t idx = 0; idx < hit_vec->size(); ++idx) {
+    const SQHit* sq_hit = hit_vec->at(idx);
+    Hit h;
+    h.index         = sq_hit->get_hit_id();
+    h.detectorID    = sq_hit->get_detector_id();
+    h.elementID     = sq_hit->get_element_id();
+    h.tdcTime       = sq_hit->get_tdc_time();
+    h.driftDistance = fabs(sq_hit->get_drift_distance()); //MC L-R info removed here
+    h.pos           = sq_hit->get_pos();
+    if(sq_hit->is_in_time()) h.setInTime();
+    sraw->insertHit(h);
+  }
+  sraw->reIndex(true);
+}
+
+void UtilSRawEvent::SetTriggerHit(SRawEvent* sraw, const SQHitVector* hit_vec, const bool do_assert)
+{
+  sraw->emptyTriggerHits();
+  if (!hit_vec) {
+    if (do_assert) {
+      cout << PHWHERE << ": SQHitVector == 0.  Abort." << endl;
+      exit(1);
+    }
+    return;
+  }
+  for(size_t idx = 0; idx < hit_vec->size(); ++idx) {
+    const SQHit* sq_hit = hit_vec->at(idx);
+    Hit h;
+    h.index         = sq_hit->get_hit_id();
+    h.detectorID    = sq_hit->get_detector_id();
+    h.elementID     = sq_hit->get_element_id();
+    h.tdcTime       = sq_hit->get_tdc_time();
+    h.driftDistance = fabs(sq_hit->get_drift_distance()); //MC L-R info removed here
+    h.pos           = sq_hit->get_pos();
+    if(sq_hit->is_in_time()) h.setInTime();
+    sraw->insertTriggerHit(h);
+  }
+}

--- a/packages/reco/ktracker/UtilSRawEvent.h
+++ b/packages/reco/ktracker/UtilSRawEvent.h
@@ -1,5 +1,6 @@
 #ifndef _UTIL_SRAWEVENT__H_
 #define _UTIL_SRAWEVENT__H_
+#include <map>
 class SRawEvent;
 class SQEvent;
 class SQSpillMap;
@@ -8,10 +9,10 @@ class SQHitVector;
 
 /// A set of utility functions about SRawEvent.
 namespace UtilSRawEvent {
-  void SetEvent     (SRawEvent* sraw, const SQEvent*     evt    , const bool do_assert=false);
-  void SetSpill     (SRawEvent* sraw, const SQSpill*     sp     , const bool do_assert=false);
-  void SetHit       (SRawEvent* sraw, const SQHitVector* hit_vec, const bool do_assert=false);
-  void SetTriggerHit(SRawEvent* sraw, const SQHitVector* hit_vec, const bool do_assert=false);
+  bool SetEvent     (SRawEvent* sraw, const SQEvent*     evt    , const bool do_assert=false);
+  bool SetSpill     (SRawEvent* sraw, const SQSpill*     sp     , const bool do_assert=false);
+  bool SetHit       (SRawEvent* sraw, const SQHitVector* hit_vec, std::map<int, size_t>* hitID_idx=0, const bool do_assert=false);
+  bool SetTriggerHit(SRawEvent* sraw, const SQHitVector* hit_vec, std::map<int, size_t>* hitID_idx=0, const bool do_assert=false);
 };
 
 #endif // _UTIL_SRAWEVENT__H_

--- a/packages/reco/ktracker/UtilSRawEvent.h
+++ b/packages/reco/ktracker/UtilSRawEvent.h
@@ -1,0 +1,17 @@
+#ifndef _UTIL_SRAWEVENT__H_
+#define _UTIL_SRAWEVENT__H_
+class SRawEvent;
+class SQEvent;
+class SQSpillMap;
+class SQSpill;
+class SQHitVector;
+
+/// A set of utility functions about SRawEvent.
+namespace UtilSRawEvent {
+  void SetEvent     (SRawEvent* sraw, const SQEvent*     evt    , const bool do_assert=false);
+  void SetSpill     (SRawEvent* sraw, const SQSpill*     sp     , const bool do_assert=false);
+  void SetHit       (SRawEvent* sraw, const SQHitVector* hit_vec, const bool do_assert=false);
+  void SetTriggerHit(SRawEvent* sraw, const SQHitVector* hit_vec, const bool do_assert=false);
+};
+
+#endif // _UTIL_SRAWEVENT__H_

--- a/simulation/g4detectors/PHG4EMCalDetector.cc
+++ b/simulation/g4detectors/PHG4EMCalDetector.cc
@@ -81,10 +81,10 @@ void PHG4EMCalDetector::Construct(G4LogicalVolume* logicWorld)
   double xLength_enve = m_tower_size_x*m_ntowers_x*cm;
   double yLength_enve = m_tower_size_y*m_ntowers_y*cm;
   double zLength_enve = m_tower_size_z*cm;
-  G4VSolid* emcal_enve_solid = new G4Box(Form("%s_enve_solid", name.c_str()), xLength_enve/2., yLength_enve/2., zLength_enve/2.);
+  G4VSolid* emcal_enve_solid = new G4Box(name+"_enve_solid", xLength_enve/2., yLength_enve/2., zLength_enve/2.);
 
   G4Material* mat_Air = G4Material::GetMaterial("G4_AIR");
-  G4LogicalVolume* emcal_enve_logic = new G4LogicalVolume(emcal_enve_solid, mat_Air, Form("%s_enve_logic", name.c_str()));
+  G4LogicalVolume* emcal_enve_logic = new G4LogicalVolume(emcal_enve_solid, mat_Air, name+"_enve_logic");
 
   G4RotationMatrix rot_enve;
   rot_enve.rotateX(m_Params->get_double_param("rot_x")*rad);
@@ -96,7 +96,7 @@ void PHG4EMCalDetector::Construct(G4LogicalVolume* logicWorld)
   loc_enve.setY(m_Params->get_double_param("place_y")*cm);
   loc_enve.setZ(m_Params->get_double_param("place_z")*cm);
 
-  new G4PVPlacement(G4Transform3D(rot_enve, loc_enve), emcal_enve_logic, Form("%s_enve_phys", name.c_str()), logicWorld, false, 0, overlapcheck);
+  new G4PVPlacement(G4Transform3D(rot_enve, loc_enve), emcal_enve_logic, name+"_enve_phys", logicWorld, false, 0, overlapcheck);
 
   // Construct a single tower
   G4LogicalVolume* singleTower_logic = ConstructSingleTower();
@@ -114,8 +114,8 @@ G4LogicalVolume* PHG4EMCalDetector::ConstructSingleTower()
 
   // create logical volume for single tower
   G4Material* mat_Air = G4Material::GetMaterial("G4_AIR");
-  G4VSolid* singleTower_solid = new G4Box(Form("%s_singleTower_solid", name.c_str()), m_tower_size_x/2., m_tower_size_y/2., m_tower_size_z/2.);
-  G4LogicalVolume* singleTower_logic = new G4LogicalVolume(singleTower_solid, mat_Air, Form("%s_singleTower_logic", name.c_str()));
+  G4VSolid* singleTower_solid = new G4Box(name+"_singleTower_solid", m_tower_size_x/2., m_tower_size_y/2., m_tower_size_z/2.);
+  G4LogicalVolume* singleTower_logic = new G4LogicalVolume(singleTower_solid, mat_Air, name+"_singleTower_logic");
 
   /* create geometry volumes for scintillator and absorber plates to place inside single_tower */
   // PHENIX EMCal JGL 3/27/2016
@@ -124,25 +124,25 @@ G4LogicalVolume* PHG4EMCalDetector::ConstructSingleTower()
   double thickness_scint     = 4.0*mm;   
   double thickness_airgap    = thickness_layer - thickness_absorber - thickness_scint;
 
-  G4VSolid* absorber_solid = new G4Box(Form("%_absorberplate_solid", name.c_str()), m_tower_size_x/2., m_tower_size_y/2., thickness_absorber/2.);
-  G4VSolid* scint_solid    = new G4Box(Form("%_scintplate_solid", name.c_str()), m_tower_size_x/2., m_tower_size_y/2., thickness_scint/2.);
+  G4VSolid* absorber_solid = new G4Box(name+"_absorberplate_solid", m_tower_size_x/2., m_tower_size_y/2., thickness_absorber/2.);
+  G4VSolid* scint_solid    = new G4Box(name+"_scintplate_solid", m_tower_size_x/2., m_tower_size_y/2., thickness_scint/2.);
 
   G4Material* mat_absorber = G4Material::GetMaterial("G4_Pb");
   G4Material* mat_scint    = G4Material::GetMaterial("G4_POLYSTYRENE");
-  m_absorberLogical = new G4LogicalVolume(absorber_solid, mat_absorber, Form("%s_absorberplate_logic", name.c_str()));
-  m_scintLogical    = new G4LogicalVolume(scint_solid, mat_scint, Form("%s_scintplace_logic", name.c_str()));
+  m_absorberLogical = new G4LogicalVolume(absorber_solid, mat_absorber, name+"_absorberplate_logic");
+  m_scintLogical    = new G4LogicalVolume(scint_solid, mat_scint, name+"_scintplace_logic");
 
   /* place physical volumes for absorber and scintillator plates */
   double zpos_i = -m_tower_size_z/2. + thickness_absorber/2.;
   for(int i = 0; i < m_npbsc_layers; ++i)
   {
     //Absorber plate first
-    new G4PVPlacement(0, G4ThreeVector(0., 0., zpos_i), m_absorberLogical, Form("%s_absplate_%d", name.c_str(), i), singleTower_logic, false, i, overlapcheck);
+    new G4PVPlacement(0, G4ThreeVector(0., 0., zpos_i), m_absorberLogical, TString::Format("%s_absplate_%d", name.c_str(), i).Data(), singleTower_logic, false, i, overlapcheck);
     //std::cout << " -- creating absorber plate at z = " << zpos_i/cm << std::endl;
 
     //Scintilator plate second
     zpos_i += (thickness_absorber/2. + thickness_airgap/2. + thickness_scint/2.);
-    new G4PVPlacement(0, G4ThreeVector(0., 0., zpos_i), m_scintLogical, Form("%s_sciplate_%d", name.c_str(), i), singleTower_logic, false, i, overlapcheck);
+    new G4PVPlacement(0, G4ThreeVector(0., 0., zpos_i), m_scintLogical, TString::Format("%s_sciplate_%d", name.c_str(), i).Data(), singleTower_logic, false, i, overlapcheck);
     //std::cout << " -- creating scintillator plate at z = " << zpos_i/cm << std::endl;
 
     //move to the next layer
@@ -166,7 +166,7 @@ void PHG4EMCalDetector::PlaceTower(G4LogicalVolume* envelope_Logic, G4LogicalVol
         std::cout << "  -- Placing tower (" << i << ", " << j << ") at x = " << x_pos/cm << " cm, y = " << y_pos/cm << " cm" << std::endl;
       }
 
-      new G4PVPlacement(0, G4ThreeVector(x_pos, y_pos, 0.), singleTower_logic, Form("%s_tower_%d_%d", name.c_str(), i, j), envelope_Logic, false, copyNo++, overlapcheck);
+      new G4PVPlacement(0, G4ThreeVector(x_pos, y_pos, 0.), singleTower_logic, TString::Format("%s_tower_%d_%d", name.c_str(), i, j).Data(), envelope_Logic, false, copyNo++, overlapcheck);
     }
   }
 }

--- a/simulation/g4eval/PHG4DSTReader.cc
+++ b/simulation/g4eval/PHG4DSTReader.cc
@@ -79,7 +79,7 @@ PHG4DSTReader::Init(PHCompositeNode*)
 
       const string & nodenam = *it;
 
-      string hname = Form("G4HIT_%s", nodenam.c_str());
+      string hname = "G4HIT_" + nodenam;
 //      _node_name.push_back(hname);
       cout << "PHG4DSTReader::Init - saving hits from node: " << hname << " - "
           << class_name << endl;


### PR DESCRIPTION
This update is to introduce a spill-by-spill output of the decoded data for the online reconstruction.  The updated code is already running fine for the online decoding.

`Fun4AllSRawEventOutputManager` is the front end of the new output scheme.  It is enabled by default in the online decoding, i.e. `online/macros/Fun4MainDaq.C`.

The translation from SQEvent/Hit to SRawEvent will be useful for other classes.  Therefore I'd like to export the contents of `SQReco::BuildSRawEvent()` to a new namespace, `UtilSRawEvent`.  One problem here is that two member variables of `SQReco`, i.e. `_m_hitID_idx` and `_m_trghitID_idx`, cannot be handled by `UtilSRawEvent`.  But these variables seem not in use at present.  Can I remove them and use `UtilSRawEvent` in `BuildSRawEvent()`?

