### PR TITLE
Arrangement of `CalibDriftDist`, `EventReducer` and `PHG4Reco`

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -15,7 +15,7 @@ test -z "$OFFLINE_MAIN" && echo "Need set 'OFFLINE_MAIN'.  Abort." && exit
 test -z "$MY_INSTALL"   && echo   "Need set 'MY_INSTALL'.  Abort." && exit
 
 src=$(dirname $(readlink -f $0))
-build=`pwd`/build
+build=$src/../core-build
 install=$MY_INSTALL
 
 mode=all
@@ -39,9 +39,6 @@ while getopts ":s:r:i:c:b:B" OPT ; do
             echo " - pass additional args $cmake_args to cmake"
             ;;
         b ) build=$(readlink -e $OPTARG)
-            echo "Build directory = $build"
-            ;;
-        B ) build=$src/../core-build
             echo "Build directory = $build"
             ;;
         * ) echo 'Unsupported option.  Abort.'

--- a/framework/phool/recoConsts.cc
+++ b/framework/phool/recoConsts.cc
@@ -41,6 +41,7 @@ void recoConsts::set_defaults()
   //Following constants are shared between simulation and reconstruction
   set_DoubleFlag("KMAGSTR", 1.0);
   set_DoubleFlag("FMAGSTR", 1.0);
+  set_DoubleFlag("TMAGSTR", 5.0); // Target magnetic field strength, in Tesla
 
   //Following flags control the running mode and must be 
   //set to appropriate values in the configuration set

--- a/generators/E906LegacyGen/SQPrimaryParticleGen.C
+++ b/generators/E906LegacyGen/SQPrimaryParticleGen.C
@@ -353,7 +353,7 @@ int SQPrimaryParticleGen::generateDrellYan(const TVector3& vtx, const double pAR
   UtilDimuon::CalcVar(_dim_gen, dim_mass, dim_pT, dim_x1, dim_x2, dim_xF);
 
   double xsec   = CrossSectionDrellYan(dim_mass, dim_xF, dim_x1, dim_x2, pARatio);
-  double weight = xsec * luminosity;
+  double weight = xsec * luminosity * (massMax - massMin) * (xfMax - xfMin);
   InsertEventInfo(xsec, weight, vtx);
 
   return 0;
@@ -366,7 +366,7 @@ int SQPrimaryParticleGen::generateJPsi(const TVector3& vtx, const double pARatio
   if(!generateDimuon(DPGEN::mjpsi, xF)) return 1;
   InsertMuonPair(vtx);
   double xsec   = CrossSectionJPsi(xF);
-  double weight = xsec * luminosity;
+  double weight = xsec * luminosity * (xfMax - xfMin);
   InsertEventInfo(xsec, weight, vtx);
   return 0;
 }
@@ -378,7 +378,7 @@ int SQPrimaryParticleGen::generatePsip(const TVector3& vtx, const double pARatio
   if(!generateDimuon(DPGEN::mpsip, xF)) return 1;
   InsertMuonPair(vtx);
   double xsec   = CrossSectionPsip(xF);
-  double weight = xsec * luminosity;
+  double weight = xsec * luminosity * (xfMax - xfMin);
   InsertEventInfo(xsec, weight, vtx);
   return 0;
 }

--- a/online/decoder_maindaq/Fun4AllEVIOInputManager.cc
+++ b/online/decoder_maindaq/Fun4AllEVIOInputManager.cc
@@ -346,6 +346,8 @@ int Fun4AllEVIOInputManager::run(const int nevents)
     hit->set_element_id (hd->ele );
     hit->set_level      (hd->lvl );
     hit->set_tdc_time   (hd->time);
+    hit->set_drift_distance(0);
+    hit->set_pos           (0);
     hit_vec->push_back(hit);
     delete hit;
   }
@@ -358,6 +360,8 @@ int Fun4AllEVIOInputManager::run(const int nevents)
     hit->set_element_id (hd->ele );
     hit->set_level      (hd->lvl );
     hit->set_tdc_time   (hd->time);
+    hit->set_drift_distance(0);
+    hit->set_pos           (0);
     trig_hit_vec->push_back(hit);
     delete hit;
   }

--- a/packages/calibrator/CalibDriftDist.cc
+++ b/packages/calibrator/CalibDriftDist.cc
@@ -107,6 +107,8 @@ int CalibDriftDist::process_event(PHCompositeNode* topNode)
     hit->set_in_time(t1 <= tdc_time && tdc_time <= t0);
     hit->set_drift_distance(drift_dist);
     /// No field for resolution in SQHit now.
+
+    hit->set_pos(geom->getMeasurement(det, ele));
   }
   return Fun4AllReturnCodes::EVENT_OK;
 }

--- a/packages/reco/ktracker/EventReducer.cxx
+++ b/packages/reco/ktracker/EventReducer.cxx
@@ -3,7 +3,7 @@
 
 #include "EventReducer.h"
 
