### PR TITLE
Modified version of kTracker for local-tracklet reconstruction

### DIFF
--- a/online/decoder_maindaq/Fun4AllEVIOInputManager.cc
+++ b/online/decoder_maindaq/Fun4AllEVIOInputManager.cc
@@ -287,6 +287,7 @@ int Fun4AllEVIOInputManager::run(const int nevents)
 
   run_header->set_run_id         (rd->run_id);
   run_header->set_unix_time_begin(rd->utime_b);
+  run_header->set_unix_time_end  (rd->utime_e);
   for (int ii = 0; ii < 5; ii++) {
     run_header->set_fpga_enabled (ii, rd->fpga_enabled [ii]);
     run_header->set_fpga_prescale(ii, rd->fpga_prescale[ii]);

--- a/packages/calibrator/CalibDriftDist.cc
+++ b/packages/calibrator/CalibDriftDist.cc
@@ -19,6 +19,11 @@ CalibDriftDist::CalibDriftDist(const std::string& name)
   , m_fn_xt("")
   , m_vec_hit(0)
   , m_cal_xt (0)
+  , m_reso_d0 (0)
+  , m_reso_d1 (0)
+  , m_reso_d2 (0)
+  , m_reso_d3p(0)
+  , m_reso_d3m(0)
 {
   ;
 }
@@ -64,6 +69,25 @@ int CalibDriftDist::InitRun(PHCompositeNode* topNode)
     cout << Name() << ": " << m_cal_xt->GetParamID() << " = " << m_cal_xt->GetMapID() << "\n";
   }
 
+  if (m_reso_d0 > 0) {
+    if (Verbosity() > 0) cout << "CalibDriftDist: Set the plane resolution.\n";
+    GeomSvc* geom = GeomSvc::instance();
+    for (int ii = 1; ii <= nChamberPlanes; ii++) {
+      Plane* plane = geom->getPlanePtr(ii);
+      string name = plane->detectorName;
+      double reso = -1;
+      if      (name.substr(0, 2) == "D0" ) reso = m_reso_d0;
+      else if (name.substr(0, 2) == "D1" ) reso = m_reso_d1;
+      else if (name.substr(0, 2) == "D2" ) reso = m_reso_d2;
+      else if (name.substr(0, 3) == "D3p") reso = m_reso_d3p;
+      else if (name.substr(0, 3) == "D3m") reso = m_reso_d3m;
+      if (reso > 0) {
+        plane->resolution = reso;
+        if (Verbosity() > 0) cout << "  " << setw(2) << ii << ":" << setw(5) << name << " = " << reso << endl;
+      }
+    }
+  }
+
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
@@ -97,6 +121,19 @@ int CalibDriftDist::process_event(PHCompositeNode* topNode)
 int CalibDriftDist::End(PHCompositeNode* topNode)
 {
   return Fun4AllReturnCodes::EVENT_OK;
+}
+
+/**
+ * The resolution values are passed to `GeomSvc` in `InitRun()` later.
+ * They will be used in `Tracklet::calcChisq()` of `FastTracklet.cxx` for example.
+ */
+void CalibDriftDist::SetResolution(const double reso_d0, const double reso_d1, const double reso_d2, const double reso_d3p, const double reso_d3m)
+{
+  m_reso_d0  = reso_d0 ;
+  m_reso_d1  = reso_d1 ;
+  m_reso_d2  = reso_d2 ;
+  m_reso_d3p = reso_d3p;
+  m_reso_d3m = reso_d3m;
 }
 
 void CalibDriftDist::ReadParamFromFile(const char* fn_xt_curve)

