### PR TITLE
Status of spill-DST output on DB

### DIFF
--- a/online/decoder_maindaq/Fun4AllSpillDstOutputManager.cc
+++ b/online/decoder_maindaq/Fun4AllSpillDstOutputManager.cc
@@ -1,8 +1,11 @@
 #include <sstream>
 #include <TSystem.h>
+#include <TSQLServer.h>
 #include <interface_main/SQEvent.h>
 #include <phool/getClass.h>
 #include <fun4all/Fun4AllServer.h>
+#include <db_svc/DbSvc.h>
+#include <UtilAna/UtilOnline.h>
 #include "Fun4AllSpillDstOutputManager.h"
 using namespace std;
 
@@ -11,14 +14,19 @@ Fun4AllSpillDstOutputManager::Fun4AllSpillDstOutputManager(const string &dir_bas
   , m_dir_base(dir_base)
   , m_sp_step(10)
   , m_run_id(0)
-  , m_sp_id(0)
+  , m_sp_id_f(0)
+  , m_db(0)
+  , m_name_table("")
 {
   ;
 }
 
 Fun4AllSpillDstOutputManager::~Fun4AllSpillDstOutputManager()
 {
-  ;
+  if (m_db) {
+    if (m_run_id != 0) DstFinished(m_run_id, m_sp_id_f, m_sp_id_f + m_sp_step - 1);
+    delete m_db;
+  }
 }
 
 int Fun4AllSpillDstOutputManager::Write(PHCompositeNode *startNode)
@@ -28,11 +36,11 @@ int Fun4AllSpillDstOutputManager::Write(PHCompositeNode *startNode)
     cout << PHWHERE << "SQEvent not found.  Abort." << endl;
     exit(1);
   }
-  int run_id = evt->get_run_id();
-  int sp_id  = (evt->get_spill_id() / m_sp_step) * m_sp_step;
-  if (m_run_id != run_id || m_sp_id != sp_id) {
-    m_run_id = run_id;
-    m_sp_id  = sp_id;
+  int run_id  =  evt->get_run_id();
+  int sp_id_f = (evt->get_spill_id() / m_sp_step) * m_sp_step;
+  if (m_run_id != run_id || m_sp_id_f != sp_id_f) {
+    m_run_id  = run_id;
+    m_sp_id_f = sp_id_f;
 
     if (dstOut) { /// Write out and close the current DST file.
       PHNodeIterator nodeiter(Fun4AllServer::instance()->topNode());
@@ -42,13 +50,15 @@ int Fun4AllSpillDstOutputManager::Write(PHCompositeNode *startNode)
         exit(1);
       }
       WriteNode(run); // dstOut is deleted at the beginning of this function.
+
+      if (m_db) DstFinished(m_run_id, m_sp_id_f - m_sp_step, m_sp_id_f - 1);
     }
 
     /// Open a new DST file.
     ostringstream oss;
     oss << m_dir_base << "/run_" << setfill('0') << setw(6) << run_id;
     gSystem->mkdir(oss.str().c_str(), true);
-    oss << "/run_" << setw(6) << run_id << "_spill_" << setw(9) << sp_id << "_spin.root";
+    oss << "/run_" << setw(6) << run_id << "_spill_" << setw(9) << sp_id_f << "_spin.root";
     outfilename = oss.str();
     dstOut = new PHNodeIOManager(outfilename.c_str(), PHWrite);
     if (!dstOut->isFunctional()) {
@@ -58,6 +68,56 @@ int Fun4AllSpillDstOutputManager::Write(PHCompositeNode *startNode)
       exit(1);
     }
     dstOut->SetCompressionLevel(3);
+
+    if (m_db) DstStarted(m_run_id, m_sp_id_f, m_sp_id_f + m_sp_step - 1, outfilename);
   }
   return Fun4AllDstOutputManager::Write(startNode);
