### PR TITLE
New variables+canvases added to OnlMonMainDaq

### DIFF
--- a/interface_main/SQEvent.h
+++ b/interface_main/SQEvent.h
@@ -9,7 +9,7 @@
 #define _H_SQEvent_H_
 
 #include <phool/PHObject.h>
-
+#include <climits>
 #include <map>
 #include <iostream>
 
@@ -41,71 +41,91 @@ public:
 		<< std::endl;
 	}
 
-	virtual int get_run_id() const = 0; ///< Return the run ID.
+        /// Return the run ID.
+	virtual int get_run_id() const = 0;
 	virtual void set_run_id(const int a) = 0;
 
-	virtual int get_spill_id() const = 0; ///< Return the spill ID.
+        /// Return the spill ID.
+	virtual int get_spill_id() const = 0;
 	virtual void set_spill_id(const int a) = 0;
 
-	virtual int get_event_id() const = 0; ///< Return the event ID, which is unique per run.
+        /// Return the event ID, which is unique per run.
+	virtual int get_event_id() const = 0;
 	virtual void set_event_id(const int a) = 0;
 
-	virtual int get_coda_event_id() const = 0; ///< Return the Coda-event ID, which is unique per run.
-	virtual void set_coda_event_id(const int a) = 0;
+        /// [Obsolete] Use `SQHardEvent` instead.
+	virtual int get_coda_event_id() const {return INT_MAX;}
+	virtual void set_coda_event_id(const int a) {;}
 
-
-	virtual int get_data_quality() const = 0; ///< Return the data-quality bits.
+        /// Return the data-quality bits.
+	virtual int get_data_quality() const = 0;
 	virtual void set_data_quality(const int a) = 0;
 
-	virtual int get_vme_time() const = 0; ///< Return the VME time.
-	virtual void set_vme_time(const int a) = 0;
+        /// [Obsolete] Use `SQHardEvent` instead.
+	virtual int get_vme_time() const {return INT_MAX;}
+	virtual void set_vme_time(const int a) {;}
 
-	virtual bool get_trigger(const SQEvent::TriggerMask i) const = 0; ///< Return the trigger bit (fired or not) of the selected trigger channel.
+        /// Return the trigger bit (fired or not) of the selected trigger channel.
+	virtual bool get_trigger(const SQEvent::TriggerMask i) const = 0; 
 	virtual void set_trigger(const SQEvent::TriggerMask i, const bool a) = 0;
 
-	virtual unsigned short get_trigger() const = 0; ///< Return the full trigger bits.
+        /// Return the full trigger bits.
+	virtual unsigned short get_trigger() const = 0;
 	virtual void           set_trigger(const unsigned short a) = 0;
 
-	virtual int get_raw_matrix(const unsigned short i) const = 0; ///< [Not Useful] Return the raw count of the selected trigger channel.
-	virtual void set_raw_matrix(const unsigned short i, const bool a) = 0;
+        /// [Obsolete] Use `SQHardEvent` instead.
+	virtual int get_raw_matrix(const unsigned short i) const { return INT_MAX; }
+	virtual void set_raw_matrix(const unsigned short i, const bool a) {;}
 
-	virtual int get_after_inh_matrix(const unsigned short i) const = 0; ///< [Not Useful] Return the after-inhibited count of the selected trigger channel.
-	virtual void set_after_inh_matrix(const unsigned short i, const bool a) = 0;
+        /// [Obsolete] Use `SQHardEvent` instead.
+	virtual int get_after_inh_matrix(const unsigned short i) const { return INT_MAX; }
+	virtual void set_after_inh_matrix(const unsigned short i, const bool a) {;}
 
 
-        virtual int  get_qie_presum(const unsigned short i) const = 0; ///< Return the i-th QIE presum, where i=0...3.
+        /// Return the i-th QIE presum, where i=0...3.
+        virtual int  get_qie_presum(const unsigned short i) const = 0; 
 	virtual void set_qie_presum(const unsigned short i, const int a) = 0;
 
-        virtual int  get_qie_trigger_count() const = 0; ///< Return the QIE trigger counts.
+        /// Return the QIE trigger counts.
+        virtual int  get_qie_trigger_count() const = 0;
 	virtual void set_qie_trigger_count(const int a) = 0;
 
-        virtual int  get_qie_turn_id() const = 0; ///< Return the QIE turn ID.
+        /// Return the QIE turn ID.
+        virtual int  get_qie_turn_id() const = 0; 
 	virtual void set_qie_turn_id(const int a) = 0;
 
-        virtual int  get_qie_rf_id() const = 0; ///< Return the QIE RF ID.
+        /// Return the QIE RF ID.
+        virtual int  get_qie_rf_id() const = 0; 
 	virtual void set_qie_rf_id(const int a) = 0;
 
-        virtual int  get_qie_rf_intensity(const short i) const = 0; ///< Return the i-th QIE RF intensity, where i=-16...+16.
+        /// Return the i-th QIE RF intensity, where i=-16...+16.
+        virtual int  get_qie_rf_intensity(const short i) const = 0; 
 	virtual void set_qie_rf_intensity(const short i, const int a) = 0;
 
 
-        virtual short get_flag_v1495() const = 0; ///< Return the quality flag of the V1495 readout.
-	virtual void  set_flag_v1495(const short a) = 0;
+        /// [Obsolete] Use `SQHardEvent` instead.
+        virtual short get_flag_v1495() const { return SHRT_MAX; }
+	virtual void  set_flag_v1495(const short a) {;}
 
-        virtual short get_n_board_qie() const = 0; ///< Return the number of QIE boards read out.
-	virtual void  set_n_board_qie(const short a) = 0;
+        /// [Obsolete] Use `SQHardEvent` instead.
+        virtual short get_n_board_qie() const { return SHRT_MAX; }
+	virtual void  set_n_board_qie(const short a) {;}
 
-        virtual short get_n_board_v1495() const = 0; ///< Return the number of V1495 boards read out.
-	virtual void  set_n_board_v1495(const short a) = 0;
+        /// [Obsolete] Use `SQHardEvent` instead.
+        virtual short get_n_board_v1495() const { return SHRT_MAX; }
+	virtual void  set_n_board_v1495(const short a) {;}
 
-        virtual short get_n_board_taiwan() const = 0; ///< Return the number of Taiwan-TDC boards read out.
-	virtual void  set_n_board_taiwan(const short a) = 0;
+        /// [Obsolete] Use `SQHardEvent` instead.
+        virtual short get_n_board_taiwan() const { return SHRT_MAX; }
+	virtual void  set_n_board_taiwan(const short a) {;}
 
-        virtual short get_n_board_trig_bit() const = 0; ///< Return the number of trigger-bit boards read out.
-	virtual void  set_n_board_trig_bit(const short a) = 0;
+        /// [Obsolete] Use `SQHardEvent` instead.
+        virtual short get_n_board_trig_bit() const { return SHRT_MAX; }
+	virtual void  set_n_board_trig_bit(const short a) {;}
 
-        virtual short get_n_board_trig_count() const = 0; ///< Return the number of trigger-count boards read out.
-	virtual void  set_n_board_trig_count(const short a) = 0;
+        /// [Obsolete] Use `SQHardEvent` instead.
+        virtual short get_n_board_trig_count() const { return SHRT_MAX; }
+	virtual void  set_n_board_trig_count(const short a) {;}
 
 
 protected:

--- a/interface_main/SQEvent_v2.cxx
+++ b/interface_main/SQEvent_v2.cxx
@@ -1,0 +1,53 @@
+#include "SQEvent_v2.h"
+using namespace std;
+
+ClassImp(SQEvent_v2)
+
+SQEvent_v2::SQEvent_v2()
+  : _run_id      (INT_MAX)
+  , _spill_id    (INT_MAX)
+  , _event_id    (INT_MAX)
+  , _trigger     (0)
+  , _data_quality(INT_MAX)
+  , _qie_trig_cnt(INT_MAX) 
+  , _qie_turn_id (INT_MAX) 
+  , _qie_rf_id   (INT_MAX) 
+{
+  memset(_qie_presums, 0, sizeof(_qie_presums));
+  memset(_qie_rf_inte, 0, sizeof(_qie_rf_inte));
+}
+
+SQEvent_v2::~SQEvent_v2()
+{
+  Reset();
+}
+
+void SQEvent_v2::Reset()
+{
+  _run_id       = INT_MAX;
+  _spill_id     = INT_MAX;
+  _event_id     = INT_MAX;
+  _trigger      = 0;
+  _data_quality = INT_MAX;
+  _qie_trig_cnt = INT_MAX;
+  _qie_turn_id  = INT_MAX;
+  _qie_rf_id    = INT_MAX;
+  memset(_qie_presums, 0, sizeof(_qie_presums));
+  memset(_qie_rf_inte, 0, sizeof(_qie_rf_inte));
+}
+
+void SQEvent_v2::identify(std::ostream& os) const
+{
+  os << "---SQEvent_v2::identify:--------------------------\n"
+     << "runID: " << _run_id << " spillID: " << _spill_id << " eventID: " << _event_id << "\n";
+  for(int i = SQEvent::NIM1; i<=SQEvent::NIM5; ++i) {
+    int name = i - SQEvent::NIM1 + 1;
+    os <<"NIM"<<name<<": " << get_trigger(static_cast<SQEvent::TriggerMask>(i)) << "; ";
+  }
+  os <<endl;
+  for(int i = SQEvent::MATRIX1; i<=SQEvent::MATRIX5; ++i){
+    int name = i - SQEvent::MATRIX1 + 1;
+    os <<"MATRIX"<<name<<": " << get_trigger(static_cast<SQEvent::TriggerMask>(i)) << "; ";
+  }
+  os <<endl;
+}

--- a/interface_main/SQEvent_v2.h
+++ b/interface_main/SQEvent_v2.h
@@ -1,0 +1,79 @@
+#ifndef _H_SQEvent_v2_H_
+#define _H_SQEvent_v2_H_
+#include <map>
+#include <iostream>
+#include <limits>
+#include <climits>
+#include "SQEvent.h"
+
+class SQEvent_v2: public SQEvent {
+  int _run_id;
+  int _spill_id;
+  int _event_id;
+  unsigned short _trigger; //< NIM[1-5], MATRIX[1-5]
+  int _data_quality;
+  
+  int _qie_presums[4];
+  int _qie_trig_cnt;
+  int _qie_turn_id;
+  int _qie_rf_id;
+  int _qie_rf_inte[33];
+
+ public:
+  SQEvent_v2();
+  virtual ~SQEvent_v2();
+  
+  virtual void Reset();
+  virtual void identify(std::ostream& os = std::cout) const;
+  virtual int  isValid() const {return 1;}
+  virtual SQEvent* Clone() const {return new SQEvent_v2(*this);}
+  
+  virtual int  get_run_id() const {return _run_id;}
+  virtual void set_run_id(const int a) {_run_id = a;}
+  
+  virtual int  get_spill_id() const {return _spill_id;}
+  virtual void set_spill_id(const int a) {_spill_id = a;}
+  
+  virtual int  get_event_id() const {return _event_id;}
+  virtual void set_event_id(const int a) {_event_id = a;}
+
+  virtual int  get_data_quality() const {return _data_quality;}
+  virtual void set_data_quality(const int a) {_data_quality = a;}
+
+  virtual bool get_trigger(const SQEvent::TriggerMask i) const {return (_trigger&(1<<i)) > 0 ;}
+  virtual void set_trigger(const SQEvent::TriggerMask i, const bool a) {a ? (_trigger |= (1<<i)) : (_trigger &= ~(1<<i)) ;}
+  
+  virtual unsigned short get_trigger() const {return _trigger;}
+  virtual void           set_trigger(const unsigned short a) {_trigger = a;}
+  
+  virtual int  get_qie_presum(const unsigned short i) const {
+    if (i<4) return _qie_presums[i]; 
+    return INT_MAX;
+  }
+  virtual void set_qie_presum(const unsigned short i, const int a) {
+    if(i<4) _qie_presums[i] = a;
+    else std::cout<<"SQEvent_v2::set_qie_presum: i>=4";
+  }
+  
+  virtual int  get_qie_trigger_count() const { return _qie_trig_cnt; }
+  virtual void set_qie_trigger_count(const int a)   { _qie_trig_cnt = a; }
+  
+  virtual int  get_qie_turn_id() const { return _qie_turn_id; }
+  virtual void set_qie_turn_id(const int a)   { _qie_turn_id = a; }
+  
+  virtual int  get_qie_rf_id() const { return _qie_rf_id; }
+  virtual void set_qie_rf_id(const int a)   { _qie_rf_id = a; }
+  
+  virtual int  get_qie_rf_intensity(const short i) const {
+    if (abs(i)<=16) return _qie_rf_inte[i+16]; 
+    return INT_MAX;
+  }
+  virtual void set_qie_rf_intensity(const short i, const int a) {
+    if(abs(i)<=16) _qie_rf_inte[i+16] = a;
+    else std::cout<<"SQEvent_v2::set_qie_rf_intensity: abs(i)>16";
+  }
+
+  ClassDef(SQEvent_v2, 1);
+};
+
+#endif /* _H_SQEvent_v2_H_ */

