### PR TITLE
Updates on Main DAQ decoder, chamber X-T curve and chamber realization

### DIFF
--- a/interface_main/SQHitVector.h
+++ b/interface_main/SQHitVector.h
@@ -54,6 +54,7 @@ public:
   virtual       SQHit* at(const size_t idkey) {return NULL;}
   virtual       void   push_back(const SQHit *hit) {}
   virtual       size_t erase(const size_t idkey) {return 0;}
+  virtual       Iter   erase(Iter pos) {return HitVector().end();}
 
   virtual ConstIter begin()                   const {return HitVector().end();}
   virtual ConstIter   end()                   const {return HitVector().end();}

--- a/interface_main/SQHitVector_v1.h
+++ b/interface_main/SQHitVector_v1.h
@@ -41,6 +41,7 @@ public:
 	  _vector.erase(_vector.begin() + idkey);
 	  return _vector.size();
 	}
+  Iter erase(Iter pos) { return _vector.erase(pos); }
 
   ConstIter begin()                   const {return _vector.begin();}
   ConstIter   end()                   const {return _vector.end();}

--- a/online/decoder_maindaq/CodaInputManager.cc
+++ b/online/decoder_maindaq/CodaInputManager.cc
@@ -73,10 +73,10 @@ int CodaInputManager::CloseFile()
   return ret;
 }
 