--- a/packages/calibrator/CalibDriftDist.h
+++ b/packages/calibrator/CalibDriftDist.h
@@ -15,6 +15,12 @@ class CalibDriftDist: public SubsysReco {
   SQHitVector* m_vec_hit;
   CalibParamXT* m_cal_xt;
 
+  double m_reso_d0;
+  double m_reso_d1;
+  double m_reso_d2;
+  double m_reso_d3p;
+  double m_reso_d3m;
+
  public:
   CalibDriftDist(const std::string &name = "CalibDriftDist");
   virtual ~CalibDriftDist();
@@ -22,6 +28,9 @@ class CalibDriftDist: public SubsysReco {
   int InitRun(PHCompositeNode *topNode);
   int process_event(PHCompositeNode *topNode);
   int End(PHCompositeNode *topNode);
+
+  /// Set the plane resolutions in cm.
+  void SetResolution(const double reso_d0, const double reso_d1, const double reso_d2, const double reso_d3p, const double reso_d3m);
 
   void ReadParamFromFile(const char* fn_xt_curve);
   CalibParamXT* GetParamXT() { return m_cal_xt; }

--- a/packages/geom_svc/GeomSvc.h
+++ b/packages/geom_svc/GeomSvc.h
@@ -197,6 +197,7 @@ public:
 
     const Plane& getPlane(int detectorID) const { return planes[detectorID]; }
     Plane getPlane(int detectorID)              { return planes[detectorID]; }
+    Plane* getPlanePtr(int detectorID)         { return &planes[detectorID]; }
 
     double getPlanePosition(int detectorID)   const { return planes[detectorID].zc; }
     double getPlaneSpacing(int detectorID)    const { return planes[detectorID].spacing; }

--- a/packages/reco/interface/FastTracklet.cxx
+++ b/packages/reco/interface/FastTracklet.cxx
@@ -923,6 +923,9 @@ void Tracklet::addDummyHits()
     sortHits();
 }
 
+/**
+ * The drift distance of a hit is ignored if the drift sign of the hit is not fixed.
+ */
 double Tracklet::calcChisq()
 {
     chisq = 0.;

--- a/packages/reco/ktracker/KalmanFastTracking.cxx
+++ b/packages/reco/ktracker/KalmanFastTracking.cxx
@@ -441,9 +441,9 @@ int KalmanFastTracking::setRawEvent(SRawEvent* event_input)
     rawEvent = event_input;
     if(!acceptEvent(rawEvent)) return TFEXIT_FAIL_MULTIPLICITY;
     hitAll = event_input->getAllHits();
-#ifdef _DEBUG_ON
-    for(std::vector<Hit>::iterator iter = hitAll.begin(); iter != hitAll.end(); ++iter) iter->print();
-#endif
+    if(verbosity >= 3) {
+      for(std::vector<Hit>::iterator iter = hitAll.begin(); iter != hitAll.end(); ++iter) iter->print();
+    }
 
     //Initialize hodo and masking IDs
     for(int i = 0; i < 4; i++)
@@ -480,9 +480,9 @@ int KalmanFastTracking::setRawEvent(SRawEvent* event_input)
         buildPropSegments();
         if(propSegs[0].empty() || propSegs[1].empty())
         {
-#ifdef _DEBUG_ON
+          if(verbosity >= 3) {
             LogInfo("Failed in prop tube segment building: " << propSegs[0].size() << ", " << propSegs[1].size());
-#endif
+          }
             //return TFEXIT_FAIL_ROUGH_MUONID;
         }
     }
@@ -495,9 +495,9 @@ int KalmanFastTracking::setRawEvent(SRawEvent* event_input)
     
     if(outputListIdx > 1 && trackletsInSt[1].empty())
     {
-#ifdef _DEBUG_ON
+      if(verbosity >= 3) {
         LogInfo("Failed in tracklet build at station 2");
-#endif
+      }
         return TFEXIT_FAIL_ST2_TRACKLET;
     }
 
@@ -509,9 +509,9 @@ int KalmanFastTracking::setRawEvent(SRawEvent* event_input)
     
     if(outputListIdx > 2 && trackletsInSt[2].empty())
     {
-#ifdef _DEBUG_ON
+      if(verbosity >= 3) {
         LogInfo("Failed in tracklet build at station 3");
-#endif
+      }
         return TFEXIT_FAIL_ST3_TRACKLET;
     }
 
@@ -524,9 +524,9 @@ int KalmanFastTracking::setRawEvent(SRawEvent* event_input)
 
     if(outputListIdx > 3 && trackletsInSt[3].empty())
     {
-#ifdef _DEBUG_ON
+      if(verbosity >= 3) {
         LogInfo("Failed in connecting station-2 and 3 tracks");
-#endif
+      }
         return TFEXIT_FAIL_BACKPARTIAL;
     }
 
@@ -536,7 +536,7 @@ int KalmanFastTracking::setRawEvent(SRawEvent* event_input)
     _timers["global"]->stop();
     if(verbosity >= 2) LogInfo("NTracklets Global: " << trackletsInSt[4].size());
     
-#ifdef _DEBUG_ON
+    if(verbosity >= 3) {
     for(int i = 0; i < 2; ++i)
     {
         std::cout << "=======================================================================================" << std::endl;
@@ -558,7 +558,7 @@ int KalmanFastTracking::setRawEvent(SRawEvent* event_input)
         }
         std::cout << "=======================================================================================" << std::endl;
     }
-#endif
+    }
 
     if(outputListIdx == 4 && trackletsInSt[4].empty()) return TFEXIT_FAIL_GLOABL;
     if(!enable_KF) return TFEXIT_SUCCESS;
@@ -572,13 +572,13 @@ int KalmanFastTracking::setRawEvent(SRawEvent* event_input)
     }
     _timers["kalman"]->stop();
 
-#ifdef _DEBUG_ON
+    if(verbosity >= 3) {
     LogInfo(stracks.size() << " final tracks:");
     for(std::list<SRecTrack>::iterator strack = stracks.begin(); strack != stracks.end(); ++strack)
     {
         strack->print();
     }
-#endif
+    }
 
     return TFEXIT_SUCCESS;
 }

--- a/packages/reco/ktracker/KalmanFastTracking.cxx
+++ b/packages/reco/ktracker/KalmanFastTracking.cxx
@@ -425,9 +425,9 @@ void KalmanFastTracking::setRawEventDebug(SRawEvent* event_input)
     hitAll = event_input->getAllHits();
 }
 
-int KalmanFastTracking::setRawEvent(SRawEvent* event_input)
+int KalmanFastTracking::setRawEventPrep(SRawEvent* event_input)
 {
-	//reset timer
+    //reset timer
     for(auto iter=_timers.begin(); iter != _timers.end(); ++iter) 
     {
         iter->second->reset();
@@ -486,6 +486,13 @@ int KalmanFastTracking::setRawEvent(SRawEvent* event_input)
             //return TFEXIT_FAIL_ROUGH_MUONID;
         }
     }
