### PR TITLE
Addition of OnlMonParam etc.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -38,7 +38,7 @@ while getopts ":s:r:i:c:b:" OPT ; do
         c ) cmake_args=$OPTARG
             echo " - pass additional args $cmake_args to cmake"
             ;;
-        b ) build=$OPTARG
+        b ) build=$(readlink -e $OPTARG)
             echo "Build directory = $build"
             ;;
         * ) echo 'Unsupported option.  Abort.'

--- a/online/onlmonserver/LinkDef.h
+++ b/online/onlmonserver/LinkDef.h
@@ -6,6 +6,7 @@
 #pragma link C++ class OnlMonServer-!;
 #pragma link C++ class OnlMonClient-!;
 #pragma link C++ class OnlMonUI-!;
+#pragma link C++ class OnlMonParam-!;
 #pragma link C++ typedef OnlMonClientList_t;
 
 #pragma link C++ class AnaWait-!;

--- a/online/onlmonserver/OnlMonMainDaq.cc
+++ b/online/onlmonserver/OnlMonMainDaq.cc
@@ -176,7 +176,7 @@ int OnlMonMainDaq::DrawMonitor()
   double n_ttdc_mean = h1_n_taiwan->GetMean();
   if (fabs(n_ttdc_mean - n_ttdc) > 0.1) {
     can->SetWorseStatus(OnlMonCanvas::ERROR);
-    can->AddMessage(TString::Format("N of Taiwan TDCs = %f, not %d.", n_ttdc_mean, n_ttdc).Data());
+    can->AddMessage(TString::Format("N of Taiwan TDCs = %.1f, not %d.", n_ttdc_mean, n_ttdc).Data());
   }
 
   pad->cd(3);

--- a/online/onlmonserver/OnlMonMainDaq.cc
+++ b/online/onlmonserver/OnlMonMainDaq.cc
@@ -11,6 +11,7 @@
 #include <phool/PHIODataNode.h>
 #include <phool/getClass.h>
 #include <UtilAna/UtilHist.h>
+#include "OnlMonParam.h"
 #include "OnlMonMainDaq.h"
 using namespace std;
 
