### PR TITLE
Addition of concrete block behind FMag

### DIFF
--- a/macros/Fun4DumpGeom.C
+++ b/macros/Fun4DumpGeom.C
@@ -1,4 +1,6 @@
-/// Macro to save the geometry info on ROOT file, `geom.root`.
+/** @file
+ * @brief Macro to save the geometry info on ROOT file, `geom.root`.
+ */
 #include <TSystem.h>
 #include "G4_Beamline.C"
 #include "G4_Target.C"

--- a/macros/Fun4DumpGeom.C
+++ b/macros/Fun4DumpGeom.C
@@ -1,17 +1,19 @@
+/// Macro to save the geometry info on ROOT file, `geom.root`.
 #include <TSystem.h>
-
 #include "G4_Beamline.C"
 #include "G4_Target.C"
 #include "G4_InsensitiveVolumes.C"
 #include "G4_SensitiveDetectors.C"
-
 R__LOAD_LIBRARY(libfun4all)
 R__LOAD_LIBRARY(libgeom_svc)
 R__LOAD_LIBRARY(libg4detectors)
 R__LOAD_LIBRARY(libg4dst)
-
 using namespace std;
 
+/// Macro function to save the geometry info on ROOT file, `geom.root`.
+/**
+ * t.b.w.
+ */
 int Fun4DumpGeom(const bool display = true)
 {
   // geometry setup

--- a/macros/G4_Beamline.C
+++ b/macros/G4_Beamline.C
@@ -1,3 +1,4 @@
+/// Macro to configure the beamline objects.
 #pragma once
 #if ROOT_VERSION_CODE >= ROOT_VERSION(6,00,0)
 #include <g4detectors/PHG4CollimatorSubsystem.h>
@@ -5,6 +6,10 @@ class SubsysReco;
 R__LOAD_LIBRARY(libg4detectors)
 #endif
 
+/// Macro function to configure the beamline objects.
+/**
+ * t.b.w.
+ */
 void SetupBeamline(
   PHG4Reco* g4Reco,
   const bool toggle_collimator = true,

--- a/macros/G4_Beamline.C
+++ b/macros/G4_Beamline.C
@@ -1,4 +1,8 @@
-/// Macro to configure the beamline objects.
+/** @file
+ * @brief Macro to configure the beamline objects.
+ *
+ * The usage is similar to `G4_SensitiveDetectors.C`.
+ */
 #pragma once
 #if ROOT_VERSION_CODE >= ROOT_VERSION(6,00,0)
 #include <g4detectors/PHG4CollimatorSubsystem.h>

--- a/macros/G4_InsensitiveVolumes.C
+++ b/macros/G4_InsensitiveVolumes.C
@@ -1,3 +1,4 @@
+/// Macro to configure the insensitive volumes.
 #pragma once
 #if ROOT_VERSION_CODE >= ROOT_VERSION(6,00,0)
 #include <g4detectors/PHG4BlockSubsystem.h>
@@ -7,15 +8,15 @@ class SubsysReco;
 R__LOAD_LIBRARY(libg4detectors)
 #endif
 
-/*
-This macro implements the all the volumes that are not sensitive - i.e. do not need to generate G4Hits
-The insensitive volumes implemented here are:
-    1. concrete shielding in front of FMag
-    2. FMag/beam dump
-    3. KMag
-    4. Muon absorber between station-3 and -4
-*/
-
+/// Macro function to configure the insensitive volumes.
+/**
+ * This macro implements the all the volumes that are not sensitive - i.e. do not need to generate G4Hits.
+ * The insensitive volumes implemented here are:
+ *     1. concrete shielding in front of FMag
+ *     2. FMag/beam dump
+ *     3. KMag
+ *     4. Muon absorber between station-3 and -4
+ */
 void SetupInsensitiveVolumes(
   PHG4Reco* g4Reco,
   const bool toggle_shielding = true,

--- a/macros/G4_InsensitiveVolumes.C
+++ b/macros/G4_InsensitiveVolumes.C
@@ -71,9 +71,9 @@ void SetupInsensitiveVolumes(
     const double inch = 2.54;
     PHG4BlockSubsystem* shielding_behind_fmag = new PHG4BlockSubsystem("ShieldingBehindFmag", 0);
     shielding_behind_fmag->set_double_param("place_x",   0.0); // Place and size are preliminary.  See DocDB 9732
-    shielding_behind_fmag->set_double_param("place_y",   0.0);
+    shielding_behind_fmag->set_double_param("place_y", -6.*inch);
     shielding_behind_fmag->set_double_param("place_z", 562.0);
-    shielding_behind_fmag->set_double_param("size_x", 108.*inch);
+    shielding_behind_fmag->set_double_param("size_x", 144.*inch);
     shielding_behind_fmag->set_double_param("size_y", 144.*inch);
     shielding_behind_fmag->set_double_param("size_z",  18.*inch);
     shielding_behind_fmag->set_string_param("material", "G4_CONCRETE");

--- a/macros/G4_InsensitiveVolumes.C
+++ b/macros/G4_InsensitiveVolumes.C
@@ -67,6 +67,19 @@ void SetupInsensitiveVolumes(
     g4Reco->registerSubsystem(shielding);
   }
 
+  if(false) { // false by default at present.  Change to true manually when necessary
+    const double inch = 2.54;
+    PHG4BlockSubsystem* shielding_behind_fmag = new PHG4BlockSubsystem("ShieldingBehindFmag", 0);
+    shielding_behind_fmag->set_double_param("place_x",   0.0); // Place and size are preliminary.  See DocDB 9732
+    shielding_behind_fmag->set_double_param("place_y",   0.0);
+    shielding_behind_fmag->set_double_param("place_z", 562.0);
+    shielding_behind_fmag->set_double_param("size_x", 108.*inch);
+    shielding_behind_fmag->set_double_param("size_y", 144.*inch);
+    shielding_behind_fmag->set_double_param("size_z",  18.*inch);
+    shielding_behind_fmag->set_string_param("material", "G4_CONCRETE");
+    g4Reco->registerSubsystem(shielding_behind_fmag);
+  }
+
   if(toggle_fmag) {
     SQG4DipoleMagnetSubsystem* fmag = new SQG4DipoleMagnetSubsystem("fmag");
     fmag->set_string_param("geomdb", "$E1039_RESOURCE/geometry/magnetic_fields/magnet_geom.db");

--- a/macros/G4_InsensitiveVolumes.C
+++ b/macros/G4_InsensitiveVolumes.C
@@ -1,4 +1,8 @@
-/// Macro to configure the insensitive volumes.
+/** @file
+ * @brief Macro to configure the insensitive volumes.
+ *
+ * The usage is similar to `G4_SensitiveDetectors.C`.
+ */
 #pragma once
 #if ROOT_VERSION_CODE >= ROOT_VERSION(6,00,0)
 #include <g4detectors/PHG4BlockSubsystem.h>

--- a/macros/G4_SensitiveDetectors.C
+++ b/macros/G4_SensitiveDetectors.C
@@ -1,5 +1,6 @@
-/// Macro to configure the sensitive volumes.
-/**
+/** @file
+ * @brief Macro to configure the sensitive volumes.
+ *
  * You first include this macro in main macro like `Fun4All.C`;
  * @code
  * #include <top/G4_SensitiveDetectors.C>
@@ -12,7 +13,7 @@
  * You can give function arguments to change the behavior.
  *
  * If you want to modify the macro function itself,
- * you can copy the macro file to your local directory and include it via;
+ * you can copy the macro file to your local directory, modify it and include it via;
  * @code
  * #include "G4_SensitiveDetectors.C"
  * @endcode

--- a/macros/G4_SensitiveDetectors.C
+++ b/macros/G4_SensitiveDetectors.C
@@ -1,3 +1,22 @@
+/// Macro to configure the sensitive volumes.
+/**
+ * You first include this macro in main macro like `Fun4All.C`;
+ * @code
+ * #include <top/G4_SensitiveDetectors.C>
+ * @endcode
+ *
+ * You then call the macro function;
+ * @code
+ * SetupSensitiveDetectors(g4Reco);
+ * @endcode
+ * You can give function arguments to change the behavior.
+ *
+ * If you want to modify the macro function itself,
+ * you can copy the macro file to your local directory and include it via;
+ * @code
+ * #include "G4_SensitiveDetectors.C"
+ * @endcode
+ */
 #pragma once
 #if ROOT_VERSION_CODE >= ROOT_VERSION(6,00,0)
 #include <g4detectors/PHG4BlockSubsystem.h>
@@ -8,6 +27,10 @@ class SubsysReco;
 #include <g4detectors/SQDigitizer.h>
 typedef SQDigitizer DPDigitizer;  //so that the naming DPDigitizer is still avaiable for backward compatibility
 
+/// Macro function to configure the sensitive volumes.
+/**
+ * This macro implements the all the volumes that are sensitive, which generate G4Hits.
+ */
 void SetupSensitiveDetectors(
   PHG4Reco*   g4Reco,
   bool        toggle_dphodo = true,

--- a/macros/G4_Target.C
+++ b/macros/G4_Target.C
@@ -1,4 +1,8 @@
-/// Macro to configure the target objects.
+/** @file
+ * @brief Macro to configure the target objects.
+ *
+ * The usage is similar to `G4_SensitiveDetectors.C`.
+ */
 #pragma once
 #if ROOT_VERSION_CODE >= ROOT_VERSION(6,00,0)
 #include <g4detectors/PHG4TargetCoilV2Subsystem.h>

--- a/macros/G4_Target.C
+++ b/macros/G4_Target.C
@@ -1,3 +1,4 @@
+/// Macro to configure the target objects.
 #pragma once
 #if ROOT_VERSION_CODE >= ROOT_VERSION(6,00,0)
 #include <g4detectors/PHG4TargetCoilV2Subsystem.h>
@@ -7,6 +8,10 @@ class SubsysReco;
 R__LOAD_LIBRARY(libg4detectors)
 #endif
 
+/// Macro function to configure the target objects.
+/**
+ * t.b.w.
+ */
 void SetupTarget(
   PHG4Reco* g4Reco,
   const double target_coil_pos_z = -300,

--- a/online/onlmonserver/OnlMonCham.cc
+++ b/online/onlmonserver/OnlMonCham.cc
@@ -34,18 +34,18 @@ int OnlMonCham::InitOnlMon(PHCompositeNode* topNode)
 int OnlMonCham::InitRunOnlMon(PHCompositeNode* topNode)
 {
   const double DT = 40/9.0; // 4/9 ns per single count of Taiwan TDC
-  int    NT = 150;
-  double T0 = 110.5*DT;
-  double T1 = 260.5*DT;
+  int    NT = 300;
+  double T0 = 150.5*DT;
+  double T1 = 450.5*DT;
 
   GeomSvc* geom = GeomSvc::instance();
   string name_regex = "";
   switch (m_type) {
   case D0 :  name_regex = "^D0" ;  break;
   case D1 :  name_regex = "^D1" ;  break;
-  case D2 :  name_regex = "^D2" ;  NT=150; T0=100.5*DT; T1=250.5*DT;  break;
-  case D3p:  name_regex = "^D3p";  NT=150; T0=100.5*DT; T1=250.5*DT;  break;
-  case D3m:  name_regex = "^D3m";  NT=150; T0=100.5*DT; T1=250.5*DT;  break;
+  case D2 :  name_regex = "^D2" ;  NT=300; T0=100.5*DT; T1=400.5*DT;  break;
+  case D3p:  name_regex = "^D3p";  NT=300; T0= 50.5*DT; T1=350.5*DT;  break;
+  case D3m:  name_regex = "^D3m";  NT=300; T0=100.5*DT; T1=400.5*DT;  break;
   }
   vector<int> list_det_id = geom->getDetectorIDs(name_regex);
   if (list_det_id.size() == 0) {


### PR DESCRIPTION
Here are small changes to
1. Add the concrete block behind FMag to the insensitive volumes,
2. Add short Doxygen comments to `G4_*.C`, and
3. Change the range of the TDC time histograms in  `OnlMonCham`.

Lines 75-87 of `InsensitiveVolumes.C` are for the 1st change.  It is disabled by default at present, and thus won't affect any real/simulation result.  DarkQuest will test it first.  SpinQuest might enable it, after checking its effect.

The 3rd change is totally an additional one that I found necessary now.  The range was found too narrow and thus enlarged.

I have confirmed that the modified code can be built without error.