+    return 0;
+}
+
+int KalmanFastTracking::setRawEvent(SRawEvent* event_input)
+{
+  int ret = setRawEventPrep(event_input);
+  if (ret != 0) return ret;
 
     //Build tracklets in station 2, 3+, 3-
     _timers["st2"]->restart();

--- a/packages/reco/ktracker/KalmanFastTracking.h
+++ b/packages/reco/ktracker/KalmanFastTracking.h
@@ -212,6 +212,8 @@ protected:
 
     //Timer
     std::map<std::string, PHTimer*> _timers;
+
+    int setRawEventPrep(SRawEvent* event_input);
 };
 
 #endif

--- a/packages/reco/ktracker/KalmanFastTracking.h
+++ b/packages/reco/ktracker/KalmanFastTracking.h
@@ -35,7 +35,7 @@ class KalmanFastTracking
 {
 public:
     explicit KalmanFastTracking(const PHField* field, const TGeoManager *geom, bool flag = true);
-    ~KalmanFastTracking();
+    virtual ~KalmanFastTracking();
 
     //set/get verbosity
     void Verbosity(const int a) {verbosity = a;}
@@ -43,7 +43,7 @@ public:
     void printTimers();
 
     //Set the input event
-    int setRawEvent(SRawEvent* event_input);
+    virtual int setRawEvent(SRawEvent* event_input);
     void setRawEventDebug(SRawEvent* event_input);
 
     //Event quality cut
@@ -51,13 +51,13 @@ public:
 
     ///Tracklet finding stuff
     //Build tracklets in a station
-    void buildTrackletsInStation(int stationID, int listID, double* pos_exp = nullptr, double* window = nullptr);
+    virtual void buildTrackletsInStation(int stationID, int listID, double* pos_exp = nullptr, double* window = nullptr);
 
     //Build back partial tracks using tracklets in station 2 & 3
-    void buildBackPartialTracks();
+    virtual void buildBackPartialTracks();
 
     //Build global tracks by connecting station 23 tracklets and station 1 tracklets
-    void buildGlobalTracks();
+    virtual void buildGlobalTracks();
 
     //Fit tracklets
     int fitTracklet(Tracklet& tracklet);
@@ -106,13 +106,17 @@ public:
     std::list<SRecTrack>& getSRecTracks() { return stracks; }
     std::list<PropSegment>& getPropSegments(int i) { return propSegs[i]; }
 
-    ///Set the index of the final output tracklet list
-    void setOutputListID(unsigned int i) { outputListIdx = i; }
+    ///Set the index of the final output tracklet list.
+    /**
+     * If it is 1, 2, 3 or 4; D2, D3, D2+3 or Global tracklets are outputted (as SRecTrack),
+     * where the track reconstruction is terminated as soon as the requested tracklet type is found empty.
+     */
+    void setOutputListIndex(unsigned int i) { outputListIdx = i; }
 
     ///Tool, a simple-minded chi square fit
     void chi2fit(int n, double x[], double y[], double& a, double& b);
 
-private:
+protected:
     //verbosity following Fun4All convention
     int verbosity;
 

--- a/packages/reco/ktracker/KalmanFastTrackletting.cxx
+++ b/packages/reco/ktracker/KalmanFastTrackletting.cxx
@@ -1,0 +1,223 @@
+#include <iostream>
+#include <phool/PHTimer.h>
+#include <phool/recoConsts.h>
+#include <fun4all/Fun4AllBase.h>
+#include <phfield/PHField.h>
+#include "KalmanFastTrackletting.h"
+using namespace std;
+
+KalmanFastTrackletting::KalmanFastTrackletting(const PHField* field, const TGeoManager* geom, bool flag)
+  : KalmanFastTracking(field, geom, flag)
+{
+  ;
+}
+
+KalmanFastTrackletting::~KalmanFastTrackletting()
+{
+  ;
+}
+
+int KalmanFastTrackletting::setRawEvent(SRawEvent* event_input)
+{
+  //reset timer
+  for(auto iter=_timers.begin(); iter != _timers.end(); ++iter) 
+  {
+    iter->second->reset();
+  }
+
+  //Initialize tracklet lists
+  for(int i = 0; i < 5; i++) trackletsInSt[i].clear();
+  stracks.clear();
+
+  //pre-tracking cuts
+  rawEvent = event_input;
+  if(!acceptEvent(rawEvent)) return TFEXIT_FAIL_MULTIPLICITY;
+  hitAll = event_input->getAllHits();
+  if(verbosity >= 3) {
+    for(std::vector<Hit>::iterator iter = hitAll.begin(); iter != hitAll.end(); ++iter) iter->print();
+  }
+
+  //Initialize hodo and masking IDs
+  for(int i = 0; i < 4; i++)
+  {
+    hitIDs_mask[i].clear();
+    hitIDs_mask[i] = rawEvent->getHitsIndexInDetectors(detectorIDs_maskX[i]);
+  }
+  
+  //Initialize prop. tube IDs
+  for(int i = 0; i < 2; ++i)
+  {
+    for(int j = 0; j < 4; ++j)
+    {
+      hitIDs_muid[i][j].clear();
+      hitIDs_muid[i][j] = rawEvent->getHitsIndexInDetector(detectorIDs_muid[i][j]);
+    }
+    hitIDs_muidHodoAid[i].clear();
+    hitIDs_muidHodoAid[i] = rawEvent->getHitsIndexInDetectors(detectorIDs_muidHodoAid[i]);
+  }
+  
+  buildPropSegments();
+  if(propSegs[0].empty() || propSegs[1].empty())
+  {
+    if(verbosity >= 3) {
+      LogInfo("Failed in prop tube segment building: " << propSegs[0].size() << ", " << propSegs[1].size());
+    }
+    //return TFEXIT_FAIL_ROUGH_MUONID;
+  }
+  
+  //Build tracklets in station 2, 3+, 3-
+  _timers["st2"]->restart();
+  buildTrackletsInStation(3, 1);   //3 for station-2, 1 for list position 1
+  _timers["st2"]->stop();
+  if(verbosity >= 2) LogInfo("NTracklets in St2: " << trackletsInSt[1].size());
+  
+  _timers["st3"]->restart();
+  buildTrackletsInStation(4, 2);   //4 for station-3+
+  buildTrackletsInStation(5, 2);   //5 for station-3-
+  _timers["st3"]->stop();
+  if(verbosity >= 2) LogInfo("NTracklets in St3: " << trackletsInSt[2].size());
+
+  // Build tracklets in station 0
+  // Do this here??
+  
+  //Build back partial tracks in station 2, 3+ and 3-
+  _timers["st23"]->restart();
+  buildBackPartialTracks();
+  _timers["st23"]->stop();
+  if(verbosity >= 2) LogInfo("NTracklets St2+St3: " << trackletsInSt[3].size());
+  
+  if(verbosity >= 3) {
+    for(int i = 0; i <= 4; i++)
+    {
+      std::cout << "=======================================================================================" << std::endl;
+      LogInfo("Tracklets in station: " << i+1 << " is " << trackletsInSt[i].size());
+      for(std::list<Tracklet>::iterator tracklet = trackletsInSt[i].begin(); tracklet != trackletsInSt[i].end(); ++tracklet)
+      {
+        tracklet->print();
+      }
+      std::cout << "=======================================================================================" << std::endl;
+    }
+  }
+  
+  return TFEXIT_SUCCESS;
+}
+
+void KalmanFastTrackletting::buildTrackletsInStation(int stationID, int listID, double* pos_exp, double* window)
+{
+  const double TX_MAX=    1.; /// Define the necessary constants here for now
+  const double TY_MAX=    1.;
+  const double X0_MAX= 1000.;
+  const double Y0_MAX= 1000.;
+
+  //actuall ID of the tracklet lists
+  int sID = stationID - 1;
+
+  //Extract the X, U, V hit pairs
+  std::list<SRawEvent::hit_pair> pairs_X, pairs_U, pairs_V;
+  if(pos_exp == nullptr)
+  {
+    pairs_X = rawEvent->getPartialHitPairsInSuperDetector(superIDs[sID][0]);
+    pairs_U = rawEvent->getPartialHitPairsInSuperDetector(superIDs[sID][1]);
+    pairs_V = rawEvent->getPartialHitPairsInSuperDetector(superIDs[sID][2]);
+  }
+  else
+  {
+    //Note that in pos_exp[], index 0 stands for X, index 1 stands for U, index 2 stands for V
+    pairs_X = rawEvent->getPartialHitPairsInSuperDetector(superIDs[sID][0], pos_exp[0], window[0]);
+    pairs_U = rawEvent->getPartialHitPairsInSuperDetector(superIDs[sID][1], pos_exp[1], window[1]);
+    pairs_V = rawEvent->getPartialHitPairsInSuperDetector(superIDs[sID][2], pos_exp[2], window[2]);
+  }
+  
+  if(pairs_X.empty() || pairs_U.empty() || pairs_V.empty()) return;
+
+  //X-U combination first, then add V pairs
+  for(std::list<SRawEvent::hit_pair>::iterator xiter = pairs_X.begin(); xiter != pairs_X.end(); ++xiter)
+  {
+    //U projections from X plane
+    double x_pos = xiter->second >= 0 ? 0.5*(hitAll[xiter->first].pos + hitAll[xiter->second].pos) : hitAll[xiter->first].pos;
+    double u_min = x_pos*u_costheta[sID] - u_win[sID];
+    double u_max = u_min + 2.*u_win[sID];
+    
+    for(std::list<SRawEvent::hit_pair>::iterator uiter = pairs_U.begin(); uiter != pairs_U.end(); ++uiter)
+    {
+      double u_pos = uiter->second >= 0 ? 0.5*(hitAll[uiter->first].pos + hitAll[uiter->second].pos) : hitAll[uiter->first].pos;
+      if(u_pos < u_min || u_pos > u_max) continue;
+      
+      //V projections from X and U plane
+      double z_x = xiter->second >= 0 ? z_plane_x[sID] : z_plane[hitAll[xiter->first].detectorID];
+      double z_u = uiter->second >= 0 ? z_plane_u[sID] : z_plane[hitAll[uiter->first].detectorID];
+      double z_v = z_plane_v[sID];
+      double v_win1 = spacing_plane[hitAll[uiter->first].detectorID]*2.*u_costheta[sID];
+      double v_win2 = fabs((z_u + z_v - 2.*z_x)*u_costheta[sID]*TX_MAX);
+      double v_win3 = fabs((z_v - z_u)*u_sintheta[sID]*TY_MAX);
+      double v_win = v_win1 + v_win2 + v_win3 + 2.*spacing_plane[hitAll[uiter->first].detectorID];
+      double v_min = 2*x_pos*u_costheta[sID] - u_pos - v_win;
+      double v_max = v_min + 2.*v_win;
+
+      for(std::list<SRawEvent::hit_pair>::iterator viter = pairs_V.begin(); viter != pairs_V.end(); ++viter)
+      {
+        double v_pos = viter->second >= 0 ? 0.5*(hitAll[viter->first].pos + hitAll[viter->second].pos) : hitAll[viter->first].pos;
+        if(v_pos < v_min || v_pos > v_max) continue;
+
+        //Now add the tracklet
+
+        for (int LR_X1 = -1; LR_X1 <= +1; LR_X1 += 2) {
+        for (int LR_X2 = -1; LR_X2 <= +1; LR_X2 += 2) {
+        for (int LR_U1 = -1; LR_U1 <= +1; LR_U1 += 2) {
+        for (int LR_U2 = -1; LR_U2 <= +1; LR_U2 += 2) {
+        for (int LR_V1 = -1; LR_V1 <= +1; LR_V1 += 2) {
+        for (int LR_V2 = -1; LR_V2 <= +1; LR_V2 += 2) {
+          Tracklet tracklet_new;
+          tracklet_new.stationID = stationID;
+        
+          if(xiter->first >= 0) {
+            tracklet_new.hits.push_back(SignedHit(hitAll[xiter->first], LR_X1));
+            tracklet_new.nXHits++;
+          }
+          if(xiter->second >= 0) {
+            tracklet_new.hits.push_back(SignedHit(hitAll[xiter->second], LR_X2));
+            tracklet_new.nXHits++;
+          }
+        
+          if(uiter->first >= 0) {
+            tracklet_new.hits.push_back(SignedHit(hitAll[uiter->first], LR_U1));
+            tracklet_new.nUHits++;
+          }
+          if(uiter->second >= 0) {
+            tracklet_new.hits.push_back(SignedHit(hitAll[uiter->second], LR_U2));
+            tracklet_new.nUHits++;
+          }
+        
+          if(viter->first >= 0) {
+            tracklet_new.hits.push_back(SignedHit(hitAll[viter->first], LR_V1));
+            tracklet_new.nVHits++;
+          }
+          if(viter->second >= 0) {
+            tracklet_new.hits.push_back(SignedHit(hitAll[viter->second], LR_V2));
+            tracklet_new.nVHits++;
+          }
+        
+          tracklet_new.sortHits();
+          if(tracklet_new.isValid() == 0) {
+            fitTracklet(tracklet_new);
+            if(acceptTracklet(tracklet_new)) trackletsInSt[listID].push_back(tracklet_new);
+          }
+        }}}}}}
+      }
+    }
+  }
+  
+  //Reduce the tracklet list and add dummy hits
+  //reduceTrackletList(trackletsInSt[listID]);
+  for(std::list<Tracklet>::iterator iter = trackletsInSt[listID].begin(); iter != trackletsInSt[listID].end(); ++iter)
+  {
+    iter->addDummyHits();
+  }
+  
+  //Only retain the best 200 tracklets if exceeded
+  //if(trackletsInSt[listID].size() > 200)
+  //{
+  //  trackletsInSt[listID].sort();
+  //  trackletsInSt[listID].resize(200);
+  //}
+}

--- a/packages/reco/ktracker/KalmanFastTrackletting.h
+++ b/packages/reco/ktracker/KalmanFastTrackletting.h
@@ -1,0 +1,16 @@
+#ifndef _KALMAN_FAST_TRACKLETTING_H
+#define _KALMAN_FAST_TRACKLETTING_H
+#include "KalmanFastTracking.h"
+
+class KalmanFastTrackletting : public KalmanFastTracking
+{
+public:
+    explicit KalmanFastTrackletting(const PHField* field, const TGeoManager *geom, bool flag = true);
+    virtual ~KalmanFastTrackletting();
+
+    virtual int setRawEvent(SRawEvent* event_input);
+
+    virtual void buildTrackletsInStation(int stationID, int listID, double* pos_exp = nullptr, double* window = nullptr);
+};
+
+#endif // _KALMAN_FAST_TRACKLETTING_H

--- a/packages/reco/ktracker/KalmanFastTrackletting.h
+++ b/packages/reco/ktracker/KalmanFastTrackletting.h
@@ -4,6 +4,11 @@
 
 class KalmanFastTrackletting : public KalmanFastTracking
 {
+  double TX_MAX;
+  double TY_MAX;
+  double X0_MAX;
+  double Y0_MAX;
+
 public:
     explicit KalmanFastTrackletting(const PHField* field, const TGeoManager *geom, bool flag = true);
     virtual ~KalmanFastTrackletting();

--- a/packages/reco/ktracker/SQReco.cxx
+++ b/packages/reco/ktracker/SQReco.cxx
@@ -50,6 +50,7 @@ SQReco::SQReco(const std::string& name):
   SubsysReco(name),
   _input_type(SQReco::E1039),
   _fitter_type(SQReco::KFREF),
+  _output_list_idx(0),
   _enable_eval(false),
   _eval_file_name("eval.root"),
   _eval_tree(nullptr),
@@ -110,10 +111,7 @@ int SQReco::InitRun(PHCompositeNode* topNode)
   ret = InitGeom(topNode);
   if(ret != Fun4AllReturnCodes::EVENT_OK) return ret;
 
-  //Init track finding
-  _fastfinder = new KalmanFastTracking(_phfield, _t_geo_manager, false);
-
-  _fastfinder->Verbosity(Verbosity());
+  InitFastTracking();
 
   if(_evt_reducer_opt == "none")  //Meaning we disable the event reducer
   {
@@ -238,6 +236,16 @@ int SQReco::InitGeom(PHCompositeNode* topNode)
 
   _t_geo_manager = PHGeomUtility::GetTGeoManager(topNode);
   return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int SQReco::InitFastTracking()
+{
+  _fastfinder = new KalmanFastTracking(_phfield, _t_geo_manager, false);
+
+  _fastfinder->Verbosity(Verbosity());
+
+  if (_output_list_idx > 0) _fastfinder->setOutputListIndex(_output_list_idx);
+  return 0;
 }
 
 int SQReco::updateHitInfo(SRawEvent* sraw_event) 

--- a/packages/reco/ktracker/SQReco.cxx
+++ b/packages/reco/ktracker/SQReco.cxx
@@ -248,6 +248,41 @@ int SQReco::InitFastTracking()
   return 0;
 }
 
+void SQReco::ProcessEventPrep()
+{
+  if(is_eval_enabled()) ResetEvalVars();
+  if(is_eval_dst_enabled()) _tracklet_vector->clear();
+
+  if(_input_type == SQReco::E1039) _rawEvent = BuildSRawEvent();
+
+  if(Verbosity() > Fun4AllBase::VERBOSITY_A_LOT) 
+  {
+    LogInfo("SRawEvent before the Reducer");
+    _rawEvent->identify();
+  }
+
+  if(_eventReducer != nullptr) 
+  {
+    _eventReducer->reduceEvent(_rawEvent);
+    if(_input_type == SQReco::E1039) updateHitInfo(_rawEvent);
+  }
+
+  if(Verbosity() > Fun4AllBase::VERBOSITY_A_LOT) 
+  {
+    LogInfo("SRawEvent after the Reducer");
+    _rawEvent->identify();
+  }
+}
+
+void SQReco::ProcessEventFinish()
+{
+  if(_input_type == SQReco::E1039) {
+    delete _rawEvent;
+    _rawEvent = 0;
+  }
+  ++_event;
+}
+
 int SQReco::updateHitInfo(SRawEvent* sraw_event) 
 {
   for(Hit hit : sraw_event->getAllHits()) 
@@ -298,54 +333,7 @@ int SQReco::process_event(PHCompositeNode* topNode)
 {
   LogDebug("Entering SQReco::process_event: " << _event);
 
-  if(is_eval_enabled()) ResetEvalVars();
-  if(is_eval_dst_enabled()) _tracklet_vector->clear();
-
-  if(_input_type == SQReco::E1039)
-  {
-    if(!_event_header) 
-    {
-      if(Verbosity() > 2) LogDebug("!_event_header");
-      //return Fun4AllReturnCodes::ABORTRUN;
-    }
-
-    if(!_spill_map) 
-    {
-      if(Verbosity() > 2) LogDebug("!_spill_map");
-      //return Fun4AllReturnCodes::ABORTRUN;
-    }
-
-    if(!_hit_vector) 
-    {
-      if(Verbosity() > 2) LogDebug("!_hit_vector");
-      return Fun4AllReturnCodes::ABORTEVENT;
-    }
-  }
-
-  std::unique_ptr<SRawEvent> up_raw_event;
-  if(_input_type == SQReco::E1039) 
-  {
-    up_raw_event = std::unique_ptr<SRawEvent>(BuildSRawEvent());
-    _rawEvent = up_raw_event.get();
-  }
-
-  if(Verbosity() > Fun4AllBase::VERBOSITY_A_LOT) 
-  {
-    LogInfo("SRawEvent before the Reducer");
-    _rawEvent->identify();
-  }
-
-  if(_eventReducer != nullptr) 
-  {
-    _eventReducer->reduceEvent(_rawEvent);
-    if(_input_type == SQReco::E1039) updateHitInfo(_rawEvent);
-  }
-
-  if(Verbosity() > Fun4AllBase::VERBOSITY_A_LOT) 
-  {
-    LogInfo("SRawEvent after the Reducer");
-    _rawEvent->identify();
-  }
+  ProcessEventPrep();
 
   int finderstatus = _fastfinder->setRawEvent(_rawEvent);
   if(_legacy_rec_container) 
@@ -411,7 +399,8 @@ int SQReco::process_event(PHCompositeNode* topNode)
   
   if(is_eval_enabled() && nTracklets > 0) _eval_tree->Fill();
 
-  ++_event;
+  ProcessEventFinish();
+
   return Fun4AllReturnCodes::EVENT_OK;
 }
 

--- a/packages/reco/ktracker/SQReco.h
+++ b/packages/reco/ktracker/SQReco.h
@@ -48,10 +48,10 @@ public:
   SQReco(const std::string& name = "SQReco");
   virtual ~SQReco();
 
-  int Init(PHCompositeNode* topNode);
-  int InitRun(PHCompositeNode* topNode);
-  int process_event(PHCompositeNode* topNode);
-  int End(PHCompositeNode* topNode);
+  virtual int Init(PHCompositeNode* topNode);
+  virtual int InitRun(PHCompositeNode* topNode);
+  virtual int process_event(PHCompositeNode* topNode);
+  virtual int End(PHCompositeNode* topNode);
 
   void setInputTy(SQReco::INPUT_TYPE input_ty) { _input_type = input_ty; }
   void setFitterTy(SQReco::FITTER_TYPE fitter_ty) { _fitter_type = fitter_ty; }
@@ -68,6 +68,9 @@ public:
   bool is_KF_enabled() const { return _enable_KF; }
   void set_enable_KF(bool enable) { _enable_KF = enable; }
 
+  /// See `KalmanFastTracking::setOutputListID()`.
+  void set_output_list_index(const int idx) { _output_list_idx = idx; }
+
   bool is_eval_enabled() const { return _enable_eval; }
   void set_enable_eval(bool enable) { _enable_eval = enable; }
   bool is_eval_dst_enabled() const { return _enable_eval_dst; }
@@ -79,12 +82,13 @@ public:
 
   void set_legacy_rec_container(const bool b = true) { _legacy_rec_container = b; } 
 
-private:
+protected:
 
-  int InitField(PHCompositeNode* topNode);
-  int InitGeom(PHCompositeNode* topNode);
-  int MakeNodes(PHCompositeNode* topNode);
-  int GetNodes(PHCompositeNode* topNode);
+  virtual int InitField(PHCompositeNode* topNode);
+  virtual int InitGeom(PHCompositeNode* topNode);
+  virtual int InitFastTracking();
+  virtual int MakeNodes(PHCompositeNode* topNode);
+  virtual int GetNodes(PHCompositeNode* topNode);
 
   int InitEvalTree();
   int ResetEvalVars();
@@ -99,6 +103,8 @@ private:
 
   SQReco::INPUT_TYPE  _input_type;
   SQReco::FITTER_TYPE _fitter_type;
+
+  int _output_list_idx;
 
   bool _enable_eval;
   TString _eval_file_name;

--- a/packages/reco/ktracker/SQReco.h
+++ b/packages/reco/ktracker/SQReco.h
@@ -93,6 +93,8 @@ protected:
   int InitEvalTree();
   int ResetEvalVars();
 
+  void ProcessEventPrep();
+  void ProcessEventFinish();
   SRawEvent* BuildSRawEvent();
   int updateHitInfo(SRawEvent* sraw_event);
 

--- a/packages/reco/ktracker/SQTrackletReco.cxx
+++ b/packages/reco/ktracker/SQTrackletReco.cxx
@@ -1,0 +1,125 @@
+#include <phool/PHNodeIterator.h>
+#include <phool/PHIODataNode.h>
+#include <phool/getClass.h>
+#include <phool/recoConsts.h>
+#include <fun4all/Fun4AllReturnCodes.h>
+#include "KalmanFastTrackletting.h"
+#include "EventReducer.h"
+#include "SQTrackletReco.h"
+
+SQTrackletReco::SQTrackletReco(const std::string& name)
+  : SQReco(name)
+{
+  ;
+}
+
+SQTrackletReco::~SQTrackletReco()
+{
+  ;
+}
+
+int SQTrackletReco::process_event(PHCompositeNode* topNode) 
+{
+  if(is_eval_enabled()) ResetEvalVars();
+  if(is_eval_dst_enabled()) _tracklet_vector->clear();
+
+  if(_input_type == SQReco::E1039)
+  {
+    if(!_hit_vector) 
+    {
+      if(Verbosity() > 2) LogDebug("!_hit_vector");
+      return Fun4AllReturnCodes::ABORTEVENT;
+    }
+  }
+
+  std::unique_ptr<SRawEvent> up_raw_event;
+  if(_input_type == SQReco::E1039) 
+  {
+    up_raw_event = std::unique_ptr<SRawEvent>(BuildSRawEvent());
+    _rawEvent = up_raw_event.get();
+  }
+
+  if(Verbosity() > Fun4AllBase::VERBOSITY_A_LOT) 
+  {
+    LogInfo("SRawEvent before the Reducer");
+    _rawEvent->identify();
+  }
+
+  if(_eventReducer != nullptr) 
+  {
+    _eventReducer->reduceEvent(_rawEvent);
+    if(_input_type == SQReco::E1039) updateHitInfo(_rawEvent);
+  }
+
+  if(Verbosity() > Fun4AllBase::VERBOSITY_A_LOT) 
+  {
+    LogInfo("SRawEvent after the Reducer");
+    _rawEvent->identify();
+  }
+
+  int finderstatus = _fastfinder->setRawEvent(_rawEvent);
+  if(_legacy_rec_container) 
+  {
+    _recEvent->setRawEvent(_rawEvent);
+    _recEvent->setRecStatus(finderstatus);
+  }
+  if(Verbosity() >= Fun4AllBase::VERBOSITY_A_LOT) _fastfinder->printTimers();
+
+  int nTracklets = 0;
+  if(is_eval_enabled() || is_eval_dst_enabled())
+  {
+    for(unsigned int i = 0; i < _eval_listIDs.size(); ++i)
+    {
+      std::list<Tracklet>& eval_tracklets = _fastfinder->getTrackletList(_eval_listIDs[i]);
+      for(auto iter = eval_tracklets.begin(); iter != eval_tracklets.end(); ++iter)
+      {
+        if(is_eval_enabled()) new((*_tracklets)[nTracklets]) Tracklet(*iter);
+        if(is_eval_dst_enabled()) _tracklet_vector->push_back(&(*iter));
+        ++nTracklets;
+      }
+    }
+  }
+  
+  if(is_eval_enabled() && nTracklets > 0) _eval_tree->Fill();
+
+  ++_event;
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+/**
+ * It uses `KalmanFastTrackletting` instead of `KalmanFastTracking`.
+ */
+int SQTrackletReco::InitFastTracking()
+{
+  _fastfinder = new KalmanFastTrackletting(_phfield, _t_geo_manager, false);
+
+  _fastfinder->Verbosity(Verbosity());
+
+  if (_output_list_idx >= 0) _fastfinder->setOutputListIndex(_output_list_idx);
+  return 0;
+}
+
+int SQTrackletReco::MakeNodes(PHCompositeNode* topNode) 
+{
+  PHNodeIterator iter(topNode);
+  PHCompositeNode* eventNode = static_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "DST"));
+  if(!eventNode) 
+  {
+    LogInfo("No DST node, create one");
+    eventNode = new PHCompositeNode("DST");
+    topNode->addNode(eventNode);
+  }
+
+  if(_enable_eval_dst)
+  {
+    _tracklet_vector = findNode::getClass<TrackletVector>(topNode, "TrackletVector"); // Could exist when the tracking is re-done.
+    if(!_tracklet_vector) {
+      _tracklet_vector = new TrackletVector();
+      _tracklet_vector->SplitLevel(99);
+      eventNode->addNode(new PHIODataNode<PHObject>(_tracklet_vector, "TrackletVector", "PHObject"));
+      if(Verbosity() >= Fun4AllBase::VERBOSITY_SOME) LogInfo("DST/TrackletVector Added");
+    }
+  }
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}

--- a/packages/reco/ktracker/SQTrackletReco.h
+++ b/packages/reco/ktracker/SQTrackletReco.h
@@ -5,10 +5,14 @@
 class SQTrackletReco: public SQReco
 {
  public:
+  bool _drop_empty_event;
+
   SQTrackletReco(const std::string& name = "SQTrackletReco");
   virtual ~SQTrackletReco();
 
   virtual int process_event(PHCompositeNode* topNode);
+
+  virtual void drop_empty_event(const bool val) { _drop_empty_event = val; }
 
  private:
   virtual int InitFastTracking();

--- a/packages/reco/ktracker/SQTrackletReco.h
+++ b/packages/reco/ktracker/SQTrackletReco.h
@@ -1,0 +1,18 @@
+#ifndef _SQ_TRACKLET_RECO_H
+#define _SQ_TRACKLET_RECO_H
+#include "SQReco.h"
+
+class SQTrackletReco: public SQReco
+{
+ public:
+  SQTrackletReco(const std::string& name = "SQTrackletReco");
+  virtual ~SQTrackletReco();
+
+  virtual int process_event(PHCompositeNode* topNode);
+
+ private:
+  virtual int InitFastTracking();
+  virtual int MakeNodes(PHCompositeNode* topNode);
+};
+
+#endif // _SQ_TRACKLET_RECO_H

--- a/packages/reco/ktracker/SQTrackletRecoLinkDef.h
+++ b/packages/reco/ktracker/SQTrackletRecoLinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class SQTrackletReco-!;
+
+#endif /* __CINT__ */


### PR DESCRIPTION
This update is to introduce a modified version of kTracker that reconstructs local tracklets using drift distance.  It is helpful in calibrating the X-T curve using cosmic data.  I'd like to first hear your opinions about the concept+method of this update.  If it looks fine, I will straighten up the code and ask you a closer review.

The original tracklet reconstruction (i.e. `KalmanFastTracking::buildTrackletsInStation()`) ignores the drift distance, as the drift sign of hits is not resolved at that stage.  Thus I created new classes; `SQTrackletReco` and `KalmanFastTrackletting`, by inheriting them from `SQReco` and `KalmanFastTracking`.  `KalmanFastTrackletting` takes all combinations of drift signs to reconstruct D3, D2 and D2+D3 tracklets.

`SQReco` and `KalmanFastTracking` were modified slightly so that the new classes can inherit them.  In addition, I replaced `_DEBUG_ON` with `verbosity`, and added a member function `SQReco::set_output_list_index()` (which is actually not helpful for my purpose but many helpful in future).

`GeomSvc` and `CalibDriftDist` were modified so that the plane resolution can be changed together with the X-T curve in `CalibDriftDist`.  I think `GeomSvc::getPlanePtr()` will be useful in getting/setting all plane parameters.

A change in `Fun4AllEVIOInputManager::run()` is just a bug fix.
