### PR TITLE
Error handling (e9060bad etc.) in Main DAQ decoder

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -21,7 +21,7 @@ install=$MY_INSTALL
 mode=all
 OPTIND=1
 cmake_args=""
-while getopts ":s:r:i:c:b:B" OPT ; do
+while getopts ":s:r:i:c:b:" OPT ; do
     case $OPT in
         s ) mode='single'
             package=$OPTARG
@@ -38,7 +38,7 @@ while getopts ":s:r:i:c:b:B" OPT ; do
         c ) cmake_args=$OPTARG
             echo " - pass additional args $cmake_args to cmake"
             ;;
-        b ) build=$(readlink -e $OPTARG)
+        b ) build=$(readlink -m $OPTARG)
             echo "Build directory = $build"
             ;;
         * ) echo 'Unsupported option.  Abort.'
@@ -105,6 +105,14 @@ else # 'all' or 'resume'
   fi
 fi
 
+## Clean up $build when $mode = 'all'.  Otherwise the file deletion via
+## 'install_manifest.txt' causes a problem when you changed 
+## "$install" (via "setup-install.sh") but didn't clean up "$install".
+if [ $mode = 'all' -a -e $build ] ; then
+    echo "Clean up the build directory."
+    rm -rf $build
+fi
+
 for package in "${packages[@]}" ; do
   echo "================================================================"
   if [ $package = '_macro_' ] ; then
@@ -122,7 +130,7 @@ for package in "${packages[@]}" ; do
       continue
   fi
 
-  echo $src/$package
+  echo "Package: $package"
   if [ -f $build/$package/install_manifest.txt ]; then
     cat $build/$package/install_manifest.txt | xargs rm -f
   fi

--- a/online/decoder_maindaq/CodaInputManager.cc
+++ b/online/decoder_maindaq/CodaInputManager.cc
@@ -108,9 +108,10 @@ bool CodaInputManager::NextCodaEvent(unsigned int& event_count, int*& event_word
       return false;
     }
     // Re-open the file, requring a larger file size