@@ -134,6 +135,9 @@ int OnlMonMainDaq::FindAllMonHist()
 
 int OnlMonMainDaq::DrawMonitor()
 {
+  OnlMonParam param(this);
+  int n_ttdc = param.GetIntParam("N_TAIWAN_TDC");
+
   UtilHist::AutoSetRange(h1_n_taiwan);
 
   OnlMonCanvas* can = GetCanvas();
@@ -169,6 +173,11 @@ int OnlMonMainDaq::DrawMonitor()
   pad22->cd();
   pad22->SetGrid();
   h1_n_taiwan->Draw();
+  double n_ttdc_mean = h1_n_taiwan->GetMean();
+  if (fabs(n_ttdc_mean - n_ttdc) > 0.1) {
+    can->SetWorseStatus(OnlMonCanvas::ERROR);
+    can->AddMessage(TString::Format("N of Taiwan TDCs = %f, not %d.", n_ttdc_mean, n_ttdc).Data());
+  }
 
   pad->cd(3);
   TPaveText* pate = new TPaveText(.02, .02, .98, .98);

--- a/online/onlmonserver/OnlMonParam.cc
+++ b/online/onlmonserver/OnlMonParam.cc
@@ -1,0 +1,134 @@
+#include <iostream>
+#include <fstream>
+#include <sstream>
+#include <iomanip>
+#include <TROOT.h>
+#include <TSystem.h>
+#include <phool/recoConsts.h>
+#include "OnlMonClient.h"
+#include "OnlMonParam.h"
+using namespace std;
+
+OnlMonParam::OnlMonParam(const OnlMonClient* omc)
+  : m_name(omc->Name())
+  , m_dir_base("/data2/e1039/onlmon/param")
+  , m_run_id(0)
+  , m_verb(2) // High default verbosity for now
+  , m_do_assert(true)
+{
+  ;
+}
+
+OnlMonParam::OnlMonParam(const std::string name)
+  : m_name(name)
+  , m_dir_base("/data2/e1039/onlmon/param")
+  , m_run_id(0)
+  , m_verb(2) // High default verbosity for now
+  , m_do_assert(true)
+{
+  ;
+}
+
+OnlMonParam::~OnlMonParam()
+{
+  ;
+}
+
+std::string OnlMonParam::GetCharParam(const std::string name)
+{
+  int run = m_run_id>0 ? m_run_id : recoConsts::instance()->get_IntFlag("RUNNUMBER");
+  string dir_name = m_dir_base + "/" + m_name;
+  if (m_verb > 0) {
+    cout << "OnlMonParam: name = " << name << " run = " << run << ".\n"
+         << "  Directory = " << dir_name << endl;
+  }
+  string value = "";
+  bool not_found = true;
+  void* dirp = gSystem->OpenDirectory(dir_name.c_str());
+  if (dirp) {
+    const char* name_char;
+    while (not_found && (name_char = gSystem->GetDirEntry(dirp))) {
+      if (m_verb > 0) {
+        cout << "  File = " << name_char << endl;
+      }
+      string name = name_char;
+      int length = name.length();
+      if (length > 4 && name.substr(length-4, 4) == ".tsv") {
+        ifstream ifs(name);
+        string line;
+        while (not_found && getline(ifs, line)) {
+          if (m_verb > 1) {
+            cout << "    Line = " << line << endl;
+          }
+          istringstream iss(line);
+          string name0, value0;
+          int run_b, run_e;
+          if (! (iss >> name0 >> value0 >> run_b >> run_e)) {
+            if (name == name0 && run_b <= run && (run_e == 0 || run <= run_e)) {
+              if (m_verb > 1) {
+                cout << "    Matched." << endl;
+              }
+              value = value0;
+              not_found = false;
+              break;
+            }
+          }
+        }
+        ifs.close();
+      }
+    }
+    gSystem->FreeDirectory(dirp);
+  }
+  if (not_found && m_do_assert) {
+    cerr << "ERROR:  OnlMonParam cannot find '" << name << "' for run " << run << ".\n"
+         << "Abort." << endl;
+    exit(1);
+  }
+  return value;
+}
+
+double OnlMonParam::GetDoubleParam(const std::string name)
+{
+  istringstream iss(GetCharParam(name));
+  double value;
+  if (!(iss >> value) && m_do_assert) {
+    cerr << "ERROR:  OnlMonParam found '" << name << "' but not 'double'.\n"
+         << "Abort." << endl;
+    exit(1);
+  }
+  if (m_verb > 0) {
+    cout << "  " << value << " as double." << endl;
+  }
+  return value;
+}
+
+int OnlMonParam::GetIntParam(const std::string name)
+{
+  istringstream iss(GetCharParam(name));
+  int value;
+  if (!(iss >> value) && m_do_assert) {
+    cerr << "ERROR:  OnlMonParam found '" << name << "' but not 'int'.\n"
+         << "Abort." << endl;
+    exit(1);
+  }
+  if (m_verb > 0) {
+    cout << "  " << value << " as int." << endl;
+  }
+  return value;
+}
+
+bool OnlMonParam::GetBoolParam(const std::string name)
+{
+  istringstream iss(GetCharParam(name));
+  bool value;
+  if (!(iss >> value) && m_do_assert) {
+    cerr << "ERROR:  OnlMonParam found '" << name << "' but not 'bool'.\n"
+         << "Abort." << endl;
+    exit(1);
+  }
+  if (m_verb > 0) {
+    cout << "  " << value << " as bool." << endl;
+  }
+  return value;
+}
+

--- a/online/onlmonserver/OnlMonParam.h
+++ b/online/onlmonserver/OnlMonParam.h
@@ -1,0 +1,57 @@
+#ifndef _ONL_MON_PARAM__H_
+#define _ONL_MON_PARAM__H_
+#include <string>
+class OnlMonClient;
+
+/// Class to get OnlMon run-dependent parameters from the configuration directory.
+/**
+ * The OnlMon client often needs run-dependent parameters when judging
+ * the goodness of data quality in `OnlMonClient::DrawMonitor()`.
+ * Such parameters should be first defined in TSV files under the configuration directory, 
+ * which is by default `/data2/e1039/onlmon/param`.
+ * They are then read via `OnlMonParam::GetIntParam()` etc.
+ *
+ * This class aborts the program when a value of the requested parameter doesn't exist.
+ * You can chage this behavior by `OnlMonParam::DoAssert()`.
+ *
+ * The run number is automatically selected via `recoConsts`.
+ * You can use `OnlMonParam::RunID()` when you have to fix it.
+ * 
+ * Typical usage: 
+ * @code
+ * OnlMonParam param(this);
+ * int n_ttdc = param.GetIntParam("N_TAIWAN_TDC");
+ * @endcode
+ */
+class OnlMonParam {
+ protected:
+  std::string m_name;
+  std::string m_dir_base;
+  int  m_run_id;
+  int  m_verb;
+  bool m_do_assert;
+
+ public:
+  OnlMonParam(const OnlMonClient* omc);
+  OnlMonParam(const std::string name);
+  virtual ~OnlMonParam();
+
+  void        BaseDir(const std::string dir_base) { m_dir_base = dir_base; }
+  std::string BaseDir() const              { return m_dir_base; }
+
+  void RunID(const int run_id) { m_run_id = run_id; }
+  int  RunID() const    { return m_run_id; }
+
+  void Verbosity(const bool verb) { m_verb = verb; }
+  int  Verbosity() const   { return m_verb; }
+
+  void DoAssert(const bool val) { m_do_assert = val; }
+  bool DoAssert() const  { return m_do_assert; }
+
+  std::string GetCharParam  (const std::string name);
+  double      GetDoubleParam(const std::string name);
+  int         GetIntParam   (const std::string name);
+  bool        GetBoolParam  (const std::string name);
+};
+
+#endif // _ONL_MON_PARAM__H_

--- a/online/onlmonserver/OnlMonParam.h
+++ b/online/onlmonserver/OnlMonParam.h
@@ -48,10 +48,14 @@ class OnlMonParam {
   void DoAssert(const bool val) { m_do_assert = val; }
   bool DoAssert() const  { return m_do_assert; }
 
-  std::string GetCharParam  (const std::string name);
-  double      GetDoubleParam(const std::string name);
-  int         GetIntParam   (const std::string name);
-  bool        GetBoolParam  (const std::string name);
+  std::string GetCharParam  (const std::string par_name);
+  double      GetDoubleParam(const std::string par_name);
+  int         GetIntParam   (const std::string par_name);
+  bool        GetBoolParam  (const std::string par_name);
+
+ protected:
+  std::string FindParamInDir(const std::string par_name);
+  bool FindParamInFile(const std::string file_name, const int run, const std::string par_name, std::string& par_value);
 };
 
 #endif // _ONL_MON_PARAM__H_

--- a/packages/evt_filter/E906SpillSelector.cxx
+++ b/packages/evt_filter/E906SpillSelector.cxx
@@ -1,0 +1,81 @@
+#include <fstream>
+#include <sstream>
+#include <TSystem.h>
+#include <TH1D.h>
+#include <fun4all/Fun4AllReturnCodes.h>
+#include <phool/getClass.h>
+#include <interface_main/SQEvent.h>
+#include "E906SpillSelector.h"
+using namespace std;
+
+E906SpillSelector::E906SpillSelector(const std::string &name)
+  : SubsysReco(name)
+  , m_fn_list("$E1039_RESOURCE/spill/e906/R009/good_spill_fy2017.txt")
+  , m_fn_out("")
+  , m_h1_evt_cnt(0)
+  , m_evt(0)
+{
+  ;
+}
+
+E906SpillSelector::~E906SpillSelector()
+{
+  if (m_h1_evt_cnt) delete m_h1_evt_cnt;
+}
+
+int E906SpillSelector::Init(PHCompositeNode* topNode)
+{
+  char* path = gSystem->ExpandPathName(m_fn_list.c_str());
+  if (Verbosity() > 0) {
+    cout << Name() << ":  Read '" << path << "'." << endl;
+  }
+  ifstream ifs(path);
+  int sp;
+  while (ifs >> sp) m_list_spill_ok.push_back(sp);
+  ifs.close();
+  if (Verbosity() > 0) {
+    cout << "  N of good spills = " << m_list_spill_ok.size() << "." << endl;
+  }
+  if (m_list_spill_ok.size() == 0) {
+    cout << Name() << ":  No good spill was found.  Abort." << endl;
+    exit(1);
+  }
+  delete path;
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int E906SpillSelector::InitRun(PHCompositeNode* topNode)
+{
+  m_evt = findNode::getClass<SQEvent>(topNode, "SQEvent");
+  if (!m_evt) return Fun4AllReturnCodes::ABORTEVENT;
+
+  if (m_fn_out != "") {
+    m_h1_evt_cnt = new TH1D("h1_evt_cnt", "", 2, 0.5, 2.5);
+    m_h1_evt_cnt->GetXaxis()->SetBinLabel(1, "All");
+    m_h1_evt_cnt->GetXaxis()->SetBinLabel(2, "Accepted");
+  }
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int E906SpillSelector::process_event(PHCompositeNode* topNode)
+{
+  m_h1_evt_cnt->Fill(1);
+  int spill_id = m_evt->get_spill_id();
+  if (find(m_list_spill_ok.begin(), m_list_spill_ok.end(), spill_id) == m_list_spill_ok.end()) return Fun4AllReturnCodes::ABORTEVENT;
+  m_h1_evt_cnt->Fill(2);
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int E906SpillSelector::End(PHCompositeNode* topNode)
+{
+  if (m_h1_evt_cnt) {
+    ofstream ofs(m_fn_out.c_str());
+    for (int ib = 1; ib <= m_h1_evt_cnt->GetNbinsX(); ib++) {
+      ofs << m_h1_evt_cnt->GetXaxis()->GetBinLabel(ib) << "\t"
+          << m_h1_evt_cnt->GetBinContent(ib) << "\n";
+    }
+    ofs.close();
+  }
+  return Fun4AllReturnCodes::EVENT_OK;
+}

--- a/packages/evt_filter/E906SpillSelector.h
+++ b/packages/evt_filter/E906SpillSelector.h
@@ -1,0 +1,40 @@
+#ifndef _E906_SPILL_SELECTOR__H_
+#define _E906_SPILL_SELECTOR__H_
+#include <vector>
+#include <fun4all/SubsysReco.h>
+class TH1;
+class SQEvent;
+
+/// A SubsysReco module to select good E906 spills.
+/**
+ * It can handle only the last E906 dataset, Run 6.
+ *
+ * It outputs the counts of all and accepted events into a tsv file once `EnableOutput()` is called.
+ * 
+ * Typical usage:
+ * @code
+ * E906SpillSelector* e906ss = new E906SpillSelector();
+ * e906ss->EnableOutput();
+ * se->registerSubsystem(e906ss);
+ * @endcode
+ */
+class E906SpillSelector: public SubsysReco {
+  std::vector<int> m_list_spill_ok;
+  std::string m_fn_list;
+  std::string m_fn_out;
+  TH1* m_h1_evt_cnt;
+  SQEvent* m_evt;
+
+ public:
+  E906SpillSelector(const std::string &name="E906SpillSelector");
+  virtual ~E906SpillSelector();
+  int Init(PHCompositeNode *topNode);
+  int InitRun(PHCompositeNode *topNode);
+  int process_event(PHCompositeNode *topNode);
+  int End(PHCompositeNode *topNode);
+
+  void SetSpillListFile(const std::string fn_list) { m_fn_list = fn_list; }
+  void EnableOutput(const std::string fn_out="e906_spill_selector.tsv") { m_fn_out = fn_out; }
+};
+
+#endif // _E906_SPILL_SELECTOR__H_

--- a/packages/evt_filter/E906SpillSelectorLinkDef.h
+++ b/packages/evt_filter/E906SpillSelectorLinkDef.h
@@ -1,0 +1,3 @@
+#ifdef __CINT__
+#pragma link C++ class E906SpillSelector-!;
+#endif

--- a/packages/evt_filter/FilterByTrigger.cxx
+++ b/packages/evt_filter/FilterByTrigger.cxx
@@ -1,0 +1,82 @@
+#include <fstream>
+#include <sstream>
+#include <TH1D.h>
+#include <fun4all/Fun4AllReturnCodes.h>
+#include <phool/getClass.h>
+#include <interface_main/SQEvent.h>
+#include "FilterByTrigger.h"
+using namespace std;
+
+FilterByTrigger::FilterByTrigger()
+  : m_trig_bits(0)
+  , m_fn_out("")
+  , m_h1_evt_cnt(0)
+  , m_evt      (0)
+{
+  ;
+}
+
+FilterByTrigger::~FilterByTrigger()
+{
+  if (m_h1_evt_cnt) delete m_h1_evt_cnt;
+}
+
+int FilterByTrigger::Init(PHCompositeNode* topNode)
+{
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int FilterByTrigger::InitRun(PHCompositeNode* topNode)
+{
+  m_evt = findNode::getClass<SQEvent>(topNode, "SQEvent");
+  if (!m_evt) return Fun4AllReturnCodes::ABORTEVENT;
+
+  if (m_fn_out != "") {
+    m_h1_evt_cnt = new TH1D("h1_evt_cnt", "", 2, 0.5, 2.5);
+    m_h1_evt_cnt->GetXaxis()->SetBinLabel(1, "All");
+    m_h1_evt_cnt->GetXaxis()->SetBinLabel(2, "Accepted");
+  }
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int FilterByTrigger::process_event(PHCompositeNode* topNode)
+{
+  if (m_h1_evt_cnt) m_h1_evt_cnt->Fill(1);
+
+  if ((m_evt->get_trigger() & m_trig_bits) == 0) return Fun4AllReturnCodes::ABORTEVENT;
+
+  if (m_h1_evt_cnt) m_h1_evt_cnt->Fill(2);
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int FilterByTrigger::End(PHCompositeNode* topNode)
+{
+  if (m_h1_evt_cnt) {
+    ofstream ofs(m_fn_out.c_str());
+    for (int ib = 1; ib <= m_h1_evt_cnt->GetNbinsX(); ib++) {
+      ofs << m_h1_evt_cnt->GetXaxis()->GetBinLabel(ib) << "\t"
+          << m_h1_evt_cnt->GetBinContent(ib) << "\n";
+    }
+    ofs.close();
+  }
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+void FilterByTrigger::SetFpgaBits(const bool fpga1, const bool fpga2, const bool fpga3, const bool fpga4, const bool fpga5)
+{
+  if (fpga1) m_trig_bits |= 0x1 << SQEvent::MATRIX1;
+  if (fpga2) m_trig_bits |= 0x1 << SQEvent::MATRIX2;
+  if (fpga3) m_trig_bits |= 0x1 << SQEvent::MATRIX3;
+  if (fpga4) m_trig_bits |= 0x1 << SQEvent::MATRIX4;
+  if (fpga5) m_trig_bits |= 0x1 << SQEvent::MATRIX5;
+}
+
+void FilterByTrigger::SetNimBits(const bool nim1, const bool nim2, const bool nim3, const bool nim4, const bool nim5)
+{
+  if (nim1) m_trig_bits |= 0x1 << SQEvent::NIM1;
+  if (nim2) m_trig_bits |= 0x1 << SQEvent::NIM2;
+  if (nim3) m_trig_bits |= 0x1 << SQEvent::NIM3;
+  if (nim4) m_trig_bits |= 0x1 << SQEvent::NIM4;
+  if (nim5) m_trig_bits |= 0x1 << SQEvent::NIM5;
+}

--- a/packages/evt_filter/FilterByTrigger.h
+++ b/packages/evt_filter/FilterByTrigger.h
@@ -1,0 +1,45 @@
+#ifndef _FILTER_BY_TRIGGER__H_
+#define _FILTER_BY_TRIGGER__H_
+#include <fun4all/SubsysReco.h>
+class TH1;
+class SQEvent;
+
+/// A SubsysReco module to filter events by trigger.
+/**
+ * It outputs the counts of all and accepted events into a tsv file once `EnableOutput()` is called.
+ * 
+ * Typical usage:
+ * @code
+ * FilterByTrigger* fbt = new FilterByTrigger();
+ * fbt->SetFpgaBits(1,0,0,0,0);
+ * fbt->SetNimBits (0,0,1,0,0);
+ * fbt->EnableOutput();
+ * se->registerSubsystem(fbt);
+ * @endcode
+ *
+ * Advanced usage:
+ * @code
+ * fbt->SetTriggerBits( (0x1<<SQEvent::MATRIX1) | (0x1<<SQEvent::NIM3) );
+ * @endcode
+ */
+class FilterByTrigger: public SubsysReco {
+  unsigned short m_trig_bits;
+  std::string m_fn_out;
+  TH1* m_h1_evt_cnt;
+  SQEvent* m_evt;
+
+ public:
+  FilterByTrigger();
+  virtual ~FilterByTrigger();
+  int Init(PHCompositeNode *topNode);
+  int InitRun(PHCompositeNode *topNode);
+  int process_event(PHCompositeNode *topNode);
+  int End(PHCompositeNode *topNode);
+
+  void SetFpgaBits(const bool fpga1, const bool fpga2, const bool fpga3, const bool fpga4, const bool fpga5);
+  void SetNimBits(const bool nim1, const bool nim2, const bool nim3, const bool nim4, const bool nim5);
+  void SetTriggerBits(const unsigned short trig_bits) { m_trig_bits = trig_bits; }
+  void EnableOutput(const std::string fn_out="filter_by_trigger.tsv") { m_fn_out = fn_out; }
+};
+
+#endif // _FILTER_BY_TRIGGER__H_

--- a/packages/evt_filter/FilterByTriggerLinkDef.h
+++ b/packages/evt_filter/FilterByTriggerLinkDef.h
@@ -1,0 +1,3 @@
+#ifdef __CINT__
+#pragma link C++ class FilterByTrigger-!;
+#endif


### PR DESCRIPTION
This PR is to add a new utility class, `OnlMonParam`, which handles run-dependent parameters for the OnlMon client.  It is used by `OnlMonMainDaq` for now, which reads the expected number (=83) of TDC boards read out per event, and makes a warning if the number is found different in runs/events.  Parameters are stored in TSV files under `/data2/e1039/onlmon/param/`, which can be modified by subsystem experts at anytime.

I also imported `E906SpillSelector` and `FilterByTrigger` from `e1039-analysis/GenRoadset/src/`.  They should be useful for other online/offline analyses when selecting events by spill IDs (of E906 data for now) and trigger bits.  We can add such general-purpose SubsysReco modules to `evt_filter/` in the future.

The updated code can be compiled fine.  I have confirmed that it runs fine on online (i.e. real) data.  It should not affect the offline analysis.