### PR TITLE
changed PHG4INEVENT from PHDataNode to PHIODataNode

### DIFF
--- a/generators/E906LegacyGen/SQPileupGen.C
+++ b/generators/E906LegacyGen/SQPileupGen.C
@@ -79,7 +79,7 @@ int SQPileupGen::InitRun(PHCompositeNode* topNode)
       PHCompositeNode* dstNode = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "DST"));
       
       _ineve = new PHG4InEvent();
-      dstNode->addNode(new PHDataNode<PHObject>(_ineve, "PHG4INEVENT", "PHObject"));
+      dstNode->addNode(new PHIODataNode<PHObject>(_ineve, "PHG4INEVENT", "PHObject"));
     }
 
   _evt = findNode::getClass<SQEvent>(topNode, "SQEvent");

--- a/generators/E906LegacyGen/SQPrimaryParticleGen.C
+++ b/generators/E906LegacyGen/SQPrimaryParticleGen.C
@@ -152,7 +152,7 @@ int SQPrimaryParticleGen::InitRun(PHCompositeNode* topNode)
   ineve = findNode::getClass<PHG4InEvent>(topNode,"PHG4INEVENT");
   if (!ineve) {
     ineve = new PHG4InEvent();
-    dstNode->addNode(new PHDataNode<PHObject>(ineve, "PHG4INEVENT", "PHObject"));
+    dstNode->addNode(new PHIODataNode<PHObject>(ineve, "PHG4INEVENT", "PHObject"));
   }
   _evt = findNode::getClass<SQEvent>(topNode, "SQEvent");
   if (! _evt) {

--- a/simulation/g4main/HepMCNodeReader.cc
+++ b/simulation/g4main/HepMCNodeReader.cc
@@ -93,8 +93,8 @@ int HepMCNodeReader::Init(PHCompositeNode *topNode)
       dstNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "DST"));
 
       ineve = new PHG4InEvent();
-      PHDataNode<PHObject> *newNode =
-        new PHDataNode<PHObject>(ineve, "PHG4INEVENT", "PHObject");
+      PHIODataNode<PHObject> *newNode =
+        new PHIODataNode<PHObject>(ineve, "PHG4INEVENT", "PHObject");
       dstNode->addNode(newNode);
     }
   unsigned int phseed = PHRandomSeed();  // fixed seed is handled in this funtcion, need to call it to preserve random numbder order even if we override it

--- a/simulation/g4main/PHG4ParticleGeneratorBase.cc
+++ b/simulation/g4main/PHG4ParticleGeneratorBase.cc
@@ -127,7 +127,7 @@ int PHG4ParticleGeneratorBase::InitRun(PHCompositeNode *topNode)
     dstNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "DST"));
 
     ineve = new PHG4InEvent();
-    PHDataNode<PHObject> *newNode = new PHDataNode<PHObject>(ineve, "PHG4INEVENT", "PHObject");
+    PHIODataNode<PHObject> *newNode = new PHIODataNode<PHObject>(ineve, "PHG4INEVENT", "PHObject");
     dstNode->addNode(newNode);
   }
   return 0;

--- a/simulation/g4main/PHG4ParticleGeneratorVectorMeson.cc
+++ b/simulation/g4main/PHG4ParticleGeneratorVectorMeson.cc
@@ -263,7 +263,7 @@ PHG4ParticleGeneratorVectorMeson::InitRun(PHCompositeNode *topNode)
     dstNode = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "DST"));
 
     ineve = new PHG4InEvent();
-    PHDataNode<PHObject> *newNode = new PHDataNode<PHObject>(ineve, "PHG4INEVENT", "PHObject");
+    PHIODataNode<PHObject> *newNode = new PHIODataNode<PHObject>(ineve, "PHG4INEVENT", "PHObject");
     dstNode->addNode(newNode);
   }
 

--- a/simulation/g4main/PHG4Reco.cc
+++ b/simulation/g4main/PHG4Reco.cc
@@ -687,7 +687,7 @@ int PHG4Reco::setupInputEventNodeReader(PHCompositeNode *topNode)
     dstNode = dynamic_cast<PHCompositeNode *>(iter.findFirst("PHCompositeNode", "DST"));
 
     ineve = new PHG4InEvent();
-    PHDataNode<PHObject> *newNode = new PHDataNode<PHObject>(ineve, "PHG4INEVENT", "PHObject");
+    PHIODataNode<PHObject> *newNode = new PHIODataNode<PHObject>(ineve, "PHG4INEVENT", "PHObject");
     dstNode->addNode(newNode);
   }
   generatorAction_ = new PHG4PrimaryGeneratorAction();

--- a/simulation/g4main/PHG4SimpleEventGenerator.cc
+++ b/simulation/g4main/PHG4SimpleEventGenerator.cc
@@ -204,7 +204,7 @@ int PHG4SimpleEventGenerator::InitRun(PHCompositeNode *topNode) {
   _ineve = findNode::getClass<PHG4InEvent>(topNode, "PHG4INEVENT");
   if (!_ineve) {
     _ineve = new PHG4InEvent();
-    dstNode->addNode(new PHDataNode<PHObject>(_ineve, "PHG4INEVENT", "PHObject"));
+    dstNode->addNode(new PHIODataNode<PHObject>(_ineve, "PHG4INEVENT", "PHObject"));
   }
   _evt = findNode::getClass<SQEvent>(topNode, "SQEvent");
   if (!_evt) {

--- a/simulation/g4main/SQCosmicGen.cc
+++ b/simulation/g4main/SQCosmicGen.cc
@@ -74,7 +74,7 @@ int SQCosmicGen::InitRun(PHCompositeNode* topNode)
     dstNode = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "DST"));
       
     _ineve = new PHG4InEvent();
-    PHDataNode<PHObject> *newNode = new PHDataNode<PHObject>(_ineve, "PHG4INEVENT", "PHObject");
+    PHIODataNode<PHObject> *newNode = new PHIODataNode<PHObject>(_ineve, "PHG4INEVENT", "PHObject");
     dstNode->addNode(newNode);
   }
 


### PR DESCRIPTION
Changed PHINEVENT from PHDataNode to PHIODataNode to make it more flexible to use in the DST level analysis (as found by discussion with Kenichi). Most of the changes are very small in the generator levels. I built the change successfully.