--- a/interface_main/SQEvent_v2LinkDef.h
+++ b/interface_main/SQEvent_v2LinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class SQEvent_v2+;
+
+#endif /* __CINT__ */

--- a/interface_main/SQHardEvent.cxx
+++ b/interface_main/SQHardEvent.cxx
@@ -1,0 +1,9 @@
+#include "SQHardEvent.h"
+using namespace std;
+
+ClassImp(SQHardEvent)
+
+void SQHardEvent::identify(std::ostream& os) const
+{
+  os << "---SQHardEvent::identify: abstract base-------------------" << endl;
+}

--- a/interface_main/SQHardEvent.h
+++ b/interface_main/SQHardEvent.h
@@ -1,0 +1,62 @@
+#ifndef _H_SQHardEvent_H_
+#define _H_SQHardEvent_H_
+#include <iostream>
+#include <phool/PHObject.h>
+
+/// An SQ interface class to hold one hardware-related event info.
+class SQHardEvent: public PHObject {
+ protected: 
+  SQHardEvent() {;}
+
+ public:
+  virtual ~SQHardEvent() {;}
+
+  virtual void Reset() = 0;
+  virtual void identify(std::ostream& os = std::cout) const = 0;
+  virtual int  isValid() const = 0;
+  virtual SQHardEvent* Clone() const = 0;
+  
+  /// Return the Coda-event ID, which is unique per run.
+  virtual int  get_coda_event_id() const = 0;
+  virtual void set_coda_event_id(const int a) = 0;
+  
+  /// Return the VME time.
+  virtual int  get_vme_time() const = 0; 
+  virtual void set_vme_time(const int a) = 0;
+  
+  /// Return the raw count of the selected trigger channel.
+  virtual int  get_raw_matrix(const unsigned short i) const = 0;
+  virtual void set_raw_matrix(const unsigned short i, const bool a) = 0;
+  
+  /// Return the after-inhibited count of the selected trigger channel.
+  virtual int  get_after_inh_matrix(const unsigned short i) const = 0; 
+  virtual void set_after_inh_matrix(const unsigned short i, const bool a) = 0;
+
+  /// Return the quality flag of the V1495 readout.
+  virtual short get_flag_v1495() const = 0;
+  virtual void  set_flag_v1495(const short a) = 0;
+
+  /// Return the number of QIE boards read out.
+  virtual short get_n_board_qie() const = 0;
+  virtual void  set_n_board_qie(const short a) = 0;
+  
+  /// Return the number of V1495 boards read out.
+  virtual short get_n_board_v1495() const = 0;
+  virtual void  set_n_board_v1495(const short a) = 0;
+  
+  /// Return the number of Taiwan-TDC boards read out.
+  virtual short get_n_board_taiwan() const = 0;
+  virtual void  set_n_board_taiwan(const short a) = 0;
+  
+  /// Return the number of trigger-bit boards read out.
+  virtual short get_n_board_trig_bit() const = 0; 
+  virtual void  set_n_board_trig_bit(const short a) = 0;
+  
+  /// Return the number of trigger-count boards read out.
+  virtual short get_n_board_trig_count() const = 0;
+  virtual void  set_n_board_trig_count(const short a) = 0;
+  
+  ClassDef(SQHardEvent, 1);
+};
+
+#endif /* _H_SQHardEvent_H_ */

--- a/interface_main/SQHardEventLinkDef.h
+++ b/interface_main/SQHardEventLinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class SQHardEvent+;
+
+#endif /* __CINT__ */

--- a/interface_main/SQHardEvent_v1.cxx
+++ b/interface_main/SQHardEvent_v1.cxx
@@ -1,0 +1,74 @@
+#include <climits>
+#include "SQHardEvent_v1.h"
+using namespace std;
+
+ClassImp(SQHardEvent_v1)
+
+SQHardEvent_v1::SQHardEvent_v1()
+  : _coda_event_id (INT_MAX)
+  , _vme_time      (INT_MAX)
+  , _flag_v1495    (SHRT_MAX) 
+  , _n_board_qie   (SHRT_MAX)
+  , _n_board_v1495 (SHRT_MAX)
+  , _n_board_taiwan(SHRT_MAX)
+  , _n_board_trig_b(SHRT_MAX)
+  , _n_board_trig_c(SHRT_MAX)
+{
+  memset(_raw_matrix      , 0, sizeof(_raw_matrix));
+  memset(_after_inh_matrix, 0, sizeof(_after_inh_matrix));
+}
+
+SQHardEvent_v1::~SQHardEvent_v1()
+{
+  Reset();
+}
+
+void SQHardEvent_v1::Reset()
+{
+  _coda_event_id  = INT_MAX;
+  _vme_time       = INT_MAX;
+  _flag_v1495     = SHRT_MAX;
+  _n_board_qie    = SHRT_MAX;
+  _n_board_v1495  = SHRT_MAX;
+  _n_board_taiwan = SHRT_MAX;
+  _n_board_trig_b = SHRT_MAX;
+  _n_board_trig_c = SHRT_MAX;
+  memset(_raw_matrix      , 0, sizeof(_raw_matrix));
+  memset(_after_inh_matrix, 0, sizeof(_after_inh_matrix));
+}
+
+int SQHardEvent_v1::get_raw_matrix(const unsigned short i) const
+{
+  if (i < 5) return _raw_matrix[i];
+  return INT_MAX;
+}
+
+void SQHardEvent_v1::set_raw_matrix(const unsigned short i, const bool a)
+{
+  if (i < 5) _raw_matrix[i] = a;
+  else cout << "SQHardEvent_v1::set_raw_matrix: i>=5" << endl;
+}
+
+int SQHardEvent_v1::get_after_inh_matrix(const unsigned short i) const
+{
+  if (i < 5) return _after_inh_matrix[i];
+  return INT_MAX;
+}
+
+void SQHardEvent_v1::set_after_inh_matrix(const unsigned short i, const bool a)
+{
+  if (i < 5) _after_inh_matrix[i] = a;
+  else cout << "SQHardEvent_v1::set_after_inh_matrix: i>=5" << endl;
+}
+
+void SQHardEvent_v1::identify(std::ostream& os) const
+{
+  os << "---SQHardEvent_v1::identify:--------------------------\n"
+     << "codaEventID: " << _coda_event_id << "\n"
+     << "raw_matrix: ";
+  for (int i = 0; i < 5; ++i) os << " " << _raw_matrix[i];
+  os << "\n"
+     << "after_inh_matrix: ";
+  for (int i = 0; i < 5; ++i) os << " " << _after_inh_matrix[i];
+  os << endl;
+}

--- a/interface_main/SQHardEvent_v1.h
+++ b/interface_main/SQHardEvent_v1.h
@@ -1,0 +1,64 @@
+#ifndef _H_SQHardEvent_v1_H_
+#define _H_SQHardEvent_v1_H_
+#include <map>
+#include <iostream>
+//#include <limits>
+//#include <climits>
+#include "SQHardEvent.h"
+
+class SQHardEvent_v1: public SQHardEvent {
+  int _coda_event_id;
+  int _vme_time;
+  int _raw_matrix[5];
+  int _after_inh_matrix[5];
+
+  short _flag_v1495;
+  short _n_board_qie;
+  short _n_board_v1495;
+  short _n_board_taiwan;
+  short _n_board_trig_b;
+  short _n_board_trig_c;
+  
+ public:
+  SQHardEvent_v1();
+  virtual ~SQHardEvent_v1();
+
+  virtual void Reset();
+  virtual void identify(std::ostream& os = std::cout) const;
+  virtual int  isValid() const { return 1; }
+  virtual SQHardEvent* Clone() const { return new SQHardEvent_v1(*this); }
+
+  virtual int  get_coda_event_id() const { return _coda_event_id; }
+  virtual void set_coda_event_id(const int a)   { _coda_event_id = a; }
+
+  virtual int  get_vme_time() const { return _vme_time; }
+  virtual void set_vme_time(const int a)   { _vme_time = a; }
+
+  virtual int  get_raw_matrix(const unsigned short i) const;
+  virtual void set_raw_matrix(const unsigned short i, const bool a);
+
+  virtual int  get_after_inh_matrix(const unsigned short i) const;
+  virtual void set_after_inh_matrix(const unsigned short i, const bool a);
+
+  virtual short get_flag_v1495() const { return _flag_v1495; }
+  virtual void  set_flag_v1495(const short a) { _flag_v1495 = a; }
+
+  virtual short get_n_board_qie() const { return _n_board_qie; }
+  virtual void  set_n_board_qie(const short a) { _n_board_qie = a; }
+  
+  virtual short get_n_board_v1495() const { return _n_board_v1495; }
+  virtual void  set_n_board_v1495(const short a) { _n_board_v1495 = a; }
+  
+  virtual short get_n_board_taiwan() const { return _n_board_taiwan; }
+  virtual void  set_n_board_taiwan(const short a) { _n_board_taiwan = a; }
+  
+  virtual short get_n_board_trig_bit() const { return _n_board_trig_b; }
+  virtual void  set_n_board_trig_bit(const short a) { _n_board_trig_b = a; }
+  
+  virtual short get_n_board_trig_count() const { return _n_board_trig_c; }
+  virtual void  set_n_board_trig_count(const short a) { _n_board_trig_c = a; }
+
+  ClassDef(SQHardEvent_v1, 1);
+};
+
+#endif /* _H_SQHardEvent_v1_H_ */

--- a/interface_main/SQHardEvent_v1LinkDef.h
+++ b/interface_main/SQHardEvent_v1LinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class SQHardEvent_v1+;
+
+#endif /* __CINT__ */

--- a/interface_main/SQHardSpill.cxx
+++ b/interface_main/SQHardSpill.cxx
@@ -1,0 +1,4 @@
+#include "SQHardSpill.h"
+using namespace std;
+
+ClassImp(SQHardSpill)

--- a/interface_main/SQHardSpill.h
+++ b/interface_main/SQHardSpill.h
@@ -1,0 +1,56 @@
+#ifndef _H_SQHardSpill_H_
+#define _H_SQHardSpill_H_
+#include <iostream>
+#include <TTimeStamp.h>
+#include <phool/PHObject.h>
+
+/// An SQ interface class to hold the hardware-related data of one spill.
+class SQHardSpill : public PHObject {
+ protected:
+  SQHardSpill() {;}
+
+ public:
+  virtual ~SQHardSpill() {;}
+
+  virtual void Reset() = 0;
+  virtual void identify(std::ostream& os=std::cout) const = 0;
+  virtual int  isValid() const = 0;
+  virtual SQHardSpill* clone() const = 0;
+  virtual SQHardSpill* Clone() const = 0; ///< No use.  Only for backward compatibility.
+
+  /// Return the Coda ID at BOS of this spill.
+  virtual int  get_bos_coda_id() const = 0;
+  virtual void set_bos_coda_id(const int a) = 0;
+
+  /// Return the VME time at BOS of this spill.
+  virtual int  get_bos_vme_time() const = 0;
+  virtual void set_bos_vme_time(const int a) = 0;
+
+  /// Return the Coda ID at EOS of this spill.
+  virtual int  get_eos_coda_id() const = 0;
+  virtual void set_eos_coda_id(const int a) = 0;
+
+  /// Return the VME time at EOS of this spill.
+  virtual int  get_eos_vme_time() const = 0;
+  virtual void set_eos_vme_time(const int a) = 0;
+
+  /// Return the times when the decoding of spill begins.
+  virtual TTimeStamp get_timestamp_deco_begin() const = 0;
+  virtual void       set_timestamp_deco_begin(const TTimeStamp a) = 0;
+
+  /// Return the time when the decoding of spill ends.
+  virtual TTimeStamp get_timestamp_deco_end() const = 0;
+  virtual void       set_timestamp_deco_end(const TTimeStamp a) = 0;
+
+  /// Return the UNIX time when the event process of spill begins.
+  virtual TTimeStamp get_timestamp_proc_begin() const = 0;
+  virtual void       set_timestamp_proc_begin(const TTimeStamp a) = 0;
+
+  /// Return the UNIX time when the event process of spill ends.
+  virtual TTimeStamp get_timestamp_proc_end() const = 0;
+  virtual void       set_timestamp_proc_end(const TTimeStamp a) = 0;
+
+  ClassDef(SQHardSpill, 1);
+};
+
+#endif /* _H_SQHardSpill_H_ */