-EventReducer::EventReducer(TString options) : afterhit(false), hodomask(false), outoftime(false), decluster(false), mergehodo(false), triggermask(false), sagitta(false), hough(false), externalpar(false), realization(false), difnim(false)
+EventReducer::EventReducer(TString options) : afterhit(false), hodomask(false), outoftime(false), decluster(false), mergehodo(false), triggermask(false), sagitta(false), hough(false), realization(false), difnim(false)
 {
     //parse the reducer setup
     options.ToLower();
@@ -15,9 +15,13 @@ EventReducer::EventReducer(TString options) : afterhit(false), hodomask(false), 
     if(options.Contains("t")) triggermask = true;
     if(options.Contains("s")) sagitta = true;
     if(options.Contains("g")) hough = true;
-    if(options.Contains("e")) externalpar = true;
     if(options.Contains("r")) realization = true;
     if(options.Contains("n")) difnim = true;
+
+    if(options.Contains("e")) {
+      std::cout << "EventReducer: !!ERROR!!  Option 'e' is no longer available.  Use 'CalibDriftDist'.  Abort." << std::endl;
+      exit(1);
+    }
 
     rc = recoConsts::instance();
     timeOffset = rc->get_DoubleFlag("TDCTimeOffset");
@@ -45,7 +49,6 @@ EventReducer::EventReducer(TString options) : afterhit(false), hodomask(false), 
     if(triggermask)   std::cout << "EventReducer: trigger road masking enabled. " << std::endl;
     if(sagitta)       std::cout << "EventReducer: sagitta reducer enabled. " << std::endl;
     if(hough)         std::cout << "EventReducer: hough transform reducer enabled. " << std::endl;
-    if(externalpar)   std::cout << "EventReducer: will reset the alignment/calibration parameters. " << std::endl;
     if(realization)   std::cout << "EventReducer: realization enabled. " << std::endl;
     if(difnim)        std::cout << "EventReducer: trigger masking will be disabled in NIM events. " << std::endl;
     if(fabs(timeOffset) > 0.01) std::cout << "EventReducer: " << timeOffset << " ns will be added to tdcTime. " << std::endl;
@@ -101,13 +104,6 @@ int EventReducer::reduceEvent(SRawEvent* rawEvent)
         {
             // if trigger masking is enabled, all the X hodos are discarded
             if(triggermask_local && p_geomSvc->getPlaneType(iter->detectorID) == 1) continue;
-        }
-
-        if(externalpar)
-        {
-            iter->pos = p_geomSvc->getMeasurement(iter->detectorID, iter->elementID);
-            iter->driftDistance = p_geomSvc->getDriftDistance(iter->detectorID, iter->tdcTime + timeOffset); // this is OK because hodoscopes don't have R-T curve anyways
-            //iter->setInTime(p_geomSvc->isInTime(iter->detectorID, iter->tdcTime));
         }
 
         if(realization && iter->detectorID <= nChamberPlanes) iter->driftDistance += rndm.Gaus(0., chamResol);

--- a/packages/reco/ktracker/EventReducer.h
+++ b/packages/reco/ktracker/EventReducer.h
@@ -86,7 +86,6 @@ private:
     bool triggermask;         //use active trigger road for track masking
     bool sagitta;             //remove the hits which cannot form a sagitta triplet
     bool hough;               //remove the hits which cannot form a peak in hough space, will be implemented later
-    bool externalpar;         //re-apply the alignment and calibration parameters
     bool realization;         //apply detector efficiency and resolution by dropping and smear
     bool difnim;              //treat the nim/FPGA triggered events differently, i.e. no trigger masking in NIM events
 

--- a/simulation/g4main/PHG4Reco.cc
+++ b/simulation/g4main/PHG4Reco.cc
@@ -305,6 +305,19 @@ int PHG4Reco::InitField(PHCompositeNode *topNode)
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
+void PHG4Reco::set_field_map()
+{
+  recoConsts *rc = recoConsts::instance();
+  ostringstream oss;
+  oss << rc->get_CharFlag("fMagFile") << " "
+      << rc->get_CharFlag("kMagFile") << " "
+      << rc->get_DoubleFlag("FMAGSTR") << " "
+      << rc->get_DoubleFlag("KMAGSTR") << " "
+      << rc->get_DoubleFlag("TMAGSTR");
+  if (verbosity > 0) cout << "PHG4Reco::set_field_map(): " << oss.str() << "." << endl;
+  set_field_map(oss.str(), PHFieldConfig::RegionalConst);
+}
+
 int PHG4Reco::InitRun(PHCompositeNode *topNode)
 {
   // this is a dumb protection against executing this twice.

--- a/simulation/g4main/PHG4Reco.h
+++ b/simulation/g4main/PHG4Reco.h
@@ -88,6 +88,12 @@ class PHG4Reco : public SubsysReco
     mapdim = dim;
   }
 
+  /// Set the magnetic field maps/strengths.
+  //! This will be the default setting method in E1039.
+  //! It takes the parameter values from recoConsts.  Thus you can change
+  //! parameters by calling recoConsts::set_DoubleFlag() etc. beforehand.
+  void set_field_map();
+  
   //! set default scaling factor for input magnetic field map. If available, Field map setting on DST take higher priority.
   void set_field_rescale(const float rescale) { magfield_rescale = rescale; }
 


### PR DESCRIPTION
This PR includes two changes.

1. I modified `CalibDriftDist` (and `Fun4AllEVIOInputManager`).  It now reads the calibration parameter stored at `$E1039_RESOURCE/calib/xt_curve/20211222` (actually it reads a copy on MySQL DB) to update the drift distance, the in-time window and the element position of `SQHit`.  I dropped the 'e' option of `EventReducer` in order to make `CalibDriftDist` unique.  I plan to factor out other functions of `EventReducer`.

2. I added a new function, `PHG4Reco::set_field_map()`, which takes no argument.  It instead reads the parameters from `recoConsts`.  On the other hand, the existing function `set_field_map(const std::string &fmap, const PHFieldConfig::FieldConfigTypes dim)` requires the parameters to be written as string in each Fun4All macro, like `e1039-analysis/SimChainDev/Fun4Sim.C`.  Thus the new function makes Fun4All macros simpler.

I have confirmed that the update code can be built fine.