-    ret = OpenFile(m_fname, m_file_size + 32768, 10, 20);
+    unsigned int event_count_jump = m_event_count + 1;
+    ret = OpenFile(m_fname, m_file_size + 32768, 10, 20); // m_event_count is reset
     if (ret == 0) {
-      unsigned int event_count_jump = m_event_count + 1;
+      cout << "Jumping over " << event_count_jump << " events." << endl;
       return JumpCodaEvent(event_count, event_words, event_count_jump);
     } else {
       cout << "OpenFile() returned " << ret << "." << endl;
@@ -239,7 +240,8 @@ void Abort(const char* message)
 void PrintWords(int* words, int idx_begin, int idx_end, int idx_atte)
 {
   cout << "  PrintWords[" << idx_begin << "-" << idx_end << "]:\n";
-  for (int idx = idx_begin; idx < idx_end; idx++) {
+  int idx_b5 = (idx_begin / 5) * 5;
+  for (int idx = idx_b5; idx < idx_end; idx++) {
     if (idx % 5 == 0) cout << "\n  " << setw(6) << idx << ": ";
     cout << " " << hex << setw(8) << words[idx] << dec;
     if (idx == idx_atte) cout << "!";

--- a/online/decoder_maindaq/DbUpSpill.cc
+++ b/online/decoder_maindaq/DbUpSpill.cc
@@ -153,7 +153,8 @@ void DbUpSpill::UploadToScalerTable(SQSpill* spi, const std::string boseos)
   oss.str("");
   oss << "delete from " << table_name << " where run_id = " << run_id << " and spill_id = " << spill_id;
   if (! db.Con()->Exec(oss.str().c_str())) {
-    cerr << "!!ERROR!!  DbUpSpill::UploadToScalerTable()." << endl;
+    cerr << "!!ERROR!!  DbUpSpill::UploadToScalerTable().\n"
+         << "  Query: " << oss.str() << endl;
     return;
   }
   oss.str("");
@@ -166,7 +167,8 @@ void DbUpSpill::UploadToScalerTable(SQSpill* spi, const std::string boseos)
   oss.seekp(-1, oss.cur);
   oss << " "; // Erase the last ',' char.
   if (! db.Con()->Exec(oss.str().c_str())) {
-    cerr << "!!ERROR!!  DbUpSpill::UploadToScalerTable()." << endl;
+    cerr << "!!ERROR!!  DbUpSpill::UploadToScalerTable().\n"
+         << "  Query: " << oss.str() << endl;
     return;
   }
 }
@@ -212,7 +214,8 @@ void DbUpSpill::UploadToSlowContTable(SQSpill* spi)
     oss.str("");
     oss << "delete from " << table_name << " where run_id = " << run_id << " and spill_id = " << spill_id;
     if (! db.Con()->Exec(oss.str().c_str())) {
-      cerr << "!!ERROR!!  DbUpSpill::UploadToSlowContTable()." << endl;
+      cerr << "!!ERROR!!  DbUpSpill::UploadToSlowContTable().\n"
+           << "  Query: " << oss.str() << endl;
       continue;
     }
     oss.str("");
@@ -220,7 +223,8 @@ void DbUpSpill::UploadToSlowContTable(SQSpill* spi)
     oss.seekp(-1, oss.cur);
     oss << " "; // Erase the last ',' char.
     if (! db.Con()->Exec(oss.str().c_str())) {
-      cerr << "!!ERROR!!  DbUpSpill::UploadToSlowContTable()." << endl;
+      cerr << "!!ERROR!!  DbUpSpill::UploadToSlowContTable().\n"
+           << "  Query: " << oss.str() << endl;
       continue;
     }
   }

--- a/online/decoder_maindaq/DecoError.h
+++ b/online/decoder_maindaq/DecoError.h
@@ -21,7 +21,8 @@ class DecoError {
     START_WO_STOP   = 4,
     START_NOT_RISE  = 5,
     DIRTY_FINISH    = 6,
-    N_TDC_ERROR     = 7
+    N_TDC_ERROR     = 7,
+    V1495_0BAD      = 8
   } TdcError_t;
 
  private:

--- a/online/decoder_maindaq/DecoParam.cc
+++ b/online/decoder_maindaq/DecoParam.cc
@@ -5,7 +5,7 @@
 using namespace std;
 
 DecoParam::DecoParam() :
-  fn_in(""), dir_param(""), is_online(false), sampling(0), verbose(0), time_wait(0), 
+  fn_in(""), dir_param(""), is_online(false), sampling(0), verb(0), time_wait(0), 
   runID(0), spillID(0), spillID_cntr(0), spillID_slow(0),
   targPos(0), targPos_slow(0), event_count(0), codaID(0), rocID(0), eventIDstd(0), hitID(0), 
   has_1st_bos(false), at_bos(false), turn_id_max(0)
@@ -24,13 +24,18 @@ int DecoParam::InitMapper()
     return 1;
   }
 
+  time_t t0 = time(0);
   chan_map_taiwan.SetMapIDbyDB(runID);
   chan_map_taiwan.ReadFromDB();
   chan_map_v1495 .SetMapIDbyDB(runID);
   chan_map_v1495 .ReadFromDB();
   chan_map_scaler.SetMapIDbyDB(runID);
   chan_map_scaler.ReadFromDB();
+  time_t t1 = time(0);
+  if (t1 - t0 > 3) {
+    cout << "DecoParam::InitMapper():  Took too long, " << t1-t0 << " sec.\n"
+         << "  Any DNS/DB problem, such as unresponsive DNS server?" << endl;
+  }
 
   return 0;
 }
-