--- a/interface_main/SQHardSpillLinkDef.h
+++ b/interface_main/SQHardSpillLinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class SQHardSpill+;
+
+#endif /* __CINT__ */

--- a/interface_main/SQHardSpill_v1.cxx
+++ b/interface_main/SQHardSpill_v1.cxx
@@ -1,0 +1,38 @@
+#include "SQHardSpill_v1.h"
+using namespace std;
+
+ClassImp(SQHardSpill_v1);
+
+SQHardSpill_v1::SQHardSpill_v1()
+  : _bos_coda_id  (0)
+  , _bos_vme_time (0)
+  , _eos_coda_id  (0)
+  , _eos_vme_time (0)
+  , _ts_deco_begin(TTimeStamp(0, 0))
+  , _ts_deco_end  (TTimeStamp(0, 0))
+  , _ts_proc_begin(TTimeStamp(0, 0))
+  , _ts_proc_end  (TTimeStamp(0, 0))
+{
+  ;
+}
+
+void SQHardSpill_v1::Reset()
+{
+  _bos_coda_id      = 0;
+  _bos_vme_time     = 0;
+  _eos_coda_id      = 0;
+  _eos_vme_time     = 0;
+  _ts_deco_begin.SetSec    (0);
+  _ts_deco_begin.SetNanoSec(0);
+  _ts_deco_end  .SetSec    (0);
+  _ts_deco_end  .SetNanoSec(0);
+  _ts_proc_begin.SetSec    (0);
+  _ts_proc_begin.SetNanoSec(0);
+  _ts_proc_end  .SetSec    (0);
+  _ts_proc_end  .SetNanoSec(0);
+}
+
+void SQHardSpill_v1::identify(ostream& os) const
+{
+  os << "---SQHardSpill_v1--------------------" << endl;
+}

--- a/interface_main/SQHardSpill_v1.h
+++ b/interface_main/SQHardSpill_v1.h
@@ -1,0 +1,54 @@
+#ifndef _H_SQHardSpill_v1_H_
+#define _H_SQHardSpill_v1_H_
+#include <iostream>
+#include "SQHardSpill.h"
+
+class SQHardSpill_v1 : public SQHardSpill {
+  int _bos_coda_id;
+  int _bos_vme_time;
+  int _eos_coda_id;
+  int _eos_vme_time;
+  TTimeStamp _ts_deco_begin;
+  TTimeStamp _ts_deco_end  ;
+  TTimeStamp _ts_proc_begin;
+  TTimeStamp _ts_proc_end  ;
+
+ public:
+  SQHardSpill_v1();
+  virtual ~SQHardSpill_v1() {;}
+
+  SQHardSpill* clone() const { return new SQHardSpill_v1(*this); }
+  SQHardSpill* Clone() const { return new SQHardSpill_v1(*this); }
+  void Reset();
+  int isValid() const { return 1; }
+  void identify(std::ostream& os = std::cout) const;
+
+  virtual int  get_bos_coda_id() const { return _bos_coda_id; }
+  virtual void set_bos_coda_id(const int a)   { _bos_coda_id = a; }
+
+  virtual int  get_bos_vme_time() const { return _bos_vme_time; }
+  virtual void set_bos_vme_time(const int a)   { _bos_vme_time = a; }
+
+  virtual int  get_eos_coda_id() const { return _eos_coda_id; }
+  virtual void set_eos_coda_id(const int a)   { _eos_coda_id = a; }
+
+  virtual int  get_eos_vme_time() const { return _eos_vme_time; }
+  virtual void set_eos_vme_time(const int a)   { _eos_vme_time = a; }
+  
+  virtual TTimeStamp get_timestamp_deco_begin() const      { return _ts_deco_begin; }
+  virtual void       set_timestamp_deco_begin(const TTimeStamp a) { _ts_deco_begin = a; }
+
+  virtual TTimeStamp get_timestamp_deco_end() const      { return _ts_deco_end; }
+  virtual void       set_timestamp_deco_end(const TTimeStamp a) { _ts_deco_end = a; }
+
+  virtual TTimeStamp get_timestamp_proc_begin() const      { return _ts_proc_begin; }
+  virtual void       set_timestamp_proc_begin(const TTimeStamp a) { _ts_proc_begin = a; }
+
+  virtual TTimeStamp get_timestamp_proc_end() const      { return _ts_proc_end; }
+  virtual void       set_timestamp_proc_end(const TTimeStamp a) { _ts_proc_end = a; }
+
+  ClassDef(SQHardSpill_v1, 1);
+};
+
+
+#endif /* _H_SQHardSpill_v1_H_ */

--- a/interface_main/SQHardSpill_v1LinkDef.h
+++ b/interface_main/SQHardSpill_v1LinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class SQHardSpill_v1+;
+
+#endif /* __CINT__ */

--- a/interface_main/SQSpill.h
+++ b/interface_main/SQSpill.h
@@ -29,31 +29,42 @@ public:
   virtual int          isValid() const {return 0;}
   virtual SQSpill*        Clone() const {return NULL;}
 
-  virtual int  get_run_id() const {return std::numeric_limits<int>::max();} ///< Return the run ID when this spill was taken.
+  /// Return the run ID when this spill was taken.
+  virtual int  get_run_id() const {return std::numeric_limits<int>::max();}
   virtual void set_run_id(const int a) {}
 
-  virtual int  get_spill_id() const {return std::numeric_limits<int>::max();} ///< Return the spill ID.
+  /// Return the spill ID.
+  virtual int  get_spill_id() const {return std::numeric_limits<int>::max();}
   virtual void set_spill_id(const int a) {}
 
-  virtual short get_target_pos() const {return std::numeric_limits<short>::max();} ///< Return the target position in this spill.
+  /// Return the target position in this spill.
+  virtual short get_target_pos() const {return std::numeric_limits<short>::max();}
   virtual void  set_target_pos(const short a) {}
 
-  virtual int  get_bos_coda_id() const {return std::numeric_limits<int>::max();} ///< Return the Coda ID at BOS of this spill.
+  /// [Obsolete] Use `SQHardSpill` instead.
+  virtual int  get_bos_coda_id() const {return std::numeric_limits<int>::max();}
   virtual void set_bos_coda_id(const int a) {};
 
-  virtual int  get_bos_vme_time() const {return std::numeric_limits<int>::max();} ///< Return the VME time at BOS of this spill.
+  /// [Obsolete] Use `SQHardSpill` instead.
+  virtual int  get_bos_vme_time() const {return std::numeric_limits<int>::max();}
   virtual void set_bos_vme_time(const int a) {};
 
-  virtual int  get_eos_coda_id() const {return std::numeric_limits<int>::max();} ///< Return the Coda ID at EOS of this spill.
+  /// [Obsolete] Use `SQHardSpill` instead.
+  virtual int  get_eos_coda_id() const {return std::numeric_limits<int>::max();}
   virtual void set_eos_coda_id(const int a) {};
 
-  virtual int  get_eos_vme_time() const {return std::numeric_limits<int>::max();} ///< Return the VME time at EOS of this spill.
+  /// [Obsolete] Use `SQHardSpill` instead.
+  virtual int  get_eos_vme_time() const {return std::numeric_limits<int>::max();}
   virtual void set_eos_vme_time(const int a) {};
 
-  virtual SQStringMap* get_bos_scaler_list() { return 0; } ///< Return the list of scaler variables read out at BOS.
-  virtual SQStringMap* get_eos_scaler_list() { return 0; } ///< Return the list of scaler variables read out at EOS.
+  /// Return the list of scaler variables read out at BOS.
+  virtual SQStringMap* get_bos_scaler_list() { return 0; }
 
-  virtual SQStringMap* get_slow_cont_list() { return 0; } ///< Return the list of slow control variables.
+  /// Return the list of scaler variables read out at EOS.
+  virtual SQStringMap* get_eos_scaler_list() { return 0; }
+
+  /// Return the list of slow control variables.
+  virtual SQStringMap* get_slow_cont_list() { return 0; }
   
 protected:
   SQSpill() {}

--- a/online/decoder_maindaq/CalibEvtQual.cc
+++ b/online/decoder_maindaq/CalibEvtQual.cc
@@ -1,4 +1,5 @@
 #include <interface_main/SQEvent.h>
+#include <interface_main/SQHardEvent.h>
 #include <fun4all/Fun4AllReturnCodes.h>
 #include <fun4all/Fun4AllHistoManager.h>
 #include <phool/PHNodeIterator.h>
@@ -27,6 +28,9 @@ int CalibEvtQual::process_event(PHCompositeNode* topNode)
   SQEvent* event = findNode::getClass<SQEvent>(topNode, "SQEvent");
   if (! event) return Fun4AllReturnCodes::ABORTEVENT;
 
+  SQHardEvent* hard_evt = findNode::getClass<SQHardEvent>(topNode, "SQHardEvent");
+  if (! hard_evt) return Fun4AllReturnCodes::ABORTEVENT;
+
   int run_id = event->get_run_id();
   int qual   = event->get_data_quality();
 
@@ -39,15 +43,15 @@ int CalibEvtQual::process_event(PHCompositeNode* topNode)
   // Note that runs 28662 & 28663 contain no event.
   // Is the change of n_tdc related to elog #17385??
   // https://e906-gat6.fnal.gov:8080/SeaQuest/17385
-  if      (event->get_n_board_taiwan() != n_tdc) qual |= ERR_N_TDC;
-  if      (event->get_n_board_v1495      () < 2) qual |= ERR_N_V1495_0;
-  else if (event->get_n_board_v1495      () > 2) qual |= ERR_N_V1495_2;
-  if      (event->get_n_board_trig_bit   () < 1) qual |= ERR_N_TRIGB_0;
-  else if (event->get_n_board_trig_bit   () > 1) qual |= ERR_N_TRIGB_2;
-  if      (event->get_n_board_trig_count () < 1) qual |= ERR_N_TRIGC_0;
-  else if (event->get_n_board_trig_count () > 1) qual |= ERR_N_TRIGC_2;
-  if      (event->get_n_board_qie        () < 1) qual |= ERR_N_QIE_0;
-  else if (event->get_n_board_qie        () > 1) qual |= ERR_N_QIE_2;
+  if      (hard_evt->get_n_board_taiwan() != n_tdc) qual |= ERR_N_TDC;
+  if      (hard_evt->get_n_board_v1495      () < 2) qual |= ERR_N_V1495_0;
+  else if (hard_evt->get_n_board_v1495      () > 2) qual |= ERR_N_V1495_2;
+  if      (hard_evt->get_n_board_trig_bit   () < 1) qual |= ERR_N_TRIGB_0;
+  else if (hard_evt->get_n_board_trig_bit   () > 1) qual |= ERR_N_TRIGB_2;
+  if      (hard_evt->get_n_board_trig_count () < 1) qual |= ERR_N_TRIGC_0;
+  else if (hard_evt->get_n_board_trig_count () > 1) qual |= ERR_N_TRIGC_2;
+  if      (hard_evt->get_n_board_qie        () < 1) qual |= ERR_N_QIE_0;
+  else if (hard_evt->get_n_board_qie        () > 1) qual |= ERR_N_QIE_2;
 
   event->set_data_quality(qual);
   //if (qual != 0) {
