### PR TITLE
Switches for filtering and digitization of simulated data

### DIFF
--- a/simulation/README.md
+++ b/simulation/README.md
@@ -1,0 +1,22 @@
+# Notes on E1039 Simulation Codes
+
+The E1039 simulation codes had been taken from (s)PHENIX, together with the Fun4All framework.
+Many obsolete/unused files are left in this directory.
+This note is to pick up and explain key files/classes, as a guideline for new developer.
+
+## Detector Configuration
+
+* The E1039 detector planes are built as `PHG4BlockSubsystem`, as defined in `macros/G4_SensitiveDetectors.C`.
+
+## Data Nodes
+
+Each event generator fills generated events into the "PHG4*" objects.
+Or some generators (like PYTHIA8) fills into the "HepMC" objects and then `HepMCNodeReader` transfers into "PHG4*".
+
+* `PHG4InEvent`
+    * `PHG4Particle`
+    * `PHG4VtxPoint`
+
+## Interface to Geant4
+
+The "PHG4*" objects are converted into "G4*" objects by `PHG4PrimaryGeneratorAction`.

--- a/simulation/g4detectors/SQDigitizer.cc
+++ b/simulation/g4detectors/SQDigitizer.cc
@@ -55,7 +55,8 @@ SQDigitizer::SQDigitizer(const std::string& name, const int verbose):
   SubsysReco(name), 
   p_geomSvc(nullptr),
   enableDC1(false),
-  enableDPHodo(true)
+  enableDPHodo(true),
+  digitize_secondaries(false)
 {
   detIDByName.clear();
   Verbosity(0);
@@ -158,7 +159,7 @@ void SQDigitizer::digitizePlane(const std::string& detName)
     const PHG4Hit& g4hit = *(it->second);
 
     int track_id = g4hit.get_trkid();
-    if(track_id < 0) continue;         //only save primary track hits
+    if (! digitize_secondaries && track_id < 0) continue; //only save primary track hits
 
     //get average momentum and position
     double x  = 0.5*(g4hit.get_x(0)  + g4hit.get_x(1));

--- a/simulation/g4detectors/SQDigitizer.h
+++ b/simulation/g4detectors/SQDigitizer.h
@@ -52,6 +52,8 @@ public:
   void set_enable_st1dc(const bool en)  { enableDC1 = en; }
   void set_enable_dphodo(const bool en) { enableDPHodo = en; }
 
+  void set_digitize_secondaries(const bool val) { digitize_secondaries = val; }
+
 private:
   //!GeomSvc
   GeomSvc* p_geomSvc;
@@ -68,6 +70,7 @@ private:
   //!flags to toggle station-1 DC and dark photon dp
   bool enableDC1;
   bool enableDPHodo;
+  bool digitize_secondaries;
 };
 
 #endif

--- a/simulation/g4main/HepMCNodeReader.cc
+++ b/simulation/g4main/HepMCNodeReader.cc
@@ -60,7 +60,14 @@ HepMCNodeReader::HepMCNodeReader(const std::string &name)
   , width_vx(0.0)
   , width_vy(0.0)
   , width_vz(0.0)
-	, _particle_filter_on(false)
+  , _particle_filter_on(false)
+  , _position_filter_on(false)
+  , _pos_filter_x_min(0.0)
+  , _pos_filter_x_max(0.0)
+  , _pos_filter_y_min(0.0)
+  , _pos_filter_y_max(0.0)
+  , _pos_filter_z_min(0.0)
+  , _pos_filter_z_max(0.0)
 {
   RandomGenerator = gsl_rng_alloc(gsl_rng_mt19937);
   _particle_filter_pid.clear();
@@ -246,6 +253,11 @@ int HepMCNodeReader::process_event(PHCompositeNode *topNode)
           cout << "Particles" << endl;
         }
 
+        if (_position_filter_on &&
+            (xpos < _pos_filter_x_min || xpos > _pos_filter_x_max ||
+             ypos < _pos_filter_y_min || ypos > _pos_filter_y_max ||
+             zpos < _pos_filter_z_min || zpos > _pos_filter_z_max   )) continue;
+        
         if (ishape == ShapeG4Tubs)
         {
           if (sqrt(xpos * xpos + ypos * ypos) > worldsizey / 2 ||
@@ -314,6 +326,18 @@ double HepMCNodeReader::smeargauss(const double width)
 {
   if (width == 0) return 0;
   return gsl_ran_gaussian(RandomGenerator, width);
+}
+
+/// Enable and define a position filter.  The x,y,z limits are in cm.
+void HepMCNodeReader::enable_position_filter(const double x_min, const double x_max, const double y_min, const double y_max, const double z_min, const double z_max)
+{
+  _position_filter_on = true;
+  _pos_filter_x_min = x_min;
+  _pos_filter_x_max = x_max;
+  _pos_filter_y_min = y_min;
+  _pos_filter_y_max = y_max;
+  _pos_filter_z_min = z_min;
+  _pos_filter_z_max = z_max;
 }
 
 bool HepMCNodeReader::PassParticleFilter(HepMC::GenParticle* p) {

--- a/simulation/g4main/HepMCNodeReader.h
+++ b/simulation/g4main/HepMCNodeReader.h
@@ -57,6 +57,8 @@ class HepMCNodeReader : public SubsysReco
   void set_particle_filter_on(const bool a) {_particle_filter_on = a;}
   void insert_particle_filter_pid(const int a) {_particle_filter_pid.push_back(a);}
 
+  void enable_position_filter(const double x_min, const double x_max, const double y_min, const double y_max, const double z_min, const double z_max);
+
   bool PassParticleFilter(HepMC::GenParticle * p);
 
  private:
@@ -75,6 +77,13 @@ class HepMCNodeReader : public SubsysReco
   bool _particle_filter_on;
   std::vector<int> _particle_filter_pid;
 
+  bool _position_filter_on;
+  double _pos_filter_x_min;
+  double _pos_filter_x_max;
+  double _pos_filter_y_min;
+  double _pos_filter_y_max;
+  double _pos_filter_z_min;
+  double _pos_filter_z_max;
 
 #ifndef __CINT__
   gsl_rng *RandomGenerator;


### PR DESCRIPTION
Here is a small update to add switches for handling of simulated data.  I needed them to efficiently generate open-charm events.

`HepMCNodeReader` is already able to filter out particles by particle ID.  I added a function, `enable_position_filter(), to select particles by production position.  Using this function, we can have an event generator (like PYTHIA) produce muons and then `HepMCNodeReader` exclude muons produced behind FMag.

`SQDigitizer` doesn't digitize secondary particles by default.  I added a function, `set_digitize_secondaries()`, to change the behavior.

They won't change the default behavior of our simulation.  Thus this PR can be merged safely.