--- a/online/decoder_maindaq/DecoParam.h
+++ b/online/decoder_maindaq/DecoParam.h
@@ -19,8 +19,8 @@ struct DecoParam {
   std::string dir_param;
   bool is_online;
   int sampling;
-  int verbose;
-  int time_wait; //< waiting time in second to pretend the online data flow.
+  int verb; ///< Verbosity.  0 = error, 1 = warning, 2 = info, 3 = debug, 4 = insane
+  int time_wait; ///< waiting time in second to pretend the online data flow.
 
   ChanMapTaiwan chan_map_taiwan;
   ChanMapV1495  chan_map_v1495;
@@ -37,15 +37,15 @@ struct DecoParam {
   short targPos;
   short targPos_slow; // from slow-control event
 
-  unsigned int event_count; //< current event count
-  unsigned int codaID; //< current Coda event ID
-  short spillType; //< current spill type
-  short rocID; //< current ROC ID
-  int eventIDstd; //< current event ID of standard physics events
-  long int hitID; //< current hit ID, commonly used by Hit and TriggerHit.
+  unsigned int event_count; ///< current event count
+  unsigned int codaID; ///< current Coda event ID
+  short spillType; ///< current spill type
+  short rocID; ///< current ROC ID
+  int eventIDstd; ///< current event ID of standard physics events
+  long int hitID; ///< current hit ID, commonly used by Hit and TriggerHit.
 
-  bool has_1st_bos; //< Set 'true' at the 1st BOS event.
-  bool at_bos; //< Set 'true' at BOS, which triggers parsing the data in one spill.
+  bool has_1st_bos; ///< Set 'true' at the 1st BOS event.
+  bool at_bos; ///< Set 'true' at BOS, which triggers parsing the data in one spill.
 
   /// Max turnOnset in a spill.  Used to drop NIM3 events that came after the beam stops.  See elog 15010
   unsigned int turn_id_max;

--- a/online/decoder_maindaq/Fun4AllEVIOInputManager.h
+++ b/online/decoder_maindaq/Fun4AllEVIOInputManager.h
@@ -7,11 +7,14 @@
 #include <map>
 
 class PHCompositeNode;
+class PHTimer;
 class SyncObject;
 class MainDaqParser;
 
 class Fun4AllEVIOInputManager : public Fun4AllInputManager
 {
+  static const std::vector<std::string> LIST_TIMERS;
+
  public:
   Fun4AllEVIOInputManager(const std::string &name = "DUMMY", const std::string &topnodename = "TOP");
   virtual ~Fun4AllEVIOInputManager();
@@ -41,6 +44,7 @@ class Fun4AllEVIOInputManager : public Fun4AllInputManager
   PHCompositeNode *topNode;
   SyncObject* syncobject;
   MainDaqParser* parser;
+  std::map<std::string, PHTimer*> m_timers; // [timer name]
 };
 
 #endif /* __Fun4AllEVIOInputManager_H_ */

--- a/online/decoder_maindaq/MainDaqParser.h
+++ b/online/decoder_maindaq/MainDaqParser.h
@@ -4,8 +4,11 @@
 #include "DecoParam.h"
 #include "DecoError.h"
 class CodaInputManager;
+class PHTimer;
 
 class MainDaqParser {
+  static const std::vector<std::string> LIST_TIMERS;
+
   long m_file_size_min;
   int m_sec_wait;
   int m_n_wait;
@@ -18,6 +21,8 @@ class MainDaqParser {
   
   SpillData   * sd_now; //< Contain the spill info of the current spill
   EventDataMap* list_ed_now; //< Contain the event info only in the current spill
+
+  std::map<std::string, PHTimer*> m_timers; // [timer name]
 
   // Handlers of CODA Event
   int ProcessCodaPrestart   (int* words);

--- a/online/macros/Fun4MainDaq.C
+++ b/online/macros/Fun4MainDaq.C
@@ -40,7 +40,7 @@ int Fun4MainDaq(const int run=46, const int nevent=0, const bool is_online=false
   se->SetOnline(is_online);
 
   Fun4AllEVIOInputManager *in = new Fun4AllEVIOInputManager("MainDaq");
-  in->Verbosity(2);
+  in->Verbosity(3);
   in->SetOnline(is_online);
   //if (is_online) in->PretendSpillInterval(20);
   in->fileopen(fn_in);


### PR DESCRIPTION
This update is mainly to deal with the "e9060bad" error, which was found to be outputted by the V1495 ROC last week.  The Main-DAQ decoder is now able to identify the error word and count it up (which is shown in the Global Status Monitor via `DecoError`).

I made additional changes as follows.
 
1. `build.sh` now auto-cleans up the build directory when executed in the "all" mode.  It is to resolve the problem observed by Abi, namely some files under `/e906/app/software/osg/software/e1039/core` were deleted unexpectedly.  Without this change, when you switch the installation directory (i.e. `$install` via `setup-install.sh`) but don't clean up the build directory (`$build`), the file deletion using `install_manifest.txt` deletes the files in the previous installation directory.
1. A bug in `CodaInputManager.cc` was fixed, which arose in PR #125.  When the CODA file of a run was reopened (when the run is being taken), `CodaInputManager` was parsing the data words from the beginning (instead of only new words).
1. Many log messages were added to the Main-DAQ decoder.  Particularly `PHTimer` was introduced to identify the time-consuming parts in future.

The new version is already running fine for the online decoding.  I think you need not build nor test it.