### PR TITLE
Small updates on SQPileupGen, MainDaqParser and CalibDriftDist

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -21,7 +21,7 @@ install=$MY_INSTALL
 mode=all
 OPTIND=1
 cmake_args=""
-while getopts ":s:r:i:c:b:" OPT ; do
+while getopts ":s:r:i:c:b:B" OPT ; do
     case $OPT in
         s ) mode='single'
             package=$OPTARG
@@ -39,6 +39,9 @@ while getopts ":s:r:i:c:b:" OPT ; do
             echo " - pass additional args $cmake_args to cmake"
             ;;
         b ) build=$OPTARG
+            echo "Build directory = $build"
+            ;;
+        B ) build=$src/../core-build
             echo "Build directory = $build"
             ;;
         * ) echo 'Unsupported option.  Abort.'

--- a/generators/E906LegacyGen/SQPileupGen.C
+++ b/generators/E906LegacyGen/SQPileupGen.C
@@ -177,6 +177,7 @@ int SQPileupGen::process_event(PHCompositeNode* topNode)
   _evt->set_run_id(0);
   _evt->set_spill_id(0);
   _evt->set_event_id(_n_proc_evt);
+  _evt->set_qie_rf_intensity(0, QIEcount);
   return Fun4AllReturnCodes::EVENT_OK; 
 }
 

--- a/generators/E906LegacyGen/SQPileupGen.h
+++ b/generators/E906LegacyGen/SQPileupGen.h
@@ -14,7 +14,7 @@ class TFile;
 class TTree;
 class TClonesArray;
 class TF1;
-class TH1D;
+class TH1;
 
 class SQMCEvent;
 class SQPrimaryVertexGen;
@@ -53,7 +53,7 @@ class SQPileupGen: public PHG4ParticleGeneratorBase
     return _beam_intensity_profile;
   }
 
-  TH1D* get_beam_intensity_profile_histo() const ///< Return beam intensity profile histogram for pileup
+  TH1* get_beam_intensity_profile_histo() const ///< Return beam intensity profile histogram for pileup
   {
     return _beam_intensity_profile_histo;
   }
@@ -63,7 +63,7 @@ class SQPileupGen: public PHG4ParticleGeneratorBase
     _beam_intensity_profile = beamIntensityProfile;
   }
 
-  void set_beam_intensity_profile_histo(TH1D* beamIntensityProfile_histo)
+  void set_beam_intensity_profile_histo(TH1* beamIntensityProfile_histo)
   {
     _beam_intensity_profile_histo = beamIntensityProfile_histo;
   }
@@ -83,7 +83,7 @@ class SQPileupGen: public PHG4ParticleGeneratorBase
 
 
   TF1* _beam_intensity_profile;
-  TH1D* _beam_intensity_profile_histo;
+  TH1* _beam_intensity_profile_histo;
   //! internal container for quick particle cache
   std::vector<ExtParticle> _extParticles;
 

--- a/online/decoder_maindaq/MainDaqParser.cc
+++ b/online/decoder_maindaq/MainDaqParser.cc
@@ -89,6 +89,7 @@ int MainDaqParser::ParseOneSpill()
       case GO_EVENT: // do nothing
         break;
       case END_EVENT:
+        ret = ProcessCodaEnd(event_words);
         coda->ForceEnd(); //if (dec_par.verbose) printf ("End Event Processed\n");
         break;
       default:
@@ -162,6 +163,18 @@ int MainDaqParser::ProcessCodaPrestart(int* words)
     coda->SetRunNumber(dec_par.runID);
 
     return 0;
+}
+
+/**
+ * Process one Coda End event.
+ *  - words[0] = Word length.
+ *  - words[1] = Event type (End).
+ */
+int MainDaqParser::ProcessCodaEnd(int* words)
+{
+  run_data.utime_e = words[2];
+  cout << "  ProcessCodaEnd " << run_data.utime_e << endl;
+  return 0;
 }
 
 int MainDaqParser::ProcessCodaFee(int* words)