-bool CodaInputManager::JumpCodaEvent(unsigned int& coda_id, int*& words, const int n_evt)
+bool CodaInputManager::JumpCodaEvent(unsigned int& event_count, int*& event_words, const unsigned int n_evt)
 {
-  for (int i_evt = 0; i_evt < n_evt; i_evt++) {
-    if (! NextCodaEvent(coda_id, words)) {
+  for (unsigned int i_evt = 0; i_evt < n_evt; i_evt++) {
+    if (! NextCodaEvent(event_count, event_words)) {
       cout << "CodaInputManager::SkipCodaEvent():  Failed at i=" << i_evt << " (n=" << n_evt << ")." << endl;
       return false;
     }
@@ -84,13 +84,13 @@ bool CodaInputManager::JumpCodaEvent(unsigned int& coda_id, int*& words, const i
   return true;
 }
 
-bool CodaInputManager::NextCodaEvent(unsigned int& coda_id, int*& words)
+bool CodaInputManager::NextCodaEvent(unsigned int& event_count, int*& event_words)
 {
   if (m_go_end) return false;
   int ret = evRead(m_handle, m_event_words, buflen);
   if (ret == 0) {
-    coda_id = m_event_count++;
-    words   = m_event_words;
+    event_count = m_event_count++;
+    event_words = m_event_words;
     return true;
   }
 
@@ -108,10 +108,10 @@ bool CodaInputManager::NextCodaEvent(unsigned int& coda_id, int*& words)
       return false;
     }
     // Re-open the file, requring a larger file size
-    int event_count = m_event_count;
     ret = OpenFile(m_fname, m_file_size + 32768, 10, 20);
     if (ret == 0) {
-      return JumpCodaEvent(coda_id, words, event_count + 1);
+      unsigned int event_count_jump = m_event_count + 1;
+      return JumpCodaEvent(event_count, event_words, event_count_jump);
     } else {
       cout << "OpenFile() returned " << ret << "." << endl;
     }

--- a/online/decoder_maindaq/CodaInputManager.h
+++ b/online/decoder_maindaq/CodaInputManager.h
@@ -30,8 +30,8 @@ class CodaInputManager {
 
   int OpenFile(const std::string fname, const long file_size_min=0, const int sec_wait=10, const int n_wait=0);
   int CloseFile();
-  bool JumpCodaEvent(unsigned int& coda_id, int*& event_words, const int n_evt);
-  bool NextCodaEvent(unsigned int& coda_id, int*& event_words);
+  bool JumpCodaEvent(unsigned int& event_count, int*& event_words, const unsigned int n_evt);
+  bool NextCodaEvent(unsigned int& event_count, int*& event_words);
 
  private:
   bool file_exists(const std::string fname);

--- a/online/decoder_maindaq/DecoParam.cc
+++ b/online/decoder_maindaq/DecoParam.cc
@@ -7,7 +7,7 @@ using namespace std;
 DecoParam::DecoParam() :
   fn_in(""), dir_param(""), is_online(false), sampling(0), verbose(0), time_wait(0), 
   runID(0), spillID(0), spillID_cntr(0), spillID_slow(0),
-  targPos(0), targPos_slow(0), codaID(0), rocID(0), eventIDstd(0), hitID(0), 
+  targPos(0), targPos_slow(0), event_count(0), codaID(0), rocID(0), eventIDstd(0), hitID(0), 
   has_1st_bos(false), at_bos(false), turn_id_max(0)
 {
   ;

--- a/online/decoder_maindaq/DecoParam.h
+++ b/online/decoder_maindaq/DecoParam.h
@@ -37,6 +37,7 @@ struct DecoParam {
   short targPos;
   short targPos_slow; // from slow-control event
 
+  unsigned int event_count; //< current event count
   unsigned int codaID; //< current Coda event ID
   short spillType; //< current spill type
   short rocID; //< current ROC ID

--- a/online/decoder_maindaq/MainDaqParser.cc
+++ b/online/decoder_maindaq/MainDaqParser.cc
@@ -931,7 +931,7 @@ int MainDaqParser::ProcessBoardV1495TDC (int* words, int idx)
 	/// is temporarily fixed to "0" as of 2017-Jan-11.  Thus not checked for now.
 	int evt_id_fpga = (words[idx+3]<<15) + words[idx+4];
 	if (evt_id != evt_id_fpga) {
-	  cerr << "!! EventID mismatch @ v1495: " << evt_id << "@CPU vs " << evt_id_fpga << "@FPGA in " << dec_par.codaID << ":" << i_evt << endl;
+	  cerr << "!! EventID mismatch @ v1495: " << evt_id << "@CPU vs " << evt_id_fpga << "@FPGA at event " << dec_par.codaID << ":" << i_evt << " board 0x" << hex << boardID << dec << endl;
 	}
 	
 	EventData* ed = &(*list_ed)[evt_id];

--- a/online/decoder_maindaq/MainDaqParser.h
+++ b/online/decoder_maindaq/MainDaqParser.h
@@ -32,13 +32,13 @@ class MainDaqParser {
   int ProcessPhysPrestart    (int* words);
   int ProcessPhysSlow        (int* words);
   int ProcessPhysSpillCounter(int* words);
-  int ProcessPhysBOSEOS      (int* words, const int type);
-  int ProcessPhysFlush       (int* words);
+  int ProcessPhysBOSEOS      (int* words, const int event_type);
+  int ProcessPhysStdAndFlush (int* words, const int event_type);
 
   // Handlers of Board data in flush event
-  int ProcessBoardData        (int* words, int idx, int idx_roc_end, int e906flag);
+  int ProcessBoardData        (int* words, int idx, int idx_roc_end, int e906flag, const int event_type);
   int ProcessBoardScaler      (int* words, int j);
-  int ProcessBoardTriggerBit  (int* words, int j);
+  int ProcessBoardTriggerBit  (int* words, int j, int idx_roc_end);
   int ProcessBoardTriggerCount(int* words, int j);
   int ProcessBoardFeeQIE      (int* words, int j);
   int ProcessBoardV1495TDC    (int* words, int idx);

--- a/online/macros/Fun4MainDaq.C
+++ b/online/macros/Fun4MainDaq.C
@@ -105,9 +105,11 @@ int Fun4MainDaq(const int run=46, const int nevent=0, const bool is_online=false
     se->registerOutputManager(om_eddst);
   }
 
-  Fun4AllSRawEventOutputManager *om_sraw = new Fun4AllSRawEventOutputManager("/data2/e1039/online");
-  om_sraw->Verbosity(10);
-  se->registerOutputManager(om_sraw);
+  if (is_online) {
+    Fun4AllSRawEventOutputManager *om_sraw = new Fun4AllSRawEventOutputManager("/data2/e1039/online");
+    om_sraw->Verbosity(10);
+    se->registerOutputManager(om_sraw);
+  }
 
   se->run(nevent);
   se->End();

--- a/online/macros/Fun4MainDaq.C
+++ b/online/macros/Fun4MainDaq.C
@@ -32,6 +32,9 @@ int Fun4MainDaq(const int run=46, const int nevent=0, const bool is_online=false
   string fn_out = oss.str();
   gSystem->mkdir(UtilOnline::GetDstFileDir().c_str(), true);
 
+  recoConsts* rc = recoConsts::instance();
+  rc->set_IntFlag("RUNNUMBER", run);
+
   OnlMonServer* se = OnlMonServer::instance();
   //se->Verbosity(1);
   se->SetOnline(is_online);

--- a/packages/calibrator/CalibDriftDist.cc
+++ b/packages/calibrator/CalibDriftDist.cc
@@ -75,23 +75,20 @@ int CalibDriftDist::process_event(PHCompositeNode* topNode)
     int det = hit->get_detector_id();
     if (!geom->isChamber(det) && !geom->isPropTube(det)) continue;
 
-    int ele = hit->get_element_id();
-    TGraphErrors* gr_t2x;
-    TGraphErrors* gr_t2dx;
-    if (! m_cal_xt->FindT2X(det, gr_t2x, gr_t2dx)) {
-      cerr << "  WARNING:  Cannot find the in-time parameter for det=" << det << " ele=" << ele << " in CalibDriftDist.\n";
+    CalibParamXT::Set* xt = m_cal_xt->GetParam(det);
+    if (! det) {
+      cerr << "  WARNING:  Cannot find the in-time parameter for det=" << det << " in CalibDriftDist.\n";
       continue;
       //return Fun4AllReturnCodes::ABORTEVENT;
     }
-    double t1, t0;
-    CalibParamXT::FindT1T0FromT2X(gr_t2x, t1, t0);
     float   tdc_time = hit->get_tdc_time();
-    float drift_dist = gr_t2x->Eval(tdc_time);
+    float drift_dist = xt->t2x.Eval(tdc_time);
     if (drift_dist < 0) drift_dist = 0;
     hit->set_drift_distance(drift_dist);
-    hit->set_in_time(t1 <= tdc_time && tdc_time <= t0);
+    hit->set_in_time(xt->T1 <= tdc_time && tdc_time <= xt->T0);
     /// No field for resolution in SQHit now.
 
+    int ele = hit->get_element_id();
     hit->set_pos(geom->getMeasurement(det, ele));
   }
   return Fun4AllReturnCodes::EVENT_OK;

--- a/packages/calibrator/CalibDriftDist.cc
+++ b/packages/calibrator/CalibDriftDist.cc
@@ -10,18 +10,15 @@
 #include <phool/getClass.h>
 #include <geom_svc/GeomSvc.h>
 #include <geom_svc/CalibParamXT.h>
-#include <geom_svc/CalibParamInTimeTaiwan.h>
 #include "CalibDriftDist.h"
 using namespace std;
 
 CalibDriftDist::CalibDriftDist(const std::string& name)
   : SubsysReco(name)
   , m_manual_map_selection(false)
-  , m_fn_int("")
   , m_fn_xt("")
   , m_vec_hit(0)
   , m_cal_xt (0)
-  , m_cal_int(0)
 {
   ;
 }
@@ -29,7 +26,6 @@ CalibDriftDist::CalibDriftDist(const std::string& name)
 CalibDriftDist::~CalibDriftDist()
 {
   if (m_cal_xt ) delete m_cal_xt ;
-  if (m_cal_int) delete m_cal_int;
 }
 
 int CalibDriftDist::Init(PHCompositeNode* topNode)
@@ -38,10 +34,6 @@ int CalibDriftDist::Init(PHCompositeNode* topNode)
     m_cal_xt = new CalibParamXT();
     m_cal_xt->SetMapID(m_fn_xt);
     m_cal_xt->ReadFromLocalFile(m_fn_xt);
-    
-    m_cal_int = new CalibParamInTimeTaiwan();
-    m_cal_int->SetMapID(m_fn_int);
-    m_cal_int->ReadFromLocalFile(m_fn_int);
   }
   return Fun4AllReturnCodes::EVENT_OK;
 }
@@ -56,25 +48,18 @@ int CalibDriftDist::InitRun(PHCompositeNode* topNode)
     m_cal_xt = new CalibParamXT();
     m_cal_xt->SetMapIDbyDB(run_header->get_run_id());
     m_cal_xt->ReadFromDB();
-    
-    m_cal_int = new CalibParamInTimeTaiwan();
-    m_cal_int->SetMapIDbyDB(run_header->get_run_id());
-    m_cal_int->ReadFromDB();
   }
 
   SQParamDeco* param_deco = findNode::getClass<SQParamDeco>(topNode, "SQParamDeco");
   if (param_deco) {
     param_deco->set_variable(m_cal_xt ->GetParamID(), m_cal_xt ->GetMapID());
-    param_deco->set_variable(m_cal_int->GetParamID(), m_cal_int->GetMapID());
   }
 
   recoConsts* rc = recoConsts::instance();
   rc->set_CharFlag(m_cal_xt ->GetParamID(), m_cal_xt ->GetMapID());
-  rc->set_CharFlag(m_cal_int->GetParamID(), m_cal_int->GetMapID());
 
   if (Verbosity() > 0) {
-    cout << Name() << ": " << m_cal_xt ->GetParamID() << " = " << m_cal_xt ->GetMapID() << "\n"
-         << Name() << ": " << m_cal_int->GetParamID() << " = " << m_cal_int->GetMapID() << "\n";
+    cout << Name() << ": " << m_cal_xt ->GetParamID() << " = " << m_cal_xt ->GetMapID() << "\n";
   }
 
   return Fun4AllReturnCodes::EVENT_OK;
@@ -91,21 +76,18 @@ int CalibDriftDist::process_event(PHCompositeNode* topNode)
     int ele = hit->get_element_id();
     TGraphErrors* gr_t2x;
     TGraphErrors* gr_t2dx;
-    double center, width;
-    if (! m_cal_xt ->Find(det, gr_t2x, gr_t2dx) || 
-        ! m_cal_int->Find(det, ele, center, width) ) {
+    if (! m_cal_xt->FindT2X(det, gr_t2x, gr_t2dx)) {
       cerr << "  WARNING:  Cannot find the in-time parameter for det=" << det << " ele=" << ele << " in CalibDriftDist.\n";
       continue;
       //return Fun4AllReturnCodes::ABORTEVENT;
     }
-    float t1 = center - width / 2;
-    float t0 = center + width / 2;
+    double t1, t0;
+    CalibParamXT::FindT1T0FromT2X(gr_t2x, t1, t0);
     float   tdc_time = hit->get_tdc_time();
-    float drift_time = t0 - tdc_time;
-    float drift_dist = gr_t2x->Eval(drift_time);
+    float drift_dist = gr_t2x->Eval(tdc_time);
     if (drift_dist < 0) drift_dist = 0;
-    hit->set_in_time(t1 <= tdc_time && tdc_time <= t0);
     hit->set_drift_distance(drift_dist);
+    hit->set_in_time(t1 <= tdc_time && tdc_time <= t0);
     /// No field for resolution in SQHit now.
 
     hit->set_pos(geom->getMeasurement(det, ele));
@@ -118,9 +100,8 @@ int CalibDriftDist::End(PHCompositeNode* topNode)
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-void CalibDriftDist::ReadParamFromFile(const char* fn_in_time, const char* fn_xt_curve)
+void CalibDriftDist::ReadParamFromFile(const char* fn_xt_curve)
 {
   m_manual_map_selection = true;
-  m_fn_int = fn_in_time;
   m_fn_xt  = fn_xt_curve;
 }

--- a/packages/calibrator/CalibDriftDist.cc
+++ b/packages/calibrator/CalibDriftDist.cc
@@ -40,26 +40,28 @@ int CalibDriftDist::Init(PHCompositeNode* topNode)
 
 int CalibDriftDist::InitRun(PHCompositeNode* topNode)
 {
-  SQRun* run_header = findNode::getClass<SQRun      >(topNode, "SQRun");
-  m_vec_hit         = findNode::getClass<SQHitVector>(topNode, "SQHitVector");
-  if (!run_header || !m_vec_hit) return Fun4AllReturnCodes::ABORTEVENT;
+  //SQRun* run_header = findNode::getClass<SQRun>(topNode, "SQRun");
+  //if (!run_header) return Fun4AllReturnCodes::ABORTEVENT;
+  m_vec_hit = findNode::getClass<SQHitVector>(topNode, "SQHitVector");
+  if (!m_vec_hit) return Fun4AllReturnCodes::ABORTEVENT;
+
+  recoConsts* rc = recoConsts::instance();
 
   if (! m_manual_map_selection) {
+    int run_id = rc->get_IntFlag("RUNNUMBER");
     m_cal_xt = new CalibParamXT();
-    m_cal_xt->SetMapIDbyDB(run_header->get_run_id());
+    m_cal_xt->SetMapIDbyDB(run_id); // (run_header->get_run_id());
     m_cal_xt->ReadFromDB();
   }
 
   SQParamDeco* param_deco = findNode::getClass<SQParamDeco>(topNode, "SQParamDeco");
   if (param_deco) {
-    param_deco->set_variable(m_cal_xt ->GetParamID(), m_cal_xt ->GetMapID());
+    param_deco->set_variable(m_cal_xt->GetParamID(), m_cal_xt->GetMapID());
   }
 
-  recoConsts* rc = recoConsts::instance();
-  rc->set_CharFlag(m_cal_xt ->GetParamID(), m_cal_xt ->GetMapID());
-
+  rc->set_CharFlag(m_cal_xt->GetParamID(), m_cal_xt->GetMapID());
   if (Verbosity() > 0) {
-    cout << Name() << ": " << m_cal_xt ->GetParamID() << " = " << m_cal_xt ->GetMapID() << "\n";
+    cout << Name() << ": " << m_cal_xt->GetParamID() << " = " << m_cal_xt->GetMapID() << "\n";
   }
 
   return Fun4AllReturnCodes::EVENT_OK;

--- a/packages/calibrator/CalibDriftDist.h
+++ b/packages/calibrator/CalibDriftDist.h
@@ -3,7 +3,6 @@
 #include <fun4all/SubsysReco.h>
 class SQHitVector;
 class CalibParamXT;
-class CalibParamInTimeTaiwan;
 
 /// SubsysReco module to calibrate the drift distance and also the in-time window of the chambers and the prop tube.
 /**
@@ -12,11 +11,9 @@ class CalibParamInTimeTaiwan;
  */
 class CalibDriftDist: public SubsysReco {
   bool m_manual_map_selection;
-  std::string m_fn_int;
   std::string m_fn_xt;
   SQHitVector* m_vec_hit;
   CalibParamXT* m_cal_xt;
-  CalibParamInTimeTaiwan* m_cal_int;
 
  public:
   CalibDriftDist(const std::string &name = "CalibDriftDist");
@@ -26,9 +23,8 @@ class CalibDriftDist: public SubsysReco {
   int process_event(PHCompositeNode *topNode);
   int End(PHCompositeNode *topNode);
 
-  void ReadParamFromFile(const char* fn_in_time, const char* fn_xt_curve);
-  CalibParamXT*           GetParamXT    () { return m_cal_xt ; }
-  CalibParamInTimeTaiwan* GetParamInTime() { return m_cal_int; }
+  void ReadParamFromFile(const char* fn_xt_curve);
+  CalibParamXT* GetParamXT() { return m_cal_xt; }
 };
 
 #endif // __CALIB_DRIFT_DIST_H__

--- a/packages/calibrator/CalibHodoInTime.cc
+++ b/packages/calibrator/CalibHodoInTime.cc
@@ -36,17 +36,21 @@ int CalibHodoInTime::Init(PHCompositeNode* topNode)
 
 int CalibHodoInTime::InitRun(PHCompositeNode* topNode)
 {
-  SQRun* run_header = findNode::getClass<SQRun      >(topNode, "SQRun");
-  m_vec_hit         = findNode::getClass<SQHitVector>(topNode, "SQHitVector");
-  m_vec_trhit       = findNode::getClass<SQHitVector>(topNode, "SQTriggerHitVector");
-  if (!run_header || !m_vec_hit || !m_vec_trhit) return Fun4AllReturnCodes::ABORTEVENT;
+  //SQRun* run_header = findNode::getClass<SQRun>(topNode, "SQRun");
+  //if (!run_header) return Fun4AllReturnCodes::ABORTEVENT;
+  m_vec_hit   = findNode::getClass<SQHitVector>(topNode, "SQHitVector");
+  m_vec_trhit = findNode::getClass<SQHitVector>(topNode, "SQTriggerHitVector");
+  if (!m_vec_hit || !m_vec_trhit) return Fun4AllReturnCodes::ABORTEVENT;
+
+  recoConsts* rc = recoConsts::instance();
+  int run_id = rc->get_IntFlag("RUNNUMBER");
 
   m_cal_taiwan = new CalibParamInTimeTaiwan();
-  m_cal_taiwan->SetMapIDbyDB(run_header->get_run_id());
+  m_cal_taiwan->SetMapIDbyDB(run_id); // (run_header->get_run_id());
   m_cal_taiwan->ReadFromDB();
 
   m_cal_v1495 = new CalibParamInTimeV1495();
-  m_cal_v1495->SetMapIDbyDB(run_header->get_run_id());
+  m_cal_v1495->SetMapIDbyDB(run_id); // (run_header->get_run_id());
   m_cal_v1495->ReadFromDB();
 
   SQParamDeco* param_deco = findNode::getClass<SQParamDeco>(topNode, "SQParamDeco");
@@ -55,7 +59,6 @@ int CalibHodoInTime::InitRun(PHCompositeNode* topNode)
     param_deco->set_variable(m_cal_v1495 ->GetParamID(), m_cal_v1495 ->GetMapID());
   }
 
-  recoConsts* rc = recoConsts::instance();
   rc->set_CharFlag(m_cal_taiwan->GetParamID(), m_cal_taiwan->GetMapID());
   rc->set_CharFlag(m_cal_v1495 ->GetParamID(), m_cal_v1495 ->GetMapID());
 

--- a/packages/geom_svc/CalibParamXT.cc
+++ b/packages/geom_svc/CalibParamXT.cc
@@ -158,12 +158,6 @@ void CalibParamXT::Add(
   gr_x2t ->SetPointError(n_pt, 0, dt);
 }
 
-/// To be obsolete.  Use `FindT2X()`.
-bool CalibParamXT::Find(const short det, TGraphErrors*& gr_t2x, TGraphErrors*& gr_t2dx)
-{
-  return FindT2X(det, gr_t2x, gr_t2dx);
-}
-
 bool CalibParamXT::FindT2X(const short det, TGraphErrors*& gr_t2x, TGraphErrors*& gr_t2dx)
 {
   if (m_map_t2x.find(det) != m_map_t2x.end()) {
@@ -195,4 +189,38 @@ void CalibParamXT::Print(std::ostream& os)
   //  n_ent++;
   //}
   //cout << "  n = " << n_ent << endl;
+}
+
+/// Find T1 and T0 (T1 < T0) from the t2x graph.
+bool CalibParamXT::FindT1T0FromT2X(const TGraph* gr_t2x, double& t1, double &t0)
+{
+  if (gr_t2x == 0 || gr_t2x->GetN() == 0) {
+    t1 = t0 = 0;
+    return false;
+  }
+  t1 = gr_t2x->GetX()[0];
+  t0 = gr_t2x->GetX()[gr_t2x->GetN() - 1];
+  if (t1 > t0) { // Need be flipped
+    double value = t1;
+    t1 = t0;
+    t0 = value;
+  }
+  return true;
+}
+
+/// Find T1 and T0 (T1 < T0) from the x2t graph.
+bool CalibParamXT::FindT1T0FromX2T(const TGraph* gr_x2t, double& t1, double &t0)
+{
+  if (gr_x2t == 0 || gr_x2t->GetN() == 0) {
+    t1 = t0 = 0;
+    return false;
+  }
+  t1 = gr_x2t->GetY()[0];
+  t0 = gr_x2t->GetY()[gr_x2t->GetN() - 1];
+  if (t1 > t0) { // Need be flipped
+    double value = t1;
+    t1 = t0;
+    t0 = value;
+  }
+  return true;
 }

--- a/packages/geom_svc/CalibParamXT.h
+++ b/packages/geom_svc/CalibParamXT.h
@@ -1,13 +1,13 @@
 #ifndef __CALIB_PARAM_XT_H__
 #define __CALIB_PARAM_XT_H__
 #include "RunParamBase.h"
+class TGraph;
 class TGraphErrors;
 
 /// Calibration parameter for chamber X-T relation.
 /**
- * The present parameter set doesn't include "dt".
- * Therefore "dt" is set to "dx * t / x" in this class temporarily.
- * The next parameter set must include "dt".
+ * The parameter 't' means the TDC time, where the meaning was changed from the drift time on 2022-01-28.
+ * This class carries the in-time range of the chambers, since the minimum and maximum of 't' are T1 and T0.
  */
 class CalibParamXT : public CalibParamBase {
   struct ParamItem {
@@ -34,10 +34,12 @@ class CalibParamXT : public CalibParamBase {
   void Add(const std::string det     ,                     const double t, const double x, const double dt, const double dx);
   void Add(const std::string det_name, const short det_id, const double t, const double x, const double dt, const double dx);
 
-  bool Find   (const short det, TGraphErrors*& gr_t2x, TGraphErrors*& gr_t2dx);
   bool FindT2X(const short det, TGraphErrors*& gr_t2x, TGraphErrors*& gr_t2dx);
   bool FindX2T(const short det, TGraphErrors*& gr_x2t, TGraphErrors*& gr_x2dt);
   void Print(std::ostream& os);
+
+  static bool FindT1T0FromT2X(const TGraph* gr_t2x, double& t1, double &t0);
+  static bool FindT1T0FromX2T(const TGraph* gr_x2t, double& t1, double &t0);
 
  protected:
   int  ReadFileCont(LineList& lines);

--- a/packages/geom_svc/CalibParamXT.h
+++ b/packages/geom_svc/CalibParamXT.h
@@ -1,5 +1,6 @@
 #ifndef __CALIB_PARAM_XT_H__
 #define __CALIB_PARAM_XT_H__
+#include <TGraphErrors.h>
 #include "RunParamBase.h"
 class TGraph;
 class TGraphErrors;
@@ -10,6 +11,24 @@ class TGraphErrors;
  * This class carries the in-time range of the chambers, since the minimum and maximum of 't' are T1 and T0.
  */
 class CalibParamXT : public CalibParamBase {
+ public:
+  /// A set of parameters for one detector (plane).
+  struct Set {
+    double X0; ///< Minimum X.  Usually zero.
+    double X1; ///< Maximim X.  Half cell width.
+    double T0; ///< T at X0.  T0 > T1.
+    double T1; ///< T at X1.
+    TGraphErrors t2x;
+    TGraph       t2dx;
+    TGraph       t2dt;
+    TGraphErrors x2t;
+    TGraph       x2dt;
+    TGraph       x2dx;
+    void Add(const double t, const double x, const double dt, const double dx);
+  };
+
+ private:
+  /// A parameter item in TSV or MySQL DB.
   struct ParamItem {
     std::string det_name;
     short  det;
@@ -21,11 +40,8 @@ class CalibParamXT : public CalibParamBase {
   typedef std::vector<ParamItem> List_t;
   List_t m_list; ///< Used to keep all information in the added order.
 
-  typedef std::map<short, TGraphErrors*> Map_t;
-  Map_t m_map_t2x;
-  Map_t m_map_t2dx;
-  Map_t m_map_x2t;
-  Map_t m_map_x2dt;
+  typedef std::map<short, Set> SetMap_t; // [det_id] = Set
+  SetMap_t m_map_sets;
 
  public:
   CalibParamXT();
@@ -34,12 +50,9 @@ class CalibParamXT : public CalibParamBase {
   void Add(const std::string det     ,                     const double t, const double x, const double dt, const double dx);
   void Add(const std::string det_name, const short det_id, const double t, const double x, const double dt, const double dx);
 
-  bool FindT2X(const short det, TGraphErrors*& gr_t2x, TGraphErrors*& gr_t2dx);
-  bool FindX2T(const short det, TGraphErrors*& gr_x2t, TGraphErrors*& gr_x2dt);
-  void Print(std::ostream& os);
+  Set* GetParam(const short det); ///< Return a set of parameters for `det`.  Return 0 if `det` is invalid.
 
-  static bool FindT1T0FromT2X(const TGraph* gr_t2x, double& t1, double &t0);
-  static bool FindT1T0FromX2T(const TGraph* gr_x2t, double& t1, double &t0);
+  void Print(std::ostream& os);
 
  protected:
   int  ReadFileCont(LineList& lines);

--- a/packages/geom_svc/macros/UploadCalibParam.C
+++ b/packages/geom_svc/macros/UploadCalibParam.C
@@ -20,7 +20,7 @@ int UploadCalibParam(const std::string type="xt_curve", const std::string map_id
   map->SetMapIDbyFile(map_id);
   map->ReadFromFile();
   //map->Print(cout);
-  map->WriteToLocalFile("output_for_check.tsv");
+  //map->WriteToLocalFile("output_for_check.tsv");
   map->WriteToDB();
   map->WriteRangeToDB();
   return 0;

--- a/packages/geom_svc/macros/UploadChanMap.C
+++ b/packages/geom_svc/macros/UploadChanMap.C
@@ -1,4 +1,4 @@
-/// UploadChanMap.C:  Macro to upload the channel mapping from tsv file to MySQL DB.
+/// UploadChanMap.C:  Macro to upload the channel mapping from TSV file to MySQL DB.
 /**
  * Usage:
  * .L UploadChanMap.C
@@ -20,7 +20,7 @@ int UploadChanMap(const std::string type="taiwan", const std::string map_id="201
   map->SetMapIDbyFile(map_id);
   map->ReadFromFile();
   //map->Print(cout);
-  map->WriteToLocalFile("output_for_check.tsv");
+  //map->WriteToLocalFile("output_for_check.tsv");
   map->WriteToDB();
   map->WriteRangeToDB();
   return 0;

--- a/packages/geom_svc/macros/UploadGeomParam.C
+++ b/packages/geom_svc/macros/UploadGeomParam.C
@@ -2,18 +2,18 @@
 /**
  * Usage:
  * .L UploadGeomParam.C
- * UploadGeomParam("G9_run5_2");
+ * UploadGeomParam("plane", "G9_run5_2");
  * CheckGeomParam(25000);
  */
 R__LOAD_LIBRARY(geom_svc)
 
-int UploadGeomParam(const std::string map_id="G9_run5_2")
+int UploadGeomParam(const std::string type="plane", const std::string map_id="G9_run5_2")
 {
   GeomParamPlane map;
   map.SetMapIDbyFile(map_id);
   map.ReadFromFile();
   //map.Print(cout);
-  map.WriteToLocalFile("output_for_check.tsv");
+  //map.WriteToLocalFile("output_for_check.tsv");
   map.WriteToDB();
   map.WriteRangeToDB();
   return 0;

--- a/packages/geom_svc/macros/upload-param.sh
+++ b/packages/geom_svc/macros/upload-param.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Wrapper script to upload a parameter set from TSV file to MySQL DB.
+# Usage: 
+#   https://github.com/E1039-Collaboration/e1039-wiki/wiki/channel-mapping
+DIR_SCRIPT=$(dirname $(readlink -f $0))
+
+CATEGORY=$1
+PARAM_TYPE=$2
+PARAM_ID=$3
+MACRO=
+
+case $CATEGORY in
+    geom  ) MACRO=UploadGeomParam.C  ;;
+    chan  ) MACRO=UploadChanMap.C    ;;
+    calib ) MACRO=UploadCalibParam.C ;;
+    * )
+        echo "!!ERROR!!  Bad category.  Abort."
+        exit
+        ;;
+esac
+
+source /data2/e1039/this-e1039.sh
+root.exe -b "$DIR_SCRIPT/$MACRO(\"$PARAM_TYPE\", \"$PARAM_ID\")"

--- a/packages/geom_svc/macros/upload-param.sh
+++ b/packages/geom_svc/macros/upload-param.sh
@@ -20,4 +20,4 @@ case $CATEGORY in
 esac
 
 source /data2/e1039/this-e1039.sh
-root.exe -b "$DIR_SCRIPT/$MACRO(\"$PARAM_TYPE\", \"$PARAM_ID\")"
+root.exe -b -q "$DIR_SCRIPT/$MACRO(\"$PARAM_TYPE\", \"$PARAM_ID\")"

--- a/packages/reco/ktracker/SQReco.cxx
+++ b/packages/reco/ktracker/SQReco.cxx
@@ -291,6 +291,8 @@ int SQReco::process_event(PHCompositeNode* topNode)
   LogDebug("Entering SQReco::process_event: " << _event);
 
   if(is_eval_enabled()) ResetEvalVars();
+  if(is_eval_dst_enabled()) _tracklet_vector->clear();
+
   if(_input_type == SQReco::E1039)
   {
     if(!_event_header) 
@@ -551,11 +553,13 @@ int SQReco::MakeNodes(PHCompositeNode* topNode)
 
   if(_enable_eval_dst)
   {
-    _tracklet_vector = new TrackletVector();
-    _tracklet_vector->SplitLevel(99);
-    PHIODataNode<PHObject>* trackletVecNode = new PHIODataNode<PHObject>(_tracklet_vector, "TrackletVector", "PHObject");
-    eventNode->addNode(trackletVecNode);
-    if(Verbosity() >= Fun4AllBase::VERBOSITY_SOME) LogInfo("DST/TrackletVector Added");
+    _tracklet_vector = findNode::getClass<TrackletVector>(topNode, "TrackletVector"); // Could exist when the tracking is re-done.
+    if(!_tracklet_vector) {
+      _tracklet_vector = new TrackletVector();
+      _tracklet_vector->SplitLevel(99);
+      eventNode->addNode(new PHIODataNode<PHObject>(_tracklet_vector, "TrackletVector", "PHObject"));
+      if(Verbosity() >= Fun4AllBase::VERBOSITY_SOME) LogInfo("DST/TrackletVector Added");
+    }
   }
 
   return Fun4AllReturnCodes::EVENT_OK;

--- a/script/exec-decoder.sh
+++ b/script/exec-decoder.sh
@@ -17,9 +17,10 @@ fi
 E1039_CORE_VERSION=default
 IS_ONLINE=false
 DECO_MODE=devel
+N_EVT=0
 
 OPTIND=1
-while getopts ":v:osd" OPT ; do
+while getopts ":v:osde:" OPT ; do
     case $OPT in
         v ) E1039_CORE_VERSION=$OPTARG
             echo "  E1039_CORE version: $E1039_CORE_VERSION"
@@ -32,6 +33,9 @@ while getopts ":v:osd" OPT ; do
             ;;
         d ) DECO_MODE=devel
             echo "  Decoder mode: $DECO_MODE"
+            ;;
+	e ) N_EVT=$OPTARG
+            echo "  N of events: $N_EVT"
             ;;
     esac
 done
@@ -60,7 +64,6 @@ if [ $1 = 'daemon' ] ; then
     root.exe -b -q "$E1039_CORE/macros/online/Daemon4MainDaq.C" &>$FN_LOG &
 else
     RUN=$1
-    N_EVT=0
     echo "Single-run decoding."
     root.exe -b -l <<-EOF
 	.L $E1039_CORE/macros/online/Daemon4MainDaq.C

--- a/simulation/g4detectors/SQChamberRealization.cc
+++ b/simulation/g4detectors/SQChamberRealization.cc
@@ -15,15 +15,6 @@ using namespace std;
 
 SQChamberRealization::SQChamberRealization(const std::string& name)
   : SubsysReco(name)
-  , m_eff_d0 (1.)
-  , m_eff_d1 (1.)
-  , m_eff_d2 (1.)
-  , m_eff_d3p(1.)
-  , m_eff_d3m(1.)
-  , m_eff_p1x(1.)
-  , m_eff_p1y(1.)
-  , m_eff_p2x(1.)
-  , m_eff_p2y(1.)
   , m_cal_xt (0)
   , m_run    (0)
   , m_hit_vec(0)
@@ -43,44 +34,48 @@ int SQChamberRealization::Init(PHCompositeNode *topNode)
 
 int SQChamberRealization::InitRun(PHCompositeNode* topNode) 
 {
-  PHNodeIterator iter(topNode);
-  m_run = findNode::getClass<SQRun>(topNode, "SQRun");
-  if (!m_run) {
-    cerr << Name() << ": SQRun node missing.  Abort." << endl;
-    return Fun4AllReturnCodes::ABORTRUN;
-  }
+  //PHNodeIterator iter(topNode);
+  //m_run = findNode::getClass<SQRun>(topNode, "SQRun");
+  //if (!m_run) {
+  //  cerr << Name() << ": SQRun node missing.  Abort." << endl;
+  //  return Fun4AllReturnCodes::ABORTRUN;
+  //}
   m_hit_vec = findNode::getClass<SQHitVector>(topNode, "SQHitVector");
   if (!m_hit_vec) {
     cerr << Name() << ": SQHitVector node missing.  Abort." << endl;
     return Fun4AllReturnCodes::ABORTRUN;
   }
 
+  recoConsts* rc = recoConsts::instance();
+  int run_id = rc->get_IntFlag("RUNNUMBER");
+
   m_cal_xt = new CalibParamXT();
-  m_cal_xt->SetMapIDbyDB(m_run->get_run_id());
+  m_cal_xt->SetMapIDbyDB(run_id); // (m_run->get_run_id());
   m_cal_xt->ReadFromDB();
-  recoConsts::instance()->set_CharFlag("CHAM_REAL_XT", m_cal_xt->GetMapID());
+  rc->set_CharFlag("CHAM_REAL_XT", m_cal_xt->GetMapID());
 
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
 int SQChamberRealization::process_event(PHCompositeNode* topNode) 
 {
+  if (Verbosity() >= 2) cout << "SQChamberRealization:  n_hits=" << m_hit_vec->size() << endl;
   SQHitVector::Iter it = m_hit_vec->begin();
   while (it != m_hit_vec->end()) {
     SQHit* hit = *it;
-    int    det_id   = hit->get_detector_id();
-    string det_name = GeomSvc::instance()->getDetectorName(det_id);
+    int det_id = hit->get_detector_id();
+    PlaneParam* param = &list_param[det_id];
+    if (! param->on) {
+      it++;
+      continue;
+    }
 
-    bool is_eff = true;
-    if      (det_name.substr(0, 2) == "D0" ) is_eff = (gRandom->Rndm() < m_eff_d0 );
-    else if (det_name.substr(0, 2) == "D1" ) is_eff = (gRandom->Rndm() < m_eff_d1 );
-    else if (det_name.substr(0, 2) == "D2" ) is_eff = (gRandom->Rndm() < m_eff_d2 );
-    else if (det_name.substr(0, 3) == "D3p") is_eff = (gRandom->Rndm() < m_eff_d3p);
-    else if (det_name.substr(0, 3) == "D3m") is_eff = (gRandom->Rndm() < m_eff_d3m);
-    else if (det_name.substr(0, 3) == "P1X") is_eff = (gRandom->Rndm() < m_eff_p1x);
-    else if (det_name.substr(0, 3) == "P1Y") is_eff = (gRandom->Rndm() < m_eff_p1y);
-    else if (det_name.substr(0, 3) == "P2X") is_eff = (gRandom->Rndm() < m_eff_p2x);
-    else if (det_name.substr(0, 3) == "P2Y") is_eff = (gRandom->Rndm() < m_eff_p2y);
+    int  ele_id = hit->get_element_id();
+    bool is_eff = (gRandom->Rndm() < param->eff);
+    if (Verbosity() >= 2) {
+      string det_name = GeomSvc::instance()->getDetectorName(det_id);
+      cout << "  Hit: det=" << det_id << ":" << det_name << " ele=" << ele_id << " is_eff=" << is_eff << endl;
+    }
     if (! is_eff) {
       it = m_hit_vec->erase(it);
       continue;
@@ -89,13 +84,17 @@ int SQChamberRealization::process_event(PHCompositeNode* topNode)
     TGraphErrors* gr_x2t;
     TGraphErrors* gr_x2dt;
     if (m_cal_xt->FindX2T(det_id, gr_x2t, gr_x2dt)) {
-      int    ele_id  = hit->get_element_id();
       double dist    = hit->get_drift_distance();
       double mean_t  = gr_x2t ->Eval(fabs(dist));
       double width_t = gr_x2dt->Eval(fabs(dist));
+      if (param->reso_fixed >= 0) width_t  = param->reso_fixed;
+      if (param->reso_scale >= 0) width_t *= param->reso_scale;
 
       double t1, t0;
       CalibParamXT::FindT1T0FromX2T(gr_x2t, t1, t0);
+      if (Verbosity() >= 2) cout << "       dd=" << dist << " t=" << mean_t << " dt=" << width_t << " t1=" << t1 << " t0=" << t0 << endl;
+      if      (mean_t < t1) mean_t = t1; // This sometimes happens when dist > cell_width...
+      else if (mean_t > t0) mean_t = t0;
 
       double tdc_time;
       int n_try = 10000;
@@ -122,17 +121,79 @@ int SQChamberRealization::End(PHCompositeNode *topNode)
 
 void SQChamberRealization::SetChamEff(const double eff_d0, const double eff_d1, const double eff_d2, const double eff_d3p, const double eff_d3m)
 {
-  m_eff_d0  = eff_d0;
-  m_eff_d1  = eff_d1;
-  m_eff_d2  = eff_d2;
-  m_eff_d3p = eff_d3p;
-  m_eff_d3m = eff_d3m;
+  GeomSvc* geom = GeomSvc::instance();
+  if (Verbosity() > 0) cout << "SQChamberRealization::SetChamEff():\n";
+  for (int ii = 1; ii <= nChamberPlanes; ii++) {
+    string name = geom->getDetectorName(ii);
+    double eff = -1;
+    if      (name.substr(0, 2) == "D0" ) eff = eff_d0;
+    else if (name.substr(0, 2) == "D1" ) eff = eff_d1;
+    else if (name.substr(0, 2) == "D2" ) eff = eff_d2;
+    else if (name.substr(0, 3) == "D3p") eff = eff_d3p;
+    else if (name.substr(0, 3) == "D3m") eff = eff_d3m;
+    if (eff >= 0) {
+      list_param[ii].on  = true;
+      list_param[ii].eff = eff;
+      if (Verbosity() > 0) cout << "  " << setw(2) << ii << ":" << setw(5) << name << " = " << eff << endl;
+    }
+  }
 }
 
 void SQChamberRealization::SetPropTubeEff(const double eff_p1x, const double eff_p1y, const double eff_p2x, const double eff_p2y)
 {
-  m_eff_p1x = eff_p1x;
-  m_eff_p1y = eff_p1y;
-  m_eff_p2x = eff_p2x;
-  m_eff_p2y = eff_p2y;
+  GeomSvc* geom = GeomSvc::instance();
+  if (Verbosity() > 0) cout << "SQChamberRealization::SetProTubeEff():\n";
+  for (int ii = nChamberPlanes+nHodoPlanes + 1; ii <= nChamberPlanes+nHodoPlanes+nPropPlanes; ii++) {
+    string name = geom->getDetectorName(ii);
+    double eff = -1;
+    if      (name.substr(0, 3) == "P1X") eff = eff_p1x;
+    else if (name.substr(0, 3) == "P1Y") eff = eff_p1y;
+    else if (name.substr(0, 3) == "P2X") eff = eff_p2x;
+    else if (name.substr(0, 3) == "P2Y") eff = eff_p2y;
+    if (eff >= 0) {
+      list_param[ii].on  = true;
+      list_param[ii].eff = eff;
+      if (Verbosity() > 0) cout << "  " << setw(2) << ii << ":" << setw(5) << name << " = " << eff << endl;
+    }
+  }
+}
+
+void SQChamberRealization::ScaleChamReso(const double scale_d0, const double scale_d1, const double scale_d2, const double scale_d3p, const double scale_d3m)
+{
+  GeomSvc* geom = GeomSvc::instance();
+  if (Verbosity() > 0) cout << "SQChamberRealization::ScaleChamReso():\n";
+  for (int ii = 1; ii <= nChamberPlanes; ii++) {
+    string name = geom->getDetectorName(ii);
+    double scale = -1;
+    if      (name.substr(0, 2) == "D0" ) scale = scale_d0 ;
+    else if (name.substr(0, 2) == "D1" ) scale = scale_d1 ;
+    else if (name.substr(0, 2) == "D2" ) scale = scale_d2 ;
+    else if (name.substr(0, 3) == "D3p") scale = scale_d3p;
+    else if (name.substr(0, 3) == "D3m") scale = scale_d3m;
+    if (scale >= 0) {
+      list_param[ii].on         = true;
+      list_param[ii].reso_scale = scale;
+      if (Verbosity() > 0) cout << "  " << setw(2) << ii << ":" << setw(5) << name << " = " << scale << endl;
+    }
+  }
+}
+
+void SQChamberRealization::FixChamReso(const double reso_d0, const double reso_d1, const double reso_d2, const double reso_d3p, const double reso_d3m)
+{
+  GeomSvc* geom = GeomSvc::instance();
+  if (Verbosity() > 0) cout << "SQChamberRealization::FixChamReso():\n";
+  for (int ii = 1; ii <= nChamberPlanes; ii++) {
+    string name = geom->getDetectorName(ii);
+    double reso = -1;
+    if      (name.substr(0, 2) == "D0" ) reso = reso_d0 ;
+    else if (name.substr(0, 2) == "D1" ) reso = reso_d1 ;
+    else if (name.substr(0, 2) == "D2" ) reso = reso_d2 ;
+    else if (name.substr(0, 3) == "D3p") reso = reso_d3p;
+    else if (name.substr(0, 3) == "D3m") reso = reso_d3m;
+    if (reso >= 0) {
+      list_param[ii].on         = true;
+      list_param[ii].reso_fixed = reso;
+      if (Verbosity() > 0) cout << "  " << setw(2) << ii << ":" << setw(5) << name << " = " << reso << endl;
+    }
+  }
 }

--- a/simulation/g4detectors/SQChamberRealization.h
+++ b/simulation/g4detectors/SQChamberRealization.h
@@ -1,5 +1,6 @@
 #ifndef SQChamberRealization_H
 #define SQChamberRealization_H
+#include <GlobalConsts.h>
 #include <fun4all/SubsysReco.h>
 class CalibParamXT;
 class SQRun;
@@ -31,16 +32,20 @@ public:
   void SetChamEff(const double eff_d0, const double eff_d1, const double eff_d2, const double eff_d3p, const double eff_d3m);
   void SetPropTubeEff(const double eff_p1x, const double eff_p1y, const double eff_p2x, const double eff_p2y);
 
+  void ScaleChamReso(const double scale_d0, const double scale_d1, const double scale_d2, const double scale_d3p, const double scale_d3m);
+
+  void FixChamReso(const double reso_d0, const double reso_d1, const double reso_d2, const double reso_d3p, const double reso_d3m);
+
 private:
-  double m_eff_d0;
-  double m_eff_d1;
-  double m_eff_d2;
-  double m_eff_d3p;
-  double m_eff_d3m;
-  double m_eff_p1x;
-  double m_eff_p1y;
-  double m_eff_p2x;
-  double m_eff_p2y;
+  struct PlaneParam {
+    bool   on;
+    double eff;
+    double reso_scale;
+    double reso_fixed;
+    PlaneParam() : on(false), eff(1.0), reso_scale(1.0), reso_fixed(-1) {;}
+  };
+  PlaneParam list_param[nChamberPlanes+nHodoPlanes+nPropPlanes+1];
+
   CalibParamXT* m_cal_xt;
 
   SQRun*       m_run;

--- a/simulation/g4detectors/SQChamberRealization.h
+++ b/simulation/g4detectors/SQChamberRealization.h
@@ -2,7 +2,6 @@
 #define SQChamberRealization_H
 #include <fun4all/SubsysReco.h>
 class CalibParamXT;
-class CalibParamInTimeTaiwan;
 class SQRun;
 class SQHitVector;
 
@@ -14,7 +13,7 @@ class SQHitVector;
  * We might better have another flag like 'is_efficient' in future.
  *
  * The drift distance of one SQHit object is converted to its TDC time,
- * by using the X-T relation and the T0 value given by CalibParamXT and CalibParamInTimeTaiwan.
+ * by using the X-T relation given by CalibParamXT.
  * User has to use (i.e. register) `CalibDriftDist` to derive the (realistic) drift distance from the TDC time,
  * because this module does _not_ modify the drift distance itself.
  */
@@ -43,7 +42,6 @@ private:
   double m_eff_p2x;
   double m_eff_p2y;
   CalibParamXT* m_cal_xt;
-  CalibParamInTimeTaiwan* m_cal_int;
 
   SQRun*       m_run;
   SQHitVector* m_hit_vec;

--- a/simulation/g4detectors/SQChamberRealization.h
+++ b/simulation/g4detectors/SQChamberRealization.h
@@ -10,13 +10,12 @@ class SQHitVector;
 /**
  * This module simulates the detection efficiency and the time/distance resolution.
  * 
- * The in-time flag of one SQHit object is set to 'false' when the hit is regarded as inefficient.
- * We might better have another flag like 'is_efficient' in future.
+ * When it regards a hit as inefficient, it erases the hit from SQHitVector.
+ * The efficiency should be set via `SetChamEff()` and `SetPropTubeEff()`.
  *
- * The drift distance of one SQHit object is converted to its TDC time,
- * by using the X-T relation given by CalibParamXT.
- * User has to use (i.e. register) `CalibDriftDist` to derive the (realistic) drift distance from the TDC time,
- * because this module does _not_ modify the drift distance itself.
+ * It smears the drift distance of a hit using dx of the X-T curve by default.
+ * The resolution (`dx`) can be changed via `ScaleChamReso()` and `FixChamReso()`.
+ * It sets the TDC time based on the smeared drift distance and the X-T curve.
  */
 class SQChamberRealization: public SubsysReco
 {
@@ -29,11 +28,16 @@ public:
   int process_event(PHCompositeNode* topNode);
   int End(PHCompositeNode* topNode);
 
+  /// Set the single-plane efficiency of the chamber planes.
   void SetChamEff(const double eff_d0, const double eff_d1, const double eff_d2, const double eff_d3p, const double eff_d3m);
+
+  /// Set the single-plane efficiency of the prop-tube planes.
   void SetPropTubeEff(const double eff_p1x, const double eff_p1y, const double eff_p2x, const double eff_p2y);
 
+  /// Set the scaling factor of the single-plane resolution of the chamber planes.
   void ScaleChamReso(const double scale_d0, const double scale_d1, const double scale_d2, const double scale_d3p, const double scale_d3m);
 
+  /// Set the single-plane resolution of the chamber planes to the given values.
   void FixChamReso(const double reso_d0, const double reso_d1, const double reso_d2, const double reso_d3p, const double reso_d3m);
 
 private:


### PR DESCRIPTION
This update is primarily to enable the V1495 TDC readout of the Main DAQ decoder.  The present cosmic runs are being decoded by this updated version, and the online monitor is showing reasonable hit distributions.

This update also includes a change in the meaning of the chamber X-T curve parameter, which is handled by `CalibParamXT`.  Now its time (T) means the *TDC* time instead of the *drift* time, and the T range of the X-T curve is regarded as the in-time window.  `CalibParamInTimeTaiwan` now takes care of only the hodoscope parameters.  This new parameter handling should be easier to be maintained.  The parameter values under `e1039-resource` have been modified accordingly.

`SQChamberRealization` and `CalibDriftDist` were modified to use the updated `CalibParamXT` properly.  `SQChamberRealization` was modified also to resolve a problem found by DarkQuest, namely it now erases inefficient hits (instead of setting the in-time flag to `false`).  The previous method didn't work because the in-time flag was overwritten by `CalibDriftDist`.

I have confirmed that the updated version can be built for online and offline.