+}
+
+void Fun4AllSpillDstOutputManager::EnableDB(const bool refresh_db, const std::string name_table)
+{
+  m_db = new DbSvc(DbSvc::DB1);
+  m_db->UseSchema(UtilOnline::GetSchemaMainDaq(), true);
+
+  m_name_table = name_table;
+
+  if (refresh_db && m_db->HasTable(m_name_table)) m_db->DropTable(m_name_table);
+  if (! m_db->HasTable(m_name_table)) {
+    DbSvc::VarList list;
+    list.Add("run_id"        , "INT", true);
+    list.Add("spill_id_first", "INT", true);
+    list.Add("spill_id_last" , "INT", true);
+    list.Add("file_name"     , "VARCHAR(256)", true);
+    list.Add("status"        , "INT");
+    list.Add("utime_b"       , "INT");
+    list.Add("utime_e"       , "INT");
+    m_db->CreateTable(m_name_table, list);
+  }
+}
+
+void Fun4AllSpillDstOutputManager::DstStarted(const int run, const int spill_f, const int spill_l, const std::string file_name, int utime)
+{
+  if (utime == 0) utime = time(0);
+
+  ostringstream oss;
+  oss << "insert into " << m_name_table
+      << " values(" << run << ", " << spill_f << ", " << spill_l << ", '" << file_name << "', 1, " << utime << ", 0)"
+      << " on duplicate key update status = 1, utime_b = " << utime << ", utime_e = 0";
+  if (! m_db->Con()->Exec(oss.str().c_str())) {
+    cerr << "!!ERROR!!  DecoStatusDb::RunStarted()." << endl;
+    return;
+  }
+}
+
+void Fun4AllSpillDstOutputManager::DstFinished(const int run, const int spill_f, const int spill_l, int utime)
+{
+  if (utime == 0) utime = time(0);
+
+  ostringstream oss;
+  oss << "update " << m_name_table << " set status = 2, utime_e = " << utime
+      << " where run_id = " << run << " and spill_id_first = " << spill_f << " and spill_id_last = " << spill_l;
+  if (! m_db->Con()->Exec(oss.str().c_str())) {
+    cerr << "!!ERROR!!  DecoStatusDb::RunFinished()." << endl;
+    return;
+  }
 }