@@ -63,14 +67,14 @@ int CalibEvtQual::End(PHCompositeNode* topNode)
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
-void CalibEvtQual::PrintEvent(SQEvent* evt)
+void CalibEvtQual::PrintEvent(SQEvent* evt, SQHardEvent* hevt)
 {
   cout << "SQEvent:  "
-       << "  " << evt->get_run_id       ()
-       << "  " << evt->get_spill_id     ()
-       << "  " << evt->get_event_id     ()
-       << "  " << evt->get_coda_event_id()
-       << "  " << evt->get_data_quality ()
-       << "  " << evt->get_vme_time     ()
+       << "  " <<  evt->get_run_id       ()
+       << "  " <<  evt->get_spill_id     ()
+       << "  " <<  evt->get_event_id     ()
+       << "  " <<  evt->get_data_quality ()
+       << "  " << hevt->get_coda_event_id()
+       << "  " << hevt->get_vme_time     ()
        << "\n";
 }

--- a/online/decoder_maindaq/CalibEvtQual.h
+++ b/online/decoder_maindaq/CalibEvtQual.h
@@ -2,7 +2,7 @@
 #define _CALIB_EVT_QUAL_H_
 #include <fun4all/SubsysReco.h>
 class SQEvent;
-class TH1;
+class SQHardEvent;
 
 class CalibEvtQual: public SubsysReco {
   /** Error flags to be inserted to the "Event.dataQuality" field.
@@ -32,7 +32,7 @@ class CalibEvtQual: public SubsysReco {
   int process_event(PHCompositeNode *topNode);
   int End(PHCompositeNode *topNode);
  private:
-  void PrintEvent(SQEvent* evt);
+  void PrintEvent(SQEvent* evt, SQHardEvent* hevt);
 };
 
 #endif /* _CALIB_EVT_QUAL_H_ */

--- a/online/decoder_maindaq/DbUpSpill.h
+++ b/online/decoder_maindaq/DbUpSpill.h
@@ -2,6 +2,7 @@
 #define _DB_UP_SPILL__H_
 #include <fun4all/SubsysReco.h>
 class SQSpill;
+class SQHardSpill;
 
 class DbUpSpill: public SubsysReco {
  public:
@@ -14,10 +15,10 @@ class DbUpSpill: public SubsysReco {
 
  private:
   void ClearTable(const char* table_name, const int run_id);
-  void UploadToSpillTable(SQSpill* spi);
+  void UploadToSpillTable(SQSpill* spi, SQHardSpill* hspi);
   void UploadToScalerTable(SQSpill* spi, const std::string boseos);
   void UploadToSlowContTable(SQSpill* spi);
-  void PrintSpill(SQSpill* spi);
+  void PrintSpill(SQSpill* spi, SQHardSpill* hspi);
 };
 
 #endif /* _DB_UP_SPILL__H_ */

--- a/online/decoder_maindaq/DecoData.cc
+++ b/online/decoder_maindaq/DecoData.cc
@@ -54,10 +54,21 @@ ScalerData::ScalerData() :
   ;
 }
 
-SpillData::SpillData() : 
-  spill_id(0), spill_id_slow(0), run_id(0), targ_pos(0), 
-  bos_coda_id(0), bos_vme_time(0), eos_coda_id(0), eos_vme_time(0), 
-  n_bos_spill(0), n_eos_spill(0), n_slow(0), n_scaler(0)
+SpillData::SpillData()
+  : spill_id     (0)
+  , spill_id_slow(0)
+  , run_id       (0)
+  , targ_pos     (0)
+  , bos_coda_id  (0)
+  , bos_vme_time (0)
+  , eos_coda_id  (0)
+  , eos_vme_time (0)
+  , n_bos_spill  (0)
+  , n_eos_spill  (0)
+  , n_slow       (0)
+  , n_scaler     (0)
+  , ts_deco_begin(TTimeStamp(0, 0))
+  , ts_deco_end  (TTimeStamp(0, 0))
 {
   ;
 }

--- a/online/decoder_maindaq/DecoData.h
+++ b/online/decoder_maindaq/DecoData.h
@@ -8,6 +8,7 @@
 #include <map>
 #include <algorithm>
 #include <TObject.h>
+#include <TTimeStamp.h>
 
 /* ================================================================
  DecoData
@@ -151,6 +152,9 @@ struct SpillData {
   unsigned int n_eos_spill;
   unsigned int n_slow;
   unsigned int n_scaler;
+
+  TTimeStamp ts_deco_begin;
+  TTimeStamp ts_deco_end;
 
   SlowControlDataList list_slow_cont;
   ScalerDataList list_scaler;

--- a/online/decoder_maindaq/DecoParam.cc
+++ b/online/decoder_maindaq/DecoParam.cc
@@ -4,11 +4,29 @@
 #include "DecoParam.h"
 using namespace std;
 
-DecoParam::DecoParam() :
-  fn_in(""), dir_param(""), is_online(false), sampling(0), verb(0), time_wait(0), 
-  runID(0), spillID(0), spillID_cntr(0), spillID_slow(0),
-  targPos(0), targPos_slow(0), event_count(0), codaID(0), rocID(0), eventIDstd(0), hitID(0), 
-  has_1st_bos(false), at_bos(false), turn_id_max(0)
+DecoParam::DecoParam()
+  : fn_in           ("")
+  , dir_param       ("")
+  , is_online       (false)
+  , sampling        (0)
+  , verb            (0)
+  , time_wait       (0)
+  , runID           (0)
+  , spillID         (0)
+  , spillID_cntr    (0)
+  , spillID_slow    (0)
+  , targPos         (0)
+  , targPos_slow    (0)
+  , ts_deco_begin   (TTimeStamp(0, 0))
+  , ts_deco_end     (TTimeStamp(0, 0))
+  , event_count     (0)
+  , codaID          (0)
+  , rocID           (0)
+  , eventIDstd      (0)
+  , hitID           (0)
+  , has_1st_bos     (false)
+  , at_bos          (false)
+  , turn_id_max     (0)
 {
   ;
 }

--- a/online/decoder_maindaq/DecoParam.h
+++ b/online/decoder_maindaq/DecoParam.h
@@ -1,5 +1,6 @@
 #ifndef __DECO_PARAM_H__
 #define __DECO_PARAM_H__
+#include <TTimeStamp.h>
 #include <geom_svc/ChanMapTaiwan.h>
 #include <geom_svc/ChanMapV1495.h>
 #include <geom_svc/ChanMapScaler.h>
@@ -36,6 +37,9 @@ struct DecoParam {
   int spillID_slow; // spillID from slow-control event
   short targPos;
   short targPos_slow; // from slow-control event
+
+  TTimeStamp ts_deco_begin; // Time when the decoding of one spill begins.  Set in EOS event.
+  TTimeStamp ts_deco_end;   // Time when the decoding of one spill ends.  Set in FLUSH events.
 
   unsigned int event_count; ///< current event count
   unsigned int codaID; ///< current Coda event ID

--- a/online/decoder_maindaq/Fun4AllEVIOInputManager.cc
+++ b/online/decoder_maindaq/Fun4AllEVIOInputManager.cc
@@ -287,7 +287,6 @@ int Fun4AllEVIOInputManager::run(const int nevents)
 
   run_header->set_run_id         (rd->run_id);
   run_header->set_unix_time_begin(rd->utime_b);
-  run_header->set_unix_time_end  (rd->utime_e);
   for (int ii = 0; ii < 5; ii++) {
     run_header->set_fpga_enabled (ii, rd->fpga_enabled [ii]);
     run_header->set_fpga_prescale(ii, rd->fpga_prescale[ii]);
@@ -440,6 +439,12 @@ int Fun4AllEVIOInputManager::fileclose()
       cout << Name() << ": fileclose: No Input file open" << endl;
       return -1;
     }
+
+  SQRun* sqrun = findNode::getClass<SQRun>(topNode, "SQRun");
+  if (sqrun) {
+    RunData* rd = parser->GetRunData();
+    sqrun->set_unix_time_end(rd->utime_e);
+  }
 
   parser->End();
   cout << "Fun4AllEVIOInputManager: Timer:\n";

--- a/online/decoder_maindaq/MainDaqParser.h
+++ b/online/decoder_maindaq/MainDaqParser.h
@@ -71,6 +71,7 @@ public:
   CodaInputManager* GetCoda() { return coda; }
   int OpenCodaFile(const std::string fname, const long file_size_min=32768, const int sec_wait=15, const int n_wait=40);
   bool NextPhysicsEvent(EventData*& ed, SpillData*& sd, RunData*& rd);
+  RunData* GetRunData() { return &run_data; }
   int End();
 
   DecoParam dec_par;

--- a/online/macros/Fun4MainDaq.C
+++ b/online/macros/Fun4MainDaq.C
@@ -54,6 +54,7 @@ int Fun4MainDaq(const int run=46, const int nevent=0, const bool is_online=false
 
   if (use_onlmon) { // Register the online-monitoring clients
     if (is_online) se->StartServer();
+    //OnlMonComm::instance()->SetMaxNumSelSpills(600); // default = 600
     se->registerSubsystem(new OnlMonMainDaq());
     se->registerSubsystem(new OnlMonTrigSig());
     se->registerSubsystem(new OnlMonTrigNim());

--- a/online/onlmonserver/OnlMonClient.cc
+++ b/online/onlmonserver/OnlMonClient.cc
@@ -308,15 +308,27 @@ int OnlMonClient::SendHist(TSocket* sock, int sp_min, int sp_max)
   return 0;
 }
 
+/// Clear the contents of all spill-by-spill histograms.
+/**
+ * This function deletes "N_spills * N_types" of histograms per client.
+ * But the memory usage usually does not go down promptly.
+ * It should be fine (i.e. not memory leak) as the memory will be released later when needed by other processes.
+ * Such delay could happen when a huge number of small memory blocks are deleted, as done in this function.
+ */
 void OnlMonClient::ClearSpillHist()
 {
+  int n_type = 0;
+  int n_hist = 0;
   for (Name2SpillHistMap_t::iterator it1 = m_map_hist_sp.begin(); it1 != m_map_hist_sp.end(); it1++) {
     SpillHistMap_t* map_hist = &it1->second;
     for (SpillHistMap_t::iterator it2 = map_hist->begin(); it2 != map_hist->end(); it2++) {
       delete it2->second;
+      n_hist++;
     }
+    n_type++;
   }
   m_map_hist_sp.clear();
+  cout << Name() << ": Cleared " << n_hist << " hists for " << n_type << " types." << endl;
 }
 
 /**

--- a/online/onlmonserver/OnlMonComm.cc
+++ b/online/onlmonserver/OnlMonComm.cc
@@ -27,7 +27,7 @@ OnlMonComm::OnlMonComm()
   , m_sp_min(0)
   , m_sp_max(0)
   , m_sp_sel(true)
-  , m_n_sp_sel_max(900)
+  , m_n_sp_sel_max(600)
 {
   ;
 }

--- a/online/onlmonserver/OnlMonMainDaq.cc
+++ b/online/onlmonserver/OnlMonMainDaq.cc
@@ -6,7 +6,10 @@
 #include <TCanvas.h>
 #include <TPaveText.h>
 #include <interface_main/SQRun.h>
+#include <interface_main/SQIntMap.h>
+#include <interface_main/SQHardSpill.h>
 #include <interface_main/SQEvent.h>
+#include <interface_main/SQHardEvent.h>
 #include <interface_main/SQHitVector.h>
 #include <fun4all/Fun4AllReturnCodes.h>
 #include <phool/PHNodeIterator.h>
@@ -23,7 +26,7 @@ OnlMonMainDaq::OnlMonMainDaq()
 {
   Name("OnlMonMainDaq");
   Title("Main DAQ");
-  NumCanvases(2);
+  NumCanvases(3);
 }
 
 int OnlMonMainDaq::InitOnlMon(PHCompositeNode* topNode)
@@ -64,48 +67,57 @@ int OnlMonMainDaq::InitRunOnlMon(PHCompositeNode* topNode)
 
   h1_cnt = new TH1D("h1_cnt", ";Type;Count", 15, 0.5, 15.5);
 
-  h1_nevt_sp = new TH1D("h1_nevt_sp", ";Spill ID;N of events/spill", 1000, -0.5, 999.5);
-
-  const int NHIT_NUM = 41;
   const int N_PL = nChamberPlanes + nHodoPlanes + nPropPlanes + nDarkPhotonPlanes;
-  double nhit_bin[NHIT_NUM+1];
-  for (int ib = 0; ib <= NHIT_NUM; ib++) nhit_bin[ib] = pow(10, 0.1 * (ib - 1));
-  h2_nhit_pl = new TH2D("h2_nhit_pl", ";N of hits/event;", NHIT_NUM, nhit_bin, N_PL+1, 0.5, N_PL+1.5);
-  for (int i_pl = 1; i_pl <= N_PL; i_pl++) {
-    ostringstream oss;
-    oss << GeomSvc::instance()->getDetectorName(i_pl) << ":" << setfill('0') << setw(2) << i_pl;
-    h2_nhit_pl->GetYaxis()->SetBinLabel(i_pl, oss.str().c_str());
+  double nhit_bin[38];
+  nhit_bin[0] = 0.9; // The 1st bin for "N=0".
+  nhit_bin[1] = 1.0;
+  for (int ii = 0; ii < 4; ii++) {
+    for (int jj = 0; jj < 9; jj++) nhit_bin[9*ii + jj + 2] = (jj + 2) * pow(10, ii);
   }
-  h2_nhit_pl->GetYaxis()->SetBinLabel(N_PL + 1, "Total");
+  h2_nhit_pl = new TH2D("h2_nhit_pl", ";N of hits/event;", 37, nhit_bin, N_PL+1, 0.5, N_PL+1.5);
+  for (int i_pl = 1; i_pl <= N_PL; i_pl++) {
+    h2_nhit_pl->GetYaxis()->SetBinLabel(i_pl, GeomSvc::instance()->getDetectorName(i_pl).c_str());
+  }
+  h2_nhit_pl->GetYaxis()->SetBinLabel(N_PL + 1, "All planes");
+
+  h1_nevt_sp = new TH1F("h1_nevt_sp", ";Spill;N of events", 1000, -0.5, 999.5);
+
+  h1_time_deco = new TH1F("h1_time_deco", ";Spill;Decoding time (sec)", 1000, -0.5, 999.5);
+
+  h1_time_ana  = new TH1F("h1_time_ana", ";Spill;Analysis time (sec)", 1000, -0.5, 999.5);
 
   RegisterHist(h1_trig);
   RegisterHist(h1_n_taiwan);
   RegisterHist(h1_evt_qual);
   RegisterHist(h1_flag_v1495);
   RegisterHist(h1_cnt, OnlMonClient::MODE_UPDATE);
-  RegisterHist(h1_nevt_sp);
   RegisterHist(h2_nhit_pl);
+  RegisterHist(h1_nevt_sp);
+  RegisterHist(h1_time_deco);
+  RegisterHist(h1_time_ana);
 
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
 int OnlMonMainDaq::ProcessEventOnlMon(PHCompositeNode* topNode)
 {
-  SQRun*   run    = findNode::getClass<SQRun      >(topNode, "SQRun");
-  SQEvent* event  = findNode::getClass<SQEvent    >(topNode, "SQEvent");
-  SQHitVector* hv = findNode::getClass<SQHitVector>(topNode, "SQHitVector");
-  if (! run || ! event || ! hv) return Fun4AllReturnCodes::ABORTEVENT;
+  SQRun*        run = findNode::getClass<SQRun      >(topNode, "SQRun");
+  SQIntMap*  map_hs = findNode::getClass<SQIntMap   >(topNode, "SQHardSpillMap");
+  SQEvent*      evt = findNode::getClass<SQEvent    >(topNode, "SQEvent");
+  SQHardEvent* hevt = findNode::getClass<SQHardEvent>(topNode, "SQHardEvent");
+  SQHitVector*   hv = findNode::getClass<SQHitVector>(topNode, "SQHitVector");
+  if (!run || !map_hs || !evt || !hevt || !hv) return Fun4AllReturnCodes::ABORTEVENT;
 
-  if (event->get_trigger(SQEvent::MATRIX1)) h1_trig->Fill( 1);
-  if (event->get_trigger(SQEvent::MATRIX2)) h1_trig->Fill( 2);
-  if (event->get_trigger(SQEvent::MATRIX3)) h1_trig->Fill( 3);
-  if (event->get_trigger(SQEvent::MATRIX4)) h1_trig->Fill( 4);
-  if (event->get_trigger(SQEvent::MATRIX5)) h1_trig->Fill( 5);
-  if (event->get_trigger(SQEvent::NIM1   )) h1_trig->Fill( 6);
-  if (event->get_trigger(SQEvent::NIM2   )) h1_trig->Fill( 7);
-  if (event->get_trigger(SQEvent::NIM3   )) h1_trig->Fill( 8);
-  if (event->get_trigger(SQEvent::NIM4   )) h1_trig->Fill( 9);
-  if (event->get_trigger(SQEvent::NIM5   )) h1_trig->Fill(10);
+  if (evt->get_trigger(SQEvent::MATRIX1)) h1_trig->Fill( 1);
+  if (evt->get_trigger(SQEvent::MATRIX2)) h1_trig->Fill( 2);
+  if (evt->get_trigger(SQEvent::MATRIX3)) h1_trig->Fill( 3);
+  if (evt->get_trigger(SQEvent::MATRIX4)) h1_trig->Fill( 4);
+  if (evt->get_trigger(SQEvent::MATRIX5)) h1_trig->Fill( 5);
+  if (evt->get_trigger(SQEvent::NIM1   )) h1_trig->Fill( 6);
+  if (evt->get_trigger(SQEvent::NIM2   )) h1_trig->Fill( 7);
+  if (evt->get_trigger(SQEvent::NIM3   )) h1_trig->Fill( 8);
+  if (evt->get_trigger(SQEvent::NIM4   )) h1_trig->Fill( 9);
+  if (evt->get_trigger(SQEvent::NIM5   )) h1_trig->Fill(10);
 
   h1_cnt->SetBinContent( 1, run->get_n_spill        ());
   h1_cnt->SetBinContent( 2, run->get_n_evt_all      ());
@@ -123,28 +135,19 @@ int OnlMonMainDaq::ProcessEventOnlMon(PHCompositeNode* topNode)
   h1_cnt->SetBinContent(14, run->get_n_v1495_d2ad   ());
   h1_cnt->SetBinContent(15, run->get_n_v1495_d3ad   ());
 
-  h1_n_taiwan->Fill(event->get_n_board_taiwan());
+  h1_n_taiwan->Fill(hevt->get_n_board_taiwan());
 
-  int dq = event->get_data_quality();
+  int dq = evt->get_data_quality();
   if (dq == 0) h1_evt_qual->Fill(0);
   for (int bit = 0; bit < 32; bit++) {
     if ((dq >> bit) & 0x1) h1_evt_qual->Fill(bit + 1);
   }
 
-  int v1495 = event->get_flag_v1495();
+  int v1495 = hevt->get_flag_v1495();
   if (v1495 == 0) h1_flag_v1495->Fill(0);
   for (int bit = 0; bit < 4; bit++) {
     if ((v1495 >> bit) & 0x1) h1_flag_v1495->Fill(bit + 1);
   }
-
-  int nbin_sp = h1_nevt_sp->GetNbinsX();
-  int sp_id = event->get_spill_id();
-  if (m_spill_id_1st == 0) {
-    h1_nevt_sp->SetBinContent(        0,     1); // UF bin to count N of histograms merged.
-    h1_nevt_sp->SetBinContent(nbin_sp+1, sp_id); // OF bin to record the 1st spill ID.
-    m_spill_id_1st = sp_id;
-  }
-  h1_nevt_sp->Fill(sp_id - m_spill_id_1st);
 
   const int N_PL = nChamberPlanes + nHodoPlanes + nPropPlanes + nDarkPhotonPlanes;
   int nhit_pl[N_PL+1]; // 0 = total, 1...N_PL = each plane
@@ -155,6 +158,33 @@ int OnlMonMainDaq::ProcessEventOnlMon(PHCompositeNode* topNode)
   }
   for (int i_pl = 1; i_pl <= N_PL; i_pl++) h2_nhit_pl->Fill(nhit_pl[i_pl], i_pl);
   h2_nhit_pl->Fill(nhit_pl[0], N_PL + 1);
+
+  int nbin_sp = h1_nevt_sp->GetNbinsX();
+  int sp_id = evt->get_spill_id();
+  if (m_spill_id_1st == 0) {
+    h1_nevt_sp->SetBinContent(        0,     1); // UF bin to count N of histograms merged.
+    h1_nevt_sp->SetBinContent(nbin_sp+1, sp_id); // OF bin to record the 1st spill ID.
+    m_spill_id_1st = sp_id;
+  }
+  int bin_sp = sp_id - m_spill_id_1st + 1;
+  if (1 <= bin_sp && bin_sp <= nbin_sp) { // Not underflow nor overflow
+    h1_nevt_sp->AddBinContent(bin_sp);
+    
+    static int sp_id_pre = 0;
+    static TTimeStamp ts_begin(0, 0); // Begin time per spill
+    if (sp_id_pre != sp_id) { // Once at the 1st event per spill
+      SQHardSpill* hard_sp = (SQHardSpill*)map_hs->get(sp_id);
+      if (hard_sp) {
+        double tb = hard_sp->get_timestamp_deco_begin().AsDouble();
+        double te = hard_sp->get_timestamp_deco_end  ().AsDouble();
+        h1_time_deco->SetBinContent(bin_sp, te - tb);
+      }
+      ts_begin.Set();
+      sp_id_pre = sp_id;
+    }
+    TTimeStamp ts_now;
+    h1_time_ana->SetBinContent(bin_sp, ts_now.AsDouble() - ts_begin.AsDouble());
+  }
 
   return Fun4AllReturnCodes::EVENT_OK;
 }
@@ -171,50 +201,60 @@ int OnlMonMainDaq::FindAllMonHist()
   h1_evt_qual   = FindMonHist("h1_evt_qual");
   h1_flag_v1495 = FindMonHist("h1_flag_v1495");
   h1_cnt        = FindMonHist("h1_cnt");
-  h1_nevt_sp    = FindMonHist("h1_nevt_sp");
   h2_nhit_pl    = (TH2*)FindMonHist("h2_nhit_pl");
-  return (h1_trig && h1_evt_qual && h1_flag_v1495 && h1_cnt && h2_nhit_pl  ?  0  :  1);
+  h1_nevt_sp    = FindMonHist("h1_nevt_sp");
+  h1_time_deco  = FindMonHist("h1_time_deco");
+  h1_time_ana   = FindMonHist("h1_time_ana");
+  return (h1_trig && h1_evt_qual && h1_flag_v1495 && h1_cnt && h2_nhit_pl && h1_nevt_sp && h1_time_deco && h1_time_ana  ?  0  :  1);
 }
 
 int OnlMonMainDaq::DrawMonitor()
 {
   OnlMonParam param(this);
-  int n_ttdc = param.GetIntParam("N_TAIWAN_TDC");
+  int    n_ttdc         = param.GetIntParam   ("N_TAIWAN_TDC");
+  int    nhit_pl_warn   = param.GetIntParam   ("N_HIT_PL_WARN");
+  int    nhit_pl_err    = param.GetIntParam   ("N_HIT_PL_ERROR");
+  int    nevt_sp_warn   = param.GetIntParam   ("N_EVT_SP_WARN");
+  int    nevt_sp_err    = param.GetIntParam   ("N_EVT_SP_ERROR");
+  double time_deco_warn = param.GetDoubleParam("TIME_DECO_WARN");
+  double time_deco_err  = param.GetDoubleParam("TIME_DECO_ERROR");
+  double time_ana_warn  = param.GetDoubleParam("TIME_ANA_WARN");
+  double time_ana_err   = param.GetDoubleParam("TIME_ANA_ERROR");
 
   UtilHist::AutoSetRange(h1_n_taiwan);
 
-  OnlMonCanvas* can0 = GetCanvas(0);
+  OnlMonCanvas* can0 = GetCanvas(0); // ========== Canvas #0 ==========
   can0->SetStatus(OnlMonCanvas::OK);
 
   TPad* pad0 = can0->GetMainPad();
   pad0->Divide(1, 3);
 
   pad0->cd(1);
-  TPad* pad01 = new TPad("pad01", "", 0.0, 0.0, 0.6, 1.0);
-  TPad* pad02 = new TPad("pad02", "", 0.6, 0.0, 1.0, 1.0);
-  pad01->Draw();
-  pad02->Draw();
+  TPad* pad011 = new TPad("pad011", "", 0.0, 0.0, 0.6, 1.0);
+  TPad* pad012 = new TPad("pad012", "", 0.6, 0.0, 1.0, 1.0);
+  pad011->Draw();
+  pad012->Draw();
 
-  pad01->cd();
-  pad01->SetGrid();
+  pad011->cd();
+  pad011->SetGrid();
   h1_trig->Draw();
 
-  pad02->cd();
-  pad02->SetGrid();
+  pad012->cd();
+  pad012->SetGrid();
   h1_flag_v1495->Draw();
 
   pad0->cd(2);
-  TPad* pad21 = new TPad("pad21", "", 0.0, 0.0, 0.7, 1.0);
-  TPad* pad22 = new TPad("pad22", "", 0.7, 0.0, 1.0, 1.0);
-  pad21->Draw();
-  pad22->Draw();
+  TPad* pad021 = new TPad("pad021", "", 0.0, 0.0, 0.7, 1.0);
+  TPad* pad022 = new TPad("pad022", "", 0.7, 0.0, 1.0, 1.0);
+  pad021->Draw();
+  pad022->Draw();
 
-  pad21->cd();
-  pad21->SetGrid();
+  pad021->cd();
+  pad021->SetGrid();
   h1_evt_qual->Draw();
 
-  pad22->cd();
-  pad22->SetGrid();
+  pad022->cd();
+  pad022->SetGrid();
   h1_n_taiwan->Draw();
   double n_ttdc_mean = h1_n_taiwan->GetMean();
   if (fabs(n_ttdc_mean - n_ttdc) > 0.1) {
@@ -292,37 +332,13 @@ int OnlMonMainDaq::DrawMonitor()
     can0->AddMessage("Errors in >1% of v1495 events.");
   }
 
-  OnlMonCanvas* can1 = GetCanvas(1);
+  OnlMonCanvas* can1 = GetCanvas(1); // ========== Canvas #1 ==========
   can1->SetStatus(OnlMonCanvas::OK);
   TPad* pad1 = can1->GetMainPad();
-  TPad* pad11 = new TPad("pad11", "", 0.0, 0.8, 1.0, 1.0);
-  TPad* pad12 = new TPad("pad12", "", 0.0, 0.0, 1.0, 0.8);
-  pad11->Draw();
-  pad12->Draw();
-
-  pad11->cd();
-  pad11->SetMargin(0.07, 0.01, 0.20, 0.01); // (l, r, b, t)
-  pad11->SetGrid();
-  pad11->SetLogy();
-
-  int nbin_sp = h1_nevt_sp->GetNbinsX();
-  unsigned int sp_id0 = (unsigned int)(h1_nevt_sp->GetBinContent(nbin_sp + 1) / h1_nevt_sp->GetBinContent(0));
-  oss.str("");
-  oss << "Spill ID #minus_{} " << sp_id0;
-  h1_nevt_sp->GetXaxis()->SetTitle(oss.str().c_str());
-  UtilHist::AutoSetRange(h1_nevt_sp, 0, 0);
-  h1_nevt_sp->GetXaxis()->SetLabelSize(0.10); // default = 0.04
-  h1_nevt_sp->GetXaxis()->SetTitleSize(0.10); // default = 0.04
-  h1_nevt_sp->GetYaxis()->SetLabelSize(0.10); // default = 0.04
-  h1_nevt_sp->GetYaxis()->SetTitleSize(0.10); // default = 0.04
-  h1_nevt_sp->GetYaxis()->SetTitleOffset(0.35); // default = 1.0
-  h1_nevt_sp->Draw();
-
-  pad12->cd();
-  pad12->SetMargin(0.10, 0.10, 0.08, 0.01); // (l, r, b, t)
-  pad12->SetGrid();
-  pad12->SetLogx();
-  pad12->SetLogz();
+  pad1->SetMargin(0.10, 0.10, 0.08, 0.01); // (l, r, b, t)
+  pad1->SetGrid();
+  pad1->SetLogx();
+  pad1->SetLogz();
 
   const int N_PL = nChamberPlanes + nHodoPlanes + nPropPlanes + nDarkPhotonPlanes;
   int nbin_nhit = h2_nhit_pl->GetNbinsX();
@@ -338,7 +354,114 @@ int OnlMonMainDaq::DrawMonitor()
   h2_nhit_pl->GetYaxis()->SetTitleSize(0.03); // default = 0.04
   h2_nhit_pl->GetZaxis()->SetLabelSize(0.03); // default = 0.04
   h2_nhit_pl->GetXaxis()->SetTitleOffset(1.1); // default = 1.0
+  h2_nhit_pl->GetZaxis()->SetLabelOffset(0); // default = 0.005
   h2_nhit_pl->Draw("colz");
 
+  h2_nhit_pl->GetYaxis()->SetRange(N_PL+1, N_PL+1);
+  double nhit_pl = h2_nhit_pl->GetMean();
+  h2_nhit_pl->GetYaxis()->SetRange(); // Reset
+  if (nhit_pl > nhit_pl_err) {
+    can1->SetWorseStatus(OnlMonCanvas::ERROR);
+    can1->AddMessage(TString::Format("N of all-plane hits = %.1f > %d.", nhit_pl, nhit_pl_err).Data());
+  } else if (nhit_pl > nhit_pl_warn) {
+    can1->SetWorseStatus(OnlMonCanvas::WARN);
+    can1->AddMessage(TString::Format("N of all-plane hits = %.1f > %d.", nhit_pl, nhit_pl_warn).Data());
+  }
+  
+  OnlMonCanvas* can2 = GetCanvas(2); // ========== Canvas #2 ==========
+  can2->SetStatus(OnlMonCanvas::OK);
+  TPad* pad2 = can2->GetMainPad();
+  pad2->Divide(1, 3);
+
+  TVirtualPad* pad21 = pad2->cd(1);
+  pad21->SetMargin(0.08, 0.01, 0.15, 0.01); // (l, r, b, t)
+  pad21->SetGrid();
+  pad21->SetLogy();
+
+  int nbin_sp = h1_nevt_sp->GetNbinsX();
+  unsigned int sp_id0 = (unsigned int)(h1_nevt_sp->GetBinContent(nbin_sp + 1) / h1_nevt_sp->GetBinContent(0));
+  oss.str("");
+  oss << "Spill ID #minus_{} " << sp_id0;
+  string title_sp_id = oss.str();
+
+  h1_nevt_sp->GetXaxis()->SetTitle(title_sp_id.c_str());
+  UtilHist::AutoSetRange(h1_nevt_sp, 0, 0);
+  h1_nevt_sp->GetXaxis()->SetLabelSize(0.08); // default = 0.04
+  h1_nevt_sp->GetXaxis()->SetTitleSize(0.08); // default = 0.04
+  h1_nevt_sp->GetYaxis()->SetLabelSize(0.08); // default = 0.04
+  h1_nevt_sp->GetYaxis()->SetTitleSize(0.08); // default = 0.04
+  h1_nevt_sp->GetYaxis()->SetTitleOffset(0.53); // default = 1.0
+  h1_nevt_sp->Draw();
+
+  double nevt_sp = EvalAverageOfFilledBins(h1_nevt_sp);
+  if (nevt_sp > nevt_sp_err) {
+    can2->SetWorseStatus(OnlMonCanvas::ERROR);
+    can2->AddMessage(TString::Format("N of events/spill = %.1f > %d.", nevt_sp, nevt_sp_err).Data());
+  } else if (nevt_sp > nevt_sp_warn) {
+    can2->SetWorseStatus(OnlMonCanvas::WARN);
+    can2->AddMessage(TString::Format("N of events/spill = %.1f > %d.", nevt_sp, nevt_sp_warn).Data());
+  }
+
+  TVirtualPad* pad22 = pad2->cd(2);
+  pad22->SetMargin(0.08, 0.01, 0.15, 0.01); // (l, r, b, t)
+  pad22->SetGrid();
+  pad22->SetLogy();
+
+  h1_time_deco->GetXaxis()->SetTitle(title_sp_id.c_str());
+  UtilHist::AutoSetRange(h1_time_deco, 0, 0);
+  h1_time_deco->GetXaxis()->SetLabelSize(0.08); // default = 0.04
+  h1_time_deco->GetXaxis()->SetTitleSize(0.08); // default = 0.04
+  h1_time_deco->GetYaxis()->SetLabelSize(0.08); // default = 0.04
+  h1_time_deco->GetYaxis()->SetTitleSize(0.08); // default = 0.04
+  h1_time_deco->GetYaxis()->SetTitleOffset(0.53); // default = 1.0
+  h1_time_deco->SetMarkerStyle(21);
+  h1_time_deco->Draw("P");
+
+  double time_deco = EvalAverageOfFilledBins(h1_time_deco);
+  if (time_deco > time_deco_err) {
+    can2->SetWorseStatus(OnlMonCanvas::ERROR);
+    can2->AddMessage(TString::Format("Decoding time = %.1f > %.1f.", time_deco, time_deco_err).Data());
+  } else if (time_deco > time_deco_warn) {
+    can2->SetWorseStatus(OnlMonCanvas::WARN);
+    can2->AddMessage(TString::Format("Decoding time = %.1f > %.1f.", time_deco, time_deco_warn).Data());
+  }
+
+  TVirtualPad* pad23 = pad2->cd(3);
+  pad23->SetMargin(0.08, 0.01, 0.15, 0.01); // (l, r, b, t)
+  pad23->SetGrid();
+  pad23->SetLogy();
+
+  h1_time_ana->GetXaxis()->SetTitle(title_sp_id.c_str());
+  UtilHist::AutoSetRange(h1_time_ana, 0, 0);
+  h1_time_ana->GetXaxis()->SetLabelSize(0.08); // default = 0.04
+  h1_time_ana->GetXaxis()->SetTitleSize(0.08); // default = 0.04
+  h1_time_ana->GetYaxis()->SetLabelSize(0.08); // default = 0.04
+  h1_time_ana->GetYaxis()->SetTitleSize(0.08); // default = 0.04
+  h1_time_ana->GetYaxis()->SetTitleOffset(0.53); // default = 1.0
+  h1_time_ana->SetMarkerStyle(21);
+  h1_time_ana->Draw("P");
+
+  double time_ana = EvalAverageOfFilledBins(h1_time_ana);
+  if (time_ana > time_ana_err) {
+    can2->SetWorseStatus(OnlMonCanvas::ERROR);
+    can2->AddMessage(TString::Format("Analysis time = %.1f > %.1f.", time_ana, time_ana_err).Data());
+  } else if (time_ana > time_ana_warn) {
+    can2->SetWorseStatus(OnlMonCanvas::WARN);
+    can2->AddMessage(TString::Format("Analysis time = %.1f > %.1f.", time_ana, time_ana_warn).Data());
+  }
+
   return 0;
+}
+
+double OnlMonMainDaq::EvalAverageOfFilledBins(TH1* h1) const
+{
+  double cont = 0;
+  int    num  = 0;
+  for (int ii = 1; ii <= h1->GetNbinsX(); ii++) {
+    double c = h1->GetBinContent(ii);
+    if (c == 0) continue;
+    cont += c;
+    num++;
+  }
+  return num > 0 ? cont/num : 0;
 }

--- a/online/onlmonserver/OnlMonMainDaq.cc
+++ b/online/onlmonserver/OnlMonMainDaq.cc
@@ -2,24 +2,28 @@
 #include <sstream>
 #include <iomanip>
 #include <TH1D.h>
+#include <TH2D.h>
 #include <TCanvas.h>
 #include <TPaveText.h>
 #include <interface_main/SQRun.h>
 #include <interface_main/SQEvent.h>
+#include <interface_main/SQHitVector.h>
 #include <fun4all/Fun4AllReturnCodes.h>
 #include <phool/PHNodeIterator.h>
 #include <phool/PHIODataNode.h>
 #include <phool/getClass.h>
+#include <geom_svc/GeomSvc.h>
 #include <UtilAna/UtilHist.h>
 #include "OnlMonParam.h"
 #include "OnlMonMainDaq.h"
 using namespace std;
 
 OnlMonMainDaq::OnlMonMainDaq()
+  : m_spill_id_1st(0)
 {
   Name("OnlMonMainDaq");
   Title("Main DAQ");
-  NumCanvases(1);
+  NumCanvases(2);
 }
 
 int OnlMonMainDaq::InitOnlMon(PHCompositeNode* topNode)
@@ -30,11 +34,6 @@ int OnlMonMainDaq::InitOnlMon(PHCompositeNode* topNode)
 int OnlMonMainDaq::InitRunOnlMon(PHCompositeNode* topNode)
 {
   h1_trig = new TH1D("h1_trig", "Trigger Status;Trigger;N of events", 10, 0.5, 10.5);
-  h1_n_taiwan = new TH1D("h1_n_taiwan", "Taiwan TDC Status;N of boards/event;N of events", 200, -0.5, 199.5);
-  h1_evt_qual = new TH1D("h1_evt_qual", "Event Status;Event-quality bit;N of events", 33, -0.5, 32.5);
-  h1_flag_v1495 = new TH1D("h1_flag_v1495", "V1495 Status;v1495 status bit; N of v1495 events", 5, -0.5, 4.5);
-  h1_cnt = new TH1D("h1_cnt", ";Type;Count", 15, 0.5, 15.5);
-
   h1_trig->GetXaxis()->SetBinLabel( 1, "FPGA1");
   h1_trig->GetXaxis()->SetBinLabel( 2, "FPGA2");
   h1_trig->GetXaxis()->SetBinLabel( 3, "FPGA3");
@@ -46,6 +45,9 @@ int OnlMonMainDaq::InitRunOnlMon(PHCompositeNode* topNode)
   h1_trig->GetXaxis()->SetBinLabel( 9, "NIM4");
   h1_trig->GetXaxis()->SetBinLabel(10, "NIM5");
 
+  h1_n_taiwan = new TH1D("h1_n_taiwan", "Taiwan TDC Status;N of boards/event;N of events", 200, -0.5, 199.5);
+
+  h1_evt_qual = new TH1D("h1_evt_qual", "Event Status;Event-quality bit;N of events", 33, -0.5, 32.5);
   ostringstream oss;
   h1_evt_qual->GetXaxis()->SetBinLabel(1, "OK");
   for (int ii = 1; ii <= 32; ii++) {
@@ -53,26 +55,46 @@ int OnlMonMainDaq::InitRunOnlMon(PHCompositeNode* topNode)
     h1_evt_qual->GetXaxis()->SetBinLabel(ii+1, oss.str().c_str());
   }
 
+  h1_flag_v1495 = new TH1D("h1_flag_v1495", "V1495 Status;v1495 status bit; N of v1495 events", 5, -0.5, 4.5);
   h1_flag_v1495->GetXaxis()->SetBinLabel(1, "OK");
   h1_flag_v1495->GetXaxis()->SetBinLabel(2, "d1ad");
   h1_flag_v1495->GetXaxis()->SetBinLabel(3, "d2ad");
   h1_flag_v1495->GetXaxis()->SetBinLabel(4, "d3ad");
   h1_flag_v1495->GetXaxis()->SetBinLabel(5, "Other");
 
+  h1_cnt = new TH1D("h1_cnt", ";Type;Count", 15, 0.5, 15.5);
+
+  h1_nevt_sp = new TH1D("h1_nevt_sp", ";Spill ID;N of events/spill", 1000, -0.5, 999.5);
+
+  const int NHIT_NUM = 41;
+  const int N_PL = nChamberPlanes + nHodoPlanes + nPropPlanes + nDarkPhotonPlanes;
+  double nhit_bin[NHIT_NUM+1];
+  for (int ib = 0; ib <= NHIT_NUM; ib++) nhit_bin[ib] = pow(10, 0.1 * (ib - 1));
+  h2_nhit_pl = new TH2D("h2_nhit_pl", ";N of hits/event;", NHIT_NUM, nhit_bin, N_PL+1, 0.5, N_PL+1.5);
+  for (int i_pl = 1; i_pl <= N_PL; i_pl++) {
+    ostringstream oss;
+    oss << GeomSvc::instance()->getDetectorName(i_pl) << ":" << setfill('0') << setw(2) << i_pl;
+    h2_nhit_pl->GetYaxis()->SetBinLabel(i_pl, oss.str().c_str());
+  }
+  h2_nhit_pl->GetYaxis()->SetBinLabel(N_PL + 1, "Total");
+
   RegisterHist(h1_trig);
   RegisterHist(h1_n_taiwan);
   RegisterHist(h1_evt_qual);
   RegisterHist(h1_flag_v1495);
   RegisterHist(h1_cnt, OnlMonClient::MODE_UPDATE);
+  RegisterHist(h1_nevt_sp);
+  RegisterHist(h2_nhit_pl);
 
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
 int OnlMonMainDaq::ProcessEventOnlMon(PHCompositeNode* topNode)
 {
-  SQRun*   run   = findNode::getClass<SQRun  >(topNode, "SQRun");
-  SQEvent* event = findNode::getClass<SQEvent>(topNode, "SQEvent");
-  if (! run || ! event) return Fun4AllReturnCodes::ABORTEVENT;
+  SQRun*   run    = findNode::getClass<SQRun      >(topNode, "SQRun");
+  SQEvent* event  = findNode::getClass<SQEvent    >(topNode, "SQEvent");
+  SQHitVector* hv = findNode::getClass<SQHitVector>(topNode, "SQHitVector");
+  if (! run || ! event || ! hv) return Fun4AllReturnCodes::ABORTEVENT;
 
   if (event->get_trigger(SQEvent::MATRIX1)) h1_trig->Fill( 1);
   if (event->get_trigger(SQEvent::MATRIX2)) h1_trig->Fill( 2);
@@ -115,6 +137,25 @@ int OnlMonMainDaq::ProcessEventOnlMon(PHCompositeNode* topNode)
     if ((v1495 >> bit) & 0x1) h1_flag_v1495->Fill(bit + 1);
   }
 
+  int nbin_sp = h1_nevt_sp->GetNbinsX();
+  int sp_id = event->get_spill_id();
+  if (m_spill_id_1st == 0) {
+    h1_nevt_sp->SetBinContent(        0,     1); // UF bin to count N of histograms merged.
+    h1_nevt_sp->SetBinContent(nbin_sp+1, sp_id); // OF bin to record the 1st spill ID.
+    m_spill_id_1st = sp_id;
+  }
+  h1_nevt_sp->Fill(sp_id - m_spill_id_1st);
+
+  const int N_PL = nChamberPlanes + nHodoPlanes + nPropPlanes + nDarkPhotonPlanes;
+  int nhit_pl[N_PL+1]; // 0 = total, 1...N_PL = each plane
+  memset(nhit_pl, 0, sizeof(nhit_pl));
+  for (SQHitVector::ConstIter it = hv->begin(); it != hv->end(); it++) {
+    nhit_pl[(*it)->get_detector_id()]++;
+    nhit_pl[0]++;
+  }
+  for (int i_pl = 1; i_pl <= N_PL; i_pl++) h2_nhit_pl->Fill(nhit_pl[i_pl], i_pl);
+  h2_nhit_pl->Fill(nhit_pl[0], N_PL + 1);
+
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
@@ -130,7 +171,9 @@ int OnlMonMainDaq::FindAllMonHist()
   h1_evt_qual   = FindMonHist("h1_evt_qual");
   h1_flag_v1495 = FindMonHist("h1_flag_v1495");
   h1_cnt        = FindMonHist("h1_cnt");
-  return (h1_trig && h1_evt_qual && h1_flag_v1495 && h1_cnt  ?  0  :  1);
+  h1_nevt_sp    = FindMonHist("h1_nevt_sp");
+  h2_nhit_pl    = (TH2*)FindMonHist("h2_nhit_pl");
+  return (h1_trig && h1_evt_qual && h1_flag_v1495 && h1_cnt && h2_nhit_pl  ?  0  :  1);
 }
 
 int OnlMonMainDaq::DrawMonitor()
@@ -140,27 +183,27 @@ int OnlMonMainDaq::DrawMonitor()
 
   UtilHist::AutoSetRange(h1_n_taiwan);
 
-  OnlMonCanvas* can = GetCanvas();
-  can->SetStatus(OnlMonCanvas::OK);
+  OnlMonCanvas* can0 = GetCanvas(0);
+  can0->SetStatus(OnlMonCanvas::OK);
 
-  TPad* pad = can->GetMainPad();
-  pad->Divide(1, 3);
+  TPad* pad0 = can0->GetMainPad();
+  pad0->Divide(1, 3);
 
-  pad->cd(1);
-  TPad* pad11 = new TPad("pad11", "", 0.0, 0.0, 0.6, 1.0);
-  TPad* pad12 = new TPad("pad12", "", 0.6, 0.0, 1.0, 1.0);
-  pad11->Draw();
-  pad12->Draw();
+  pad0->cd(1);
+  TPad* pad01 = new TPad("pad01", "", 0.0, 0.0, 0.6, 1.0);
+  TPad* pad02 = new TPad("pad02", "", 0.6, 0.0, 1.0, 1.0);
+  pad01->Draw();
+  pad02->Draw();
 
-  pad11->cd();
-  pad11->SetGrid();
+  pad01->cd();
+  pad01->SetGrid();
   h1_trig->Draw();
 
-  pad12->cd();
-  pad12->SetGrid();
+  pad02->cd();
+  pad02->SetGrid();
   h1_flag_v1495->Draw();
 
-  pad->cd(2);
+  pad0->cd(2);
   TPad* pad21 = new TPad("pad21", "", 0.0, 0.0, 0.7, 1.0);
   TPad* pad22 = new TPad("pad22", "", 0.7, 0.0, 1.0, 1.0);
   pad21->Draw();
@@ -175,11 +218,11 @@ int OnlMonMainDaq::DrawMonitor()
   h1_n_taiwan->Draw();
   double n_ttdc_mean = h1_n_taiwan->GetMean();
   if (fabs(n_ttdc_mean - n_ttdc) > 0.1) {
-    can->SetWorseStatus(OnlMonCanvas::ERROR);
-    can->AddMessage(TString::Format("N of Taiwan TDCs = %.1f, not %d.", n_ttdc_mean, n_ttdc).Data());
+    can0->SetWorseStatus(OnlMonCanvas::ERROR);
+    can0->AddMessage(TString::Format("N of Taiwan TDCs = %.1f, not %d.", n_ttdc_mean, n_ttdc).Data());
   }
 
-  pad->cd(3);
+  pad0->cd(3);
   TPaveText* pate = new TPaveText(.02, .02, .98, .98);
   ostringstream oss;
   oss << "N of spill-counter events = " << h1_cnt->GetBinContent(1);
@@ -200,11 +243,11 @@ int OnlMonMainDaq::DrawMonitor()
   oss << "N of Coda flush events = " << n_all << " (all), " << n_bad << " (bad)";
   pate->AddText(oss.str().c_str());
   if (n_bad / n_all > 0.05) {
-    can->SetWorseStatus(OnlMonCanvas::ERROR);
-    can->AddMessage("Errors in >5% of Coda flush events.");
+    can0->SetWorseStatus(OnlMonCanvas::ERROR);
+    can0->AddMessage("Errors in >5% of Coda flush events.");
   } else if (n_bad / n_all > 0.01) {
-    can->SetWorseStatus(OnlMonCanvas::WARN);
-    can->AddMessage("Errors in >1% of Coda flush events.");
+    can0->SetWorseStatus(OnlMonCanvas::WARN);
+    can0->AddMessage("Errors in >1% of Coda flush events.");
   }
 
   n_all = h1_cnt->GetBinContent(8);
@@ -213,11 +256,11 @@ int OnlMonMainDaq::DrawMonitor()
   oss << "N of Taiwan TDC hits = " << n_all << " (all), " << n_bad << " (bad)";
   pate->AddText(oss.str().c_str());
   if (n_bad / n_all > 0.05) {
-    can->SetWorseStatus(OnlMonCanvas::ERROR);
-    can->AddMessage("Errors in >5% of Taiwan TDC hits.");
+    can0->SetWorseStatus(OnlMonCanvas::ERROR);
+    can0->AddMessage("Errors in >5% of Taiwan TDC hits.");
   } else if (n_bad / n_all > 0.01) {
-    can->SetWorseStatus(OnlMonCanvas::WARN);
-    can->AddMessage("Errors in >1% of Taiwan TDC hits.");
+    can0->SetWorseStatus(OnlMonCanvas::WARN);
+    can0->AddMessage("Errors in >1% of Taiwan TDC hits.");
   }
 
   n_all = h1_cnt->GetBinContent(9);
@@ -226,11 +269,11 @@ int OnlMonMainDaq::DrawMonitor()
   oss << "N of v1495 TDC hits = " << n_all << " (all), " << n_bad << " (bad)";
   pate->AddText(oss.str().c_str());
   if (n_bad / n_all > 0.05) {
-    can->SetWorseStatus(OnlMonCanvas::ERROR);
-    can->AddMessage("Errors in >5% of v1495 TDC hits.");
+    can0->SetWorseStatus(OnlMonCanvas::ERROR);
+    can0->AddMessage("Errors in >5% of v1495 TDC hits.");
   } else if (n_bad / n_all > 0.01) {
-    can->SetWorseStatus(OnlMonCanvas::WARN);
-    can->AddMessage("Errors in >1% of v1495 TDC hits.");
+    can0->SetWorseStatus(OnlMonCanvas::WARN);
+    can0->AddMessage("Errors in >1% of v1495 TDC hits.");
   }
 
   n_all         = h1_cnt->GetBinContent(12);
@@ -242,12 +285,60 @@ int OnlMonMainDaq::DrawMonitor()
   pate->AddText(oss.str().c_str());
   pate->Draw();
   if ((n_d1ad + n_d2ad + n_d3ad) / n_all > 0.05) {
-    can->SetWorseStatus(OnlMonCanvas::ERROR);
-    can->AddMessage("Errors in >5% of v1495 events.");
+    can0->SetWorseStatus(OnlMonCanvas::ERROR);
+    can0->AddMessage("Errors in >5% of v1495 events.");
   } else if ((n_d1ad + n_d2ad + n_d3ad) / n_all > 0.01) {
-    can->SetWorseStatus(OnlMonCanvas::WARN);
-    can->AddMessage("Errors in >1% of v1495 events.");
+    can0->SetWorseStatus(OnlMonCanvas::WARN);
+    can0->AddMessage("Errors in >1% of v1495 events.");
   }
+
+  OnlMonCanvas* can1 = GetCanvas(1);
+  can1->SetStatus(OnlMonCanvas::OK);
+  TPad* pad1 = can1->GetMainPad();
+  TPad* pad11 = new TPad("pad11", "", 0.0, 0.8, 1.0, 1.0);
+  TPad* pad12 = new TPad("pad12", "", 0.0, 0.0, 1.0, 0.8);
+  pad11->Draw();
+  pad12->Draw();
+
+  pad11->cd();
+  pad11->SetMargin(0.07, 0.01, 0.20, 0.01); // (l, r, b, t)
+  pad11->SetGrid();
+  pad11->SetLogy();
+
+  int nbin_sp = h1_nevt_sp->GetNbinsX();
+  unsigned int sp_id0 = (unsigned int)(h1_nevt_sp->GetBinContent(nbin_sp + 1) / h1_nevt_sp->GetBinContent(0));
+  oss.str("");
+  oss << "Spill ID #minus_{} " << sp_id0;
+  h1_nevt_sp->GetXaxis()->SetTitle(oss.str().c_str());
+  UtilHist::AutoSetRange(h1_nevt_sp, 0, 0);
+  h1_nevt_sp->GetXaxis()->SetLabelSize(0.10); // default = 0.04
+  h1_nevt_sp->GetXaxis()->SetTitleSize(0.10); // default = 0.04
+  h1_nevt_sp->GetYaxis()->SetLabelSize(0.10); // default = 0.04
+  h1_nevt_sp->GetYaxis()->SetTitleSize(0.10); // default = 0.04
+  h1_nevt_sp->GetYaxis()->SetTitleOffset(0.35); // default = 1.0
+  h1_nevt_sp->Draw();
+
+  pad12->cd();
+  pad12->SetMargin(0.10, 0.10, 0.08, 0.01); // (l, r, b, t)
+  pad12->SetGrid();
+  pad12->SetLogx();
+  pad12->SetLogz();
+
+  const int N_PL = nChamberPlanes + nHodoPlanes + nPropPlanes + nDarkPhotonPlanes;
+  int nbin_nhit = h2_nhit_pl->GetNbinsX();
+  for (int i_pl = 1; i_pl <= N_PL + 1; i_pl++) {
+    double n_uf = h2_nhit_pl->GetBinContent(          0, i_pl);
+    double n_of = h2_nhit_pl->GetBinContent(nbin_nhit+1, i_pl);
+    h2_nhit_pl->AddBinContent(h2_nhit_pl->GetBin(        1, i_pl), n_uf);
+    h2_nhit_pl->AddBinContent(h2_nhit_pl->GetBin(nbin_nhit, i_pl), n_of);
+  }
+  h2_nhit_pl->GetXaxis()->SetLabelSize(0.03); // default = 0.04
+  h2_nhit_pl->GetXaxis()->SetTitleSize(0.03); // default = 0.04
+  h2_nhit_pl->GetYaxis()->SetLabelSize(0.03); // default = 0.04
+  h2_nhit_pl->GetYaxis()->SetTitleSize(0.03); // default = 0.04
+  h2_nhit_pl->GetZaxis()->SetLabelSize(0.03); // default = 0.04
+  h2_nhit_pl->GetXaxis()->SetTitleOffset(1.1); // default = 1.0
+  h2_nhit_pl->Draw("colz");
 
   return 0;
 }

--- a/online/onlmonserver/OnlMonMainDaq.h
+++ b/online/onlmonserver/OnlMonMainDaq.h
@@ -4,11 +4,14 @@
 #include "OnlMonClient.h"
 
 class OnlMonMainDaq: public OnlMonClient {
+  unsigned int m_spill_id_1st;
   TH1* h1_trig;
   TH1* h1_n_taiwan;
   TH1* h1_evt_qual;
   TH1* h1_flag_v1495;
   TH1* h1_cnt;
+  TH1* h1_nevt_sp;
+  TH2* h2_nhit_pl;
 
  public:
   OnlMonMainDaq();

--- a/online/onlmonserver/OnlMonMainDaq.h
+++ b/online/onlmonserver/OnlMonMainDaq.h
@@ -10,8 +10,10 @@ class OnlMonMainDaq: public OnlMonClient {
   TH1* h1_evt_qual;
   TH1* h1_flag_v1495;
   TH1* h1_cnt;
-  TH1* h1_nevt_sp;
   TH2* h2_nhit_pl;
+  TH1* h1_nevt_sp;
+  TH1* h1_time_deco;
+  TH1* h1_time_ana;
 
  public:
   OnlMonMainDaq();
@@ -24,6 +26,9 @@ class OnlMonMainDaq: public OnlMonClient {
   int EndOnlMon(PHCompositeNode *topNode);
   int FindAllMonHist();
   int DrawMonitor();
+
+ protected:
+  double EvalAverageOfFilledBins(TH1* h1) const;
 };
 
 #endif /* _ONL_MON_MAIN_DAQ__H_ */

--- a/online/onlmonserver/OnlMonParam.cc
+++ b/online/onlmonserver/OnlMonParam.cc
@@ -87,7 +87,7 @@ std::string OnlMonParam::FindParamInDir(const std::string par_name)
   delete path;
   dir_name += "/" + m_name;
   int run = m_run_id>0 ? m_run_id : recoConsts::instance()->get_IntFlag("RUNNUMBER");
-  if (m_verb > 0) {
+  if (m_verb > 1) {
     cout << "OnlMonParam: par_name = " << par_name << " run = " << run << ".\n"
          << "  Directory = " << dir_name << endl;
   }
@@ -119,7 +119,7 @@ std::string OnlMonParam::FindParamInDir(const std::string par_name)
 
 bool OnlMonParam::FindParamInFile(const std::string file_name, const int run, const std::string par_name, std::string& par_value)
 {
-  if (m_verb > 0) {
+  if (m_verb > 1) {
     cout << "  File = " << file_name << endl;
   }
   bool do_found = false;
@@ -127,7 +127,7 @@ bool OnlMonParam::FindParamInFile(const std::string file_name, const int run, co
   string line;
   while (getline(ifs, line)) {
     if (line.length() == 0 || line[0] == '#') continue;
-    if (m_verb > 1) {
+    if (m_verb > 2) {
       cout << "    Line = " << line << endl;
     }
     istringstream iss(line);

--- a/online/onlmonserver/OnlMonQie.cc
+++ b/online/onlmonserver/OnlMonQie.cc
@@ -9,6 +9,7 @@
 #include <TLegend.h>
 #include <interface_main/SQRun.h>
 #include <interface_main/SQEvent.h>
+#include <interface_main/SQHardEvent.h>
 #include <fun4all/Fun4AllReturnCodes.h>
 #include <phool/PHNodeIterator.h>
 #include <phool/PHIODataNode.h>
@@ -61,13 +62,14 @@ int OnlMonQie::InitRunOnlMon(PHCompositeNode* topNode)
 
 int OnlMonQie::ProcessEventOnlMon(PHCompositeNode* topNode)
 {
-  SQRun*   run   = findNode::getClass<SQRun  >(topNode, "SQRun");
-  SQEvent* event = findNode::getClass<SQEvent>(topNode, "SQEvent");
-  if (! run || ! event) return Fun4AllReturnCodes::ABORTEVENT;
+  SQRun*        run = findNode::getClass<SQRun      >(topNode, "SQRun");
+  SQEvent*      evt = findNode::getClass<SQEvent    >(topNode, "SQEvent");
+  SQHardEvent* hevt = findNode::getClass<SQHardEvent>(topNode, "SQHardEvent");
+  if (! run || ! evt || ! hevt) return Fun4AllReturnCodes::ABORTEVENT;
 
   h1_evt_status->Fill(ALL);
 
-  int n_brd = event->get_n_board_qie();
+  int n_brd = hevt->get_n_board_qie();
   if (n_brd == 0) {
     h1_evt_status->Fill(NO_DATA);
     return Fun4AllReturnCodes::EVENT_OK;
@@ -76,19 +78,19 @@ int OnlMonQie::ProcessEventOnlMon(PHCompositeNode* topNode)
     return Fun4AllReturnCodes::EVENT_OK;
   }
 
-  //h1_trig_cnt->Fill(event->get_qie_trigger_count());
+  //h1_trig_cnt->Fill(evt->get_qie_trigger_count());
   //for (int ii = 0; ii < N_PRESUM; ii++) {
-  //  h2_presum->Fill(event->get_qie_presum(ii), ii);
+  //  h2_presum->Fill(evt->get_qie_presum(ii), ii);
   //}
-  int turn_id = event->get_qie_turn_id();
-  int   rf_id = event->get_qie_rf_id();
+  int turn_id = evt->get_qie_turn_id();
+  int   rf_id = evt->get_qie_rf_id();
   h2_turn_rf->Fill(turn_id, rf_id);
   if (turn_id <= 0 || rf_id <= 0) h1_evt_status->Fill(TURN_RF_ID_ZERO);
 
   bool found_zero_pm13 = false;
   bool found_zero_pm08 = false;
   for (int ii = -N_RF_INTE/2; ii <= N_RF_INTE/2; ii++) {
-    int inte = event->get_qie_rf_intensity(ii);
+    int inte = evt->get_qie_rf_intensity(ii);
     h2_inte_rf->Fill(inte, ii);
     if (inte == 0) {
       if (abs(ii) <= 13) found_zero_pm13 = true;


### PR DESCRIPTION
This update is mainly to add new variables and canvases to OnlMonMainDaq.  Attached are the new two canvases that show
 * The plane occupancy (i.e. N of hits/plane/event) and
 * The number of events, a decoding time and an analysis time per spill.
![OnlMonMainDaq_can1](https://user-images.githubusercontent.com/41366345/157523116-eb3df4af-11ec-44b7-8fd2-e960ea349d2c.png)
![OnlMonMainDaq_can2](https://user-images.githubusercontent.com/41366345/157523130-d2106a11-a505-4f4c-a29e-346591331eac.png)
They should be useful in the DAQ stress test on Friday.  Moreover the attached images (which were made with run 3700) already show a interesting (strange) behavior around the 700th spill.  We should investigate this later.

The decoding time shown here includes the waiting time for new words in Coda file, which is actually dominant.  The real decoding time is <0.1 sec/spill, as seen in several spills.  The analysis time is defined as the time when the last event is processed by "process_event()" minus the time when the first event is processed.

To record these decoding and analysis times, I created two types of the DST data nodes; `SQHardSpill` and `SQHardEvent`.  They should contain hardware-related variables.  I moved several variables (such as Coda event ID, VME time, N of TDCs) from `SQEvent' to `SQHardEvent`.  In offline production, `SQHard*` need not be written out.

I have confirmed that the updated code can be built fine.  It is being used in the online decoding.