--- a/online/decoder_maindaq/MainDaqParser.h
+++ b/online/decoder_maindaq/MainDaqParser.h
@@ -21,6 +21,7 @@ class MainDaqParser {
 
   // Handlers of CODA Event
   int ProcessCodaPrestart   (int* words);
+  int ProcessCodaEnd        (int* words);
   int ProcessCodaFee        (int* words);
   int ProcessCodaFeeBoard   (int* words);
   int ProcessCodaFeePrescale(int* words);

--- a/packages/calibrator/CalibDriftDist.h
+++ b/packages/calibrator/CalibDriftDist.h
@@ -6,7 +6,14 @@ class CalibParamXT;
 class CalibParamInTimeTaiwan;
 
 /// SubsysReco module to calibrate the drift distance and also the in-time window of the chambers and the prop tube.
+/**
+ * This module automatically selects a proper set of calibration parameters based on the run number.
+ * Only when necessary, you can manually give a parameter set via `ReadParamFromFile()`.
+ */
 class CalibDriftDist: public SubsysReco {
+  bool m_manual_map_selection;
+  std::string m_fn_int;
+  std::string m_fn_xt;
   SQHitVector* m_vec_hit;
   CalibParamXT* m_cal_xt;
   CalibParamInTimeTaiwan* m_cal_int;
@@ -18,6 +25,10 @@ class CalibDriftDist: public SubsysReco {
   int InitRun(PHCompositeNode *topNode);
   int process_event(PHCompositeNode *topNode);
   int End(PHCompositeNode *topNode);
+
+  void ReadParamFromFile(const char* fn_in_time, const char* fn_xt_curve);
+  CalibParamXT*           GetParamXT    () { return m_cal_xt ; }
+  CalibParamInTimeTaiwan* GetParamInTime() { return m_cal_int; }
 };
 
 #endif // __CALIB_DRIFT_DIST_H__

--- a/packages/geom_svc/RunParamBase.cc
+++ b/packages/geom_svc/RunParamBase.cc
@@ -62,12 +62,14 @@ void RunParamBase::WriteToFile()
 
 void RunParamBase::ReadFromLocalFile(const string fn_tsv)
 {
-  cout << "  RunParamBase::ReadFromFile(): " << fn_tsv << "...";
-  ifstream ifs(fn_tsv.c_str());
+  char* path = gSystem->ExpandPathName(fn_tsv.c_str());
+  cout << "  RunParamBase::ReadFromFile(): " << path << "...";
+  ifstream ifs(path);
   if (! ifs) {
-    cerr << "\n!!ERROR!!  Cannot open the map file '" << fn_tsv << "'." << endl;
+    cerr << "\n!!ERROR!!  Cannot open the map file '" << path << "'." << endl;
     exit(1);
   } 
+  delete path;
 
   LineList lines;
   string buffer;
@@ -82,12 +84,15 @@ void RunParamBase::ReadFromLocalFile(const string fn_tsv)
 
 void RunParamBase::WriteToLocalFile(const string fn_tsv)
 {
-  cout << "  RunParamBase::WriteToFile(): " << fn_tsv << "...";
-  ofstream ofs(fn_tsv.c_str());
+  char* path = gSystem->ExpandPathName(fn_tsv.c_str());
+  cout << "  RunParamBase::WriteToFile(): " << path << "...";
+  ofstream ofs(path);
   if (! ofs) {
-    cerr << "\n!!ERROR!!  Cannot open the map file '" << fn_tsv << "'." << endl;
+    cerr << "\n!!ERROR!!  Cannot open the map file '" << path << "'." << endl;
     exit(1);
   }
+  delete path;
+
   ofs << "#" << m_header << "\n";
   int nn = WriteFileCont(ofs);
   ofs.close();

--- a/script/exec-decoder.sh
+++ b/script/exec-decoder.sh
@@ -10,19 +10,19 @@
 # without manual setting.
 
 if [ $(hostname -s) != 'e1039prod1' ] ; then
-    echo "!!ERROR!!  This script must be run on seaquestdaq01.  Abort."
+    echo "!!ERROR!!  This script must be run on e1039prod1.  Abort."
     exit
 fi
 
-CORE_VER=default
+E1039_CORE_VERSION=default
 IS_ONLINE=false
 DECO_MODE=devel
 
 OPTIND=1
 while getopts ":v:osd" OPT ; do
     case $OPT in
-        v ) CORE_VER=$OPTARG
-            echo "  E1039_CORE version: $CORE_VER"
+        v ) E1039_CORE_VERSION=$OPTARG
+            echo "  E1039_CORE version: $E1039_CORE_VERSION"
             ;;
         o ) IS_ONLINE=true
             echo "  Online mode: $IS_ONLINE"
@@ -44,7 +44,7 @@ fi
 
 DIR_SCRIPT=$(dirname $(readlink -f $0))
 if [ $DIR_SCRIPT = '/data2/e1039/script' ] ; then
-    source /data2/e1039/this-e1039.sh $CORE_VER
+    source /data2/e1039/this-e1039.sh
 elif [ -z "$E1039_CORE" ] ; then
     echo '!!ERROR!!  "E1039_CORE" has not been set.  Abort.'
     exit

--- a/script/setup-install.sh
+++ b/script/setup-install.sh
@@ -25,8 +25,6 @@ if [ -z "$1" ] ; then
     exit 1
 elif [ "X$1" = 'Xauto' ] ; then
     DIR_INST=$(readlink -f $DIR_SCRIPT/../../core-inst)
-elif [ "X$1" = 'Xonline' ] ; then
-    DIR_INST=/data2/e1039/core/new
 elif [ "X$1" = 'Xosg-user' ] ; then
     DIR_INST=/e906/app/software/osg/users/$USER/e1039/core
 else


### PR DESCRIPTION
I'd like to suggest a small update on SQPileupGen, together with other unrelated ones that I need now.

I added `_evt->set_qie_rf_intensity(0, QIEcount)` to `SQPileupGen.C`, which sets the QIE count to SQEvent.  It should be useful in comparing the piled-up events with the E906 NIM3 events etc.  I also changed `TH1D*` to `TH1*` in SQPileupGen, where we had better use the base class in general.

I modified the decoder (`MainDaqParser`), which now extracts the run-end time from the Coda End event.  The run-end time had been available but just not utilized by the decoder. 

I modified `CalibDriftDist` (and `RunParamBase`), which is now able to read a parameter set (i.e. chamber X-T curve) from a local file.  This function will be soon used by the calibration of the X-T curve using cosmic rays.

I added a "-B" option to `build.sh`.  It sets the build directory to `../core-build`, instead of `./build`.  I think it convenient because the source directory is kept clean.  Can I even make it default?

The updated code can be built fine.  I have only confirmed that the run-end time extracted by `MainDaqParser` is reasonable.  The other changes should not affect the default software behavior.  I will do individual tests in the coming weeks.