--- a/online/decoder_maindaq/Fun4AllSpillDstOutputManager.cc
+++ b/online/decoder_maindaq/Fun4AllSpillDstOutputManager.cc
@@ -87,7 +87,7 @@ void Fun4AllSpillDstOutputManager::EnableDB(const bool refresh_db, const std::st
     list.Add("run_id"        , "INT", true);
     list.Add("spill_id_first", "INT", true);
     list.Add("spill_id_last" , "INT", true);
-    list.Add("file_name"     , "VARCHAR(256)", true);
+    list.Add("file_name"     , "VARCHAR(256)");
     list.Add("status"        , "INT");
     list.Add("utime_b"       , "INT");
     list.Add("utime_e"       , "INT");
@@ -102,7 +102,7 @@ void Fun4AllSpillDstOutputManager::DstStarted(const int run, const int spill_f, 
   ostringstream oss;
   oss << "insert into " << m_name_table
       << " values(" << run << ", " << spill_f << ", " << spill_l << ", '" << file_name << "', 1, " << utime << ", 0)"
-      << " on duplicate key update status = 1, utime_b = " << utime << ", utime_e = 0";
+      << " on duplicate key update file_name = '" << file_name << "', status = 1, utime_b = " << utime << ", utime_e = 0";
   if (! m_db->Con()->Exec(oss.str().c_str())) {
     cerr << "!!ERROR!!  DecoStatusDb::RunStarted()." << endl;
     return;

--- a/online/decoder_maindaq/Fun4AllSpillDstOutputManager.h
+++ b/online/decoder_maindaq/Fun4AllSpillDstOutputManager.h
@@ -18,9 +18,9 @@ class DbSvc;
  */
 class Fun4AllSpillDstOutputManager: public Fun4AllDstOutputManager {
   std::string m_dir_base;
-  int m_sp_step;
-  int m_run_id;
-  int m_sp_id_f;
+  int m_sp_step; ///< Step size to switch to next DST file, i.e. N of spills per DST.
+  int m_run_id; ///< Current run ID.
+  int m_sp_id_f; ///< First spill ID of current DST.  The last spill ID is `m_sp_id_f + m_sp_step - 1`.
 
   DbSvc* m_db;
   std::string m_name_table;

--- a/online/decoder_maindaq/Fun4AllSpillDstOutputManager.h
+++ b/online/decoder_maindaq/Fun4AllSpillDstOutputManager.h
@@ -1,6 +1,7 @@
 #ifndef __FUN4ALL_SPILL_DST_OUTPUT_MANAGER_H__
 #define __FUN4ALL_SPILL_DST_OUTPUT_MANAGER_H__
 #include <fun4all/Fun4AllDstOutputManager.h>
+class DbSvc;
 
 /// A Fun4All output manger that creates one DST file per spill group.
 /**
@@ -10,12 +11,19 @@
  * Fun4AllSpillDstOutputManager* out_sp = new Fun4AllSpillDstOutputManager(UtilOnline::GetDstFileDir() + "/spill");
  * //out_sp->SetSpillStep(50);
  * se->registerOutputManager(out_sp);
+ *
+ * The status of DST outputs is recorded onto MySQL DB, once `EnableDB()` is called.
+ * The table name is `spill_dst_status` by default.
+ * The status is `1` when started, and `2` when finished.
  */
 class Fun4AllSpillDstOutputManager: public Fun4AllDstOutputManager {
   std::string m_dir_base;
   int m_sp_step;
   int m_run_id;
-  int m_sp_id;
+  int m_sp_id_f;
+
+  DbSvc* m_db;
+  std::string m_name_table;
 
  public:
   Fun4AllSpillDstOutputManager(const std::string &dir_base, const std::string &myname = "SPILLDSTOUT");
@@ -23,6 +31,11 @@ class Fun4AllSpillDstOutputManager: public Fun4AllDstOutputManager {
 
   void SetSpillStep(const int step) { m_sp_step = step; }
   int Write(PHCompositeNode *startNode);
+  void EnableDB(const bool refresh_db=false, const std::string name_table="spill_dst_status");
+
+ protected:
+  void DstStarted (const int run, const int spill_f, const int spill_l, const std::string file_name, int utime=0);
+  void DstFinished(const int run, const int spill_f, const int spill_l, int utime=0);
 };
 
 #endif /* __FUN4ALL_SPILL_DST_OUTPUT_MANAGER_H__ */

--- a/online/macros/Daemon4MainDaq.C
+++ b/online/macros/Daemon4MainDaq.C
@@ -1,7 +1,5 @@
 /// Daemon4MainDaq.C
-#if ROOT_VERSION_CODE >= ROOT_VERSION(6,00,0)
 R__LOAD_LIBRARY(libdecoder_maindaq)
-#endif
 
 bool FindExistingRuns(vector<int>& list_run)
 {
@@ -29,28 +27,11 @@ bool FindExistingRuns(vector<int>& list_run)
 void StartDecoder(const int run, const int n_evt=0, const bool is_online=true)
 {
   ostringstream oss;
-  oss << "/dev/shm/decoder_maindaq";
-  gSystem->mkdir(oss.str().c_str(), true);
-  oss << "/log_" << setfill('0') << setw(6) << run << ".txt";
-  string fn_log = oss.str();
-  if (! gSystem->AccessPathName(fn_log.c_str())) { // if exists
-    for (int ii = 1; true; ii++) {
-      oss.str("");
-      oss << fn_log << "." << ii;
-      if (gSystem->AccessPathName(oss.str().c_str())) {
-        cout << "Rename the existing log file with suffix=" << ii << "." << endl;
-        gSystem->Rename(fn_log.c_str(), oss.str().c_str());
-        break;
-      }
-    }
-  }
-
-  oss.str("");
-  oss << "root.exe -b -q '" << gSystem->Getenv("E1039_CORE")
-      << "/macros/online/Fun4MainDaq.C(" << run << ", " << n_evt << ", " << is_online << ")' &>" << fn_log << " &";
+  oss << gSystem->Getenv("E1039_CORE") << "/script/exec-decoder.sh -s -e " << n_evt;
+  if (is_online) oss << " -o";
+  oss << " " << run << " &";
 
   cout << "Start the decoder for run " << run << ":\n"
-       << "  Log file = " << fn_log << "\n"
        << "  Command: " << oss.str() << endl;
   gSystem->Exec(oss.str().c_str());
 }

--- a/online/macros/Fun4MainDaq.C
+++ b/online/macros/Fun4MainDaq.C
@@ -1,11 +1,9 @@
 /// Fun4MainDaq.C:  Fun4all macro to decode the MainDAQ data.
-#if ROOT_VERSION_CODE >= ROOT_VERSION(6,00,0)
 R__LOAD_LIBRARY(libinterface_main)
 R__LOAD_LIBRARY(libdecoder_maindaq)
 R__LOAD_LIBRARY(libonlmonserver)
 R__LOAD_LIBRARY(libpheve_modules)
 R__LOAD_LIBRARY(libktracker)
-#endif
 
 int Fun4MainDaq(const int run=46, const int nevent=0, const bool is_online=false)
 {
@@ -94,6 +92,7 @@ int Fun4MainDaq(const int run=46, const int nevent=0, const bool is_online=false
 
   Fun4AllSpillDstOutputManager *om_spdst = new Fun4AllSpillDstOutputManager(UtilOnline::GetDstFileDir(), "SPILLDSTOUT");
   om_spdst->SetSpillStep(100);
+  om_spdst->EnableDB();
   se->registerOutputManager(om_spdst);
 
   if (use_evt_disp) {

--- a/packages/db_svc/DbSvc.h
+++ b/packages/db_svc/DbSvc.h
@@ -3,6 +3,7 @@
 #include <vector>
 #include <string>
 #include <sstream>
+#include <TSQLServer.h>
 class TSQLServer;
 class TSQLStatement;
 

--- a/script/setup-install.sh
+++ b/script/setup-install.sh
@@ -38,7 +38,7 @@ echo "  $DIR_INST"
 ##
 mkdir -p $DIR_INST/script
 \cp $DIR_SCRIPT/this-core-org.sh $DIR_INST/this-core.sh
-\cp $DIR_SCRIPT/exec-decoder.sh $DIR_INST/script
+\cp $DIR_SCRIPT/exec-decoder.sh $DIR_INST/script/
 
 ##
 ## Check and set up the parent environments.

--- a/script/setup-install.sh
+++ b/script/setup-install.sh
@@ -36,8 +36,9 @@ echo "  $DIR_INST"
 ##
 ## Create the setup script
 ##
-mkdir -p $DIR_INST
+mkdir -p $DIR_INST/script
 \cp $DIR_SCRIPT/this-core-org.sh $DIR_INST/this-core.sh
+\cp $DIR_SCRIPT/exec-decoder.sh $DIR_INST/script
 
 ##
 ## Check and set up the parent environments.


### PR DESCRIPTION
`Fun4AllSpillDstOutputManager` is the Fun4All output manager that is outputting spill-DSTs (one file per 100 spills by default).  This update makes the manager record the status of each spill DST on MySQL DB.  The record can be used by the semi-online reconstruction to launch a job once each spill DST gets ready.

Below is an example of the DB table.  "status = 1" means the output of each spill DST has started, and "status = 2" means it has finished.  

```
select * from user_e1039_maindaq.spill_dst_status;
+--------+----------------+---------------+------------------------------------------------------------------+--------+------------+------------+
| run_id | spill_id_first | spill_id_last | file_name                                                        | status | utime_b    | utime_e    |
+--------+----------------+---------------+------------------------------------------------------------------+--------+------------+------------+
|   3932 |              0 |            99 | /data2/e1039/dst/run_003932/run_003932_spill_000000000_spin.root |      2 | 1652073149 | 1652079392 |
|   3932 |            100 |           199 | /data2/e1039/dst/run_003932/run_003932_spill_000000100_spin.root |      2 | 1652079392 | 1652085676 |
|   3932 |            200 |           299 | /data2/e1039/dst/run_003932/run_003932_spill_000000200_spin.root |      2 | 1652085676 | 1652091980 |
|   3932 |            300 |           399 | /data2/e1039/dst/run_003932/run_003932_spill_000000300_spin.root |      2 | 1652091980 | 1652098288 |
|   3932 |            400 |           499 | /data2/e1039/dst/run_003932/run_003932_spill_000000400_spin.root |      2 | 1652098288 | 1652104597 |
|   3932 |            500 |           599 | /data2/e1039/dst/run_003932/run_003932_spill_000000500_spin.root |      2 | 1652104597 | 1652110894 |
|   3932 |            600 |           699 | /data2/e1039/dst/run_003932/run_003932_spill_000000600_spin.root |      2 | 1652110894 | 1652116413 |
|   3933 |              0 |            99 | /data2/e1039/dst/run_003933/run_003933_spill_000000000_spin.root |      1 | 1652116484 |          0 |
+--------+----------------+---------------+------------------------------------------------------------------+--------+------------+------------+
```

In addition,  the script to execute the decoder (`exec-decoder.sh`) was modified.  It will send out a WhatsApp+email message when the decoder encounters an error.

The updated code is running for the online decoding.  DB entries for the current run (#3933) are being created.
