### PR TITLE
Configuration of kTThreads for online cosmic data

### DIFF
--- a/packages/kTThreads/KScheduler.h
+++ b/packages/kTThreads/KScheduler.h
@@ -30,13 +30,10 @@
 #include <TMutex.h>
 #include <TCondition.h>
 
-#include <fun4all/SubsysReco.h>
-
 #include <ktracker/EventReducer.h>
 #include <ktracker/SRawEvent.h>
 #include <ktracker/TriggerAnalyzer.h>
 #include <ktracker/KalmanFastTracking.h>
-#include <ktracker/SQReco.h>
 #include <ktracker/UtilSRawEvent.h>
 
 #include <interface_main/SQHit.h>
@@ -49,13 +46,9 @@
 #include <interface_main/SQSpillMap_v1.h>
 #include <interface_main/SQTrackVector_v1.h>
 
-
-
-#define LOUD 0 // verbosity
-#define NTHREADS 1 // later make JobOpt
+#define NTHREADS 16 // later make JobOpt
 #define INPUT_PIPE_DEPTH 32 // play with iobuffer to load memory vs do computation...
 #define OUTPUT_PIPE_DEPTH 32
-#define E906DATA 0
 
 #define NEVENT_REDUCERS NTHREADS// reducer factories
 #define NKFAST_TRACKERS NTHREADS// tracking factories
@@ -76,6 +69,8 @@ class KScheduler{
     KScheduler(TString inFile, TString outFile);
     ~KScheduler();
 
+    void Init();
+
     static TString getInputFilename(); 
     static void setInputFilename(TString name); 
     static TString getOutputFilename();
@@ -84,6 +79,15 @@ class KScheduler{
     void postCompletedEvent();
 
     Int_t runThreads();
+
+    static void Verbose(const int a) { verb = a; }
+    static int  Verbose() { return verb; }
+
+    void UseE906Data(const bool a) { use_e906_data = a; }
+    bool UseE906Data() { return use_e906_data; }
+
+    void UseTrackletReco(const bool a) { use_tracklet_reco = a; }
+    bool UseTrackletReco() const { return use_tracklet_reco; }
 
     // output tracklets
     
@@ -135,11 +139,12 @@ class KScheduler{
 
 
 // stuff
+    static int verb;
+    static bool use_e906_data;
 
-    GeomSvc* p_geomSvc;
+    bool use_tracklet_reco;
+
     TriggerAnalyzer* p_triggerAna;
-
-    static int trackletStationId;
 
     //io thread
     static TString inputFilename;
@@ -219,6 +224,9 @@ public:
     KJob(bool poisoned);
     ~KJob();
 
+    static void Verbose(const int a) { verb = a; }
+    static int  Verbose() { return verb; }
+
     //TODO needs a mutex     // TMUTEX 
     //KJobStatus getJobStatus();
     int jobId;
@@ -238,6 +246,7 @@ public:
 
 
 private:
+    static int verb;
 
     ClassDef(KJob,1)
 

--- a/packages/kTThreads/macros/AnaData.C
+++ b/packages/kTThreads/macros/AnaData.C
@@ -1,0 +1,53 @@
+R__LOAD_LIBRARY(libinterface_main)
+R__LOAD_LIBRARY(libktracker)
+
+// St. ID: 1=D0, 2=D1, 3=D2, 4=D3p, 5=D3m, 6=D23, 7=Global
+int AnaData(const int run_id, TString infile, TString outfile)
+{
+  TFile* f_out = new TFile(outfile, "RECREATE");
+  TH1* h1_st_id = new TH1D("h1_st_id", ";Station ID;N of tracklets", 7, -0.5, 6.5);
+  TH2* h2_ntrk  = new TH2D("h2_ntrk" , ";N of tracklets/event;Station ID",  100, -0.5, 199.5,  7, 0.5, 7.5);
+  TH2* h2_nhit  = new TH2D("h2_nhit" , ";N of hits/tracklet;Station ID",  20, 0.5, 20.5,  7, 0.5, 7.5);
+  TH2* h2_rchi2 = new TH2D("h2_chi2" , ";Tracklet #chi^{2}/NDF;Station ID" , 100, 0, 10,  7, 0.5, 7.5);
+
+  TFile* f_in = new TFile(infile);
+  TTree* t_in = (TTree*)f_in->Get("save");
+  if (! t_in) return 1;
+
+  //SRawEvent* raw = 0;
+  SRecEvent* rec = 0;
+  TClonesArray* arr_trk = new TClonesArray("Tracklet",1000);
+
+  t_in->SetBranchAddress("recEvent"       , &rec);
+  t_in->SetBranchAddress("outputTracklets", &arr_trk);
+
+  int n_evt = t_in->GetEntries();
+  for (int i_evt = 0; i_evt < n_evt; i_evt++) {
+    t_in->GetEntry(i_evt);
+    int n_trk = arr_trk->GetEntries();
+
+    map<int, int> list_n_trk; // <station ID, N of tracks>
+    for (int i_trk = 0; i_trk < n_trk; i_trk++) {
+      Tracklet* trk = (Tracklet*)arr_trk->At(i_trk);
+      int st_id = trk->stationID;
+      int n_hit = trk->getNHits();
+      int ndf = n_hit - 4; // Correct only when KMag is off
+      double rchi2 = trk->chisq / ndf;
+
+      list_n_trk[st_id]++;
+
+      h1_st_id->Fill(st_id);
+      h2_nhit ->Fill(n_hit, st_id);
+      h2_rchi2->Fill(rchi2, st_id);
+    }
+
+    for (int st_id = 1; st_id <= 7; st_id++) {
+      h2_ntrk->Fill(list_n_trk[st_id], st_id);
+    }
+  }
+
+  f_out->Write();
+  f_out->Close();
+
+  return 0;
+}

--- a/packages/kTThreads/macros/README.md
+++ b/packages/kTThreads/macros/README.md
@@ -1,0 +1,40 @@
+# kTThreads/macros
+
+Scripts and macros to launch the online multi-CPU reconstruction.
+
+The e1039-core library (`e1039-core/packages/kTThreads`) does not work as is.
+A modified version is being used for now, as seen in `setup.sh`.
+
+
+## One-Time Execution
+
+### Reconstruction
+
+```
+./watch_deco_data.sh
+```
+
+This script watches newly-decoded data (i.e. spill-by-spill SRawEvent files).
+It executes `exec_reco.sh` per data file, which calls `RecoData.C`.
+
+`exec_reco.sh` can be executely manually for test:
+```
+./exec_reco.sh 3346 1
+```
+
+
+## Analysis
+
+```
+./watch_reco_data.sh
+```
+
+This script watches newly-reconstructed data. 
+It executes `exec_ana.sh` per data file, which calls `AnaData.C`.
+
+
+## Daemonized Execution
+
+Keep both `watch_deco_data.sh` and `watch_reco_data.sh` running in background.
+`/home/Tracking/kenichi/script/keep-daemon-up.sh` is a script for it.
+

--- a/packages/kTThreads/macros/RecoData.C
+++ b/packages/kTThreads/macros/RecoData.C
@@ -1,0 +1,51 @@
+/// ROOT macro to run the online reconstruction.
+/** 
+ * Based on `RunScheduler.C`.
+ */
+R__LOAD_LIBRARY(libinterface_main)
+R__LOAD_LIBRARY(libktracker)
+R__LOAD_LIBRARY(libktthread)
+
+int RecoData(const int run_id, TString infile="input.root", TString outfile="output.root")
+{
+    // Enable thread safety feature from ROOT
+    std::cout << "ROOT enabling thread safety..." << std::endl;
+    ROOT::EnableThreadSafety();
+    std::cout << "Start of kTThreadTest" << std::endl;
+
+    // Initialize running constants
+    const bool cosmic = true;
+    recoConsts* rc = recoConsts::instance();
+    rc->set_IntFlag("RUNNUMBER", run_id);
+    rc->set_CharFlag("EventReduceOpts", "a"); // Better set "none" if possible
+    if (cosmic) {
+        rc->init("cosmic");
+        rc->set_BoolFlag("COARSE_MODE", true);
+        rc->set_DoubleFlag("KMAGSTR", 0.);
+        rc->set_DoubleFlag("FMAGSTR", 0.);
+    } else {
+      const double FMAGSTR = -1.054;
+      const double KMAGSTR = -0.951;
+      rc->set_DoubleFlag("FMAGSTR", FMAGSTR);
+      rc->set_DoubleFlag("KMAGSTR", KMAGSTR);
+    }
+    rc->Print();
+
+    // Start the scheduler call
+    std::cout << "Initializing Scheduler" << std::endl;
+    //KJob      ::Verbose(1);
+    //KScheduler::Verbose(1);
+    KScheduler* ksched = new KScheduler(infile, outfile);
+    ksched->UseTrackletReco(true);
+    ksched->Init();
+
+    std::cout << "Master call to run the threads and join" << std::endl;
+    ksched->runThreads();
+
+    std::cout << "All threads dead! all done... bye bye!\n";
+
+    delete ksched;
+    return 0;
+}
+
+

--- a/packages/kTThreads/macros/exec_ana.sh
+++ b/packages/kTThreads/macros/exec_ana.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+RUN=${1:-3346}
+SPILL=${2:-1}
+
+if [ -z "$DIR_TOP" ] ; then
+    echo "DIR_TOP is not defined.  Source 'setup.sh' first.  Abort."
+    exit 1
+fi
+
+##
+## Main
+##
+RUN6=$(printf '%06d' $RUN)
+SPILL9=$(printf '%09d' $SPILL)
+DIR_OUT=$DIR_ONLINE/ana/cpu/run_$RUN6
+
+FN_IN=$DIR_ONLINE/srec/cpu/run_$RUN6/run_${RUN6}_spill_${SPILL9}_srec.root
+FN_OUT=$DIR_OUT/run_${RUN6}_spill_${SPILL9}_ana.root
+
+umask 0002
+mkdir -p $DIR_OUT
+
+root.exe -b -q "$DIR_TOP/AnaData.C($RUN, \"$FN_IN\", \"$FN_OUT\")" |& tee $DIR_OUT/run_${RUN6}_spill_${SPILL9}_ana.txt
+RET=$?
+exit $RET

--- a/packages/kTThreads/macros/exec_reco.sh
+++ b/packages/kTThreads/macros/exec_reco.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+RUN=${1:-3346}
+SPILL=${2:-1}
+
+if [ -z "$DIR_TOP" ] ; then
+    echo "DIR_TOP is not defined.  Source 'setup.sh' first.  Abort."
+    exit 1
+fi
+
+RUN6=$(printf '%06d' $RUN)
+SPILL9=$(printf '%09d' $SPILL)
+DIR_OUT=$DIR_ONLINE/srec/cpu/run_$RUN6
+
+FN_IN=$DIR_ONLINE/sraw/run_$RUN6/run_${RUN6}_spill_${SPILL9}_sraw.root
+FN_OUT=$DIR_OUT/run_${RUN6}_spill_${SPILL9}_srec.root
+
+umask 0002
+mkdir -p $DIR_OUT
+
+root.exe -b -q "$DIR_TOP/RecoData.C($RUN, \"$FN_IN\", \"$FN_OUT\")" |& tee $DIR_OUT/run_${RUN6}_spill_${SPILL9}_srec.txt
+RET=$?
+exit $RET

--- a/packages/kTThreads/macros/setup.sh
+++ b/packages/kTThreads/macros/setup.sh
@@ -1,0 +1,16 @@
+export DIR_TOP=$(dirname $(readlink -f $BASH_SOURCE))
+
+#source /data2/e1039/this-e1039.sh
+source /data2/users/kenichi/e1039/online/core-inst/this-e1039.sh
+
+export DIR_ONLINE=$E1039_ROOT/online
+export STATUS_DB=$DIR_ONLINE/data_status.db
+export STATUS_TBL=data_status
+
+export DB_VAL_UNDEF=0
+export DB_VAL_START=1
+export DB_VAL_UPDATE=2
+export DB_VAL_END=3
+
+## Note:
+## Not only the DB file but also its directory have to be writable.

--- a/packages/kTThreads/macros/setup.sh
+++ b/packages/kTThreads/macros/setup.sh
@@ -1,7 +1,7 @@
 export DIR_TOP=$(dirname $(readlink -f $BASH_SOURCE))
 
-#source /data2/e1039/this-e1039.sh
-source /data2/users/kenichi/e1039/online/core-inst/this-e1039.sh
+source /data2/e1039/this-e1039.sh
+#source /data2/users/kenichi/e1039/online/core-inst/this-e1039.sh
 
 export DIR_ONLINE=$E1039_ROOT/online
 export STATUS_DB=$DIR_ONLINE/data_status.db

--- a/packages/kTThreads/macros/watch_deco_data.sh
+++ b/packages/kTThreads/macros/watch_deco_data.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+DIR_SCRIPT=$(dirname $(readlink -f $BASH_SOURCE))
+
+##
+## Functions
+##
+function FindAvailableData {
+    local -r SEC_MAX=600
+
+    local RET=
+    for (( II = 0 ; II < 5 ; II++ )) ; do
+	sqlite3 -separator ' ' "file:$STATUS_DB?mode=ro" \
+	    "select run_id, spill_id   from $STATUS_TBL
+              where strftime('%s', 'now') - utime_deco < $SEC_MAX
+                and status_deco = $DB_VAL_END
+                and status_reco_cpu = $DB_VAL_UNDEF" | sort -r -n -k 1,1 -k 2,2
+        #order by run_id desc, spill_id desc"
+	RET=$?
+	test $RET -eq 0 && break
+	echo "  II=$II"
+	sleep 1
+    done
+    test $RET -ne 0 && echo "FindAvailableData failed with ret = $RET."
+    return $RET
+}
+
+function SetStatus {
+    local -r   RUN=$1
+    local -r SPILL=$2
+    local -r VALUE=$3
+
+    local RET=
+    for (( II = 0 ; II < 5 ; II++ )) ; do
+	sqlite3 $STATUS_DB "update $STATUS_TBL set utime_reco_cpu = strftime('%s', 'now'), status_reco_cpu = $VALUE where run_id = $RUN and spill_id = $SPILL"
+	
+	RET=$?
+	test $RET -eq 0 && break
+	echo "  II=$II"
+	sleep 1
+    done
+    test $RET -ne 0 && echo "SetStatus failed with ret = $RET."
+    return $RET
+}
+
+##
+## Main
+##
+source $DIR_SCRIPT/setup.sh
+umask 0002
+
+while true ; do
+    echo "Looping..."
+    N_FILE=5 # Only a limited number of files is analyzed for now.
+    FindAvailableData | while read RUN SPILL ; do
+	echo "Run $RUN, Spill $SPILL, N $N_FILE"
+	SetStatus $RUN $SPILL $DB_VAL_START
+
+	$DIR_SCRIPT/exec_reco.sh $RUN $SPILL &>/dev/null
+	RET=$?
+	test $RET -ne 0 && echo "  Return = $RET"
+
+	SetStatus $RUN $SPILL $DB_VAL_END
+	test $(( --N_FILE )) -eq 0 && break
+    done
+    #echo "Wait for 30 s..."
+    sleep 30
+done

--- a/packages/kTThreads/macros/watch_reco_data.sh
+++ b/packages/kTThreads/macros/watch_reco_data.sh
@@ -1,0 +1,113 @@
+#!/bin/bash
+DIR_SCRIPT=$(dirname $(readlink -f $BASH_SOURCE))
+
+TABLE_ANA='cpu_ana_status'
+
+##
+## Functions
+##
+function TableExists {
+    local -r  FILE=$1
+    local -r TABLE=$2
+    local -r N_TBL=$(sqlite3 "file:$FILE?mode=ro" "select count(*) from sqlite_master where type='table' and name='$TABLE'")
+    test $N_TBL -gt 0
+}
+
+function CreateTable {
+    local -r  FILE=$1
+    local -r TABLE=$2
+    echo "Create the table: $TABLE."
+    sqlite3 $FILE \
+	"create table $TABLE ( 
+                run_id         INTEGER, 
+                spill_id       INTEGER, 
+                utime_ana_cpu  INTEGER DEFAULT 0,
+                status_ana_cpu INTEGER DEFAULT 0,
+                UNIQUE(run_id, spill_id) )"
+}
+
+# As of 2022-08-04 the SQLite query becomes very slow if "order by ... desc" is used.
+# The speed cannot be improved even with the "index" table created.
+# Thus the descending sort is done with the "sort" command.
+function FindAvailableData {
+    local -r ANA_DB=$DIR_SCRIPT/ana_status.db
+    local -r SEC_MAX=600
+
+    local RET=
+    for (( II = 0 ; II < 5 ; II++ )) ; do
+	sqlite3 -separator ' ' "file:$STATUS_DB?mode=ro" \
+	    "select run_id, spill_id 
+               from $STATUS_TBL left join $TABLE_ANA using (run_id, spill_id) 
+              where strftime('%s', 'now') - utime_reco_cpu < $SEC_MAX
+                and status_reco_cpu = $DB_VAL_END
+                and (status_ana_cpu is null or status_ana_cpu != $DB_VAL_END)" | sort -r -n -k 1,1 -k 2,2
+	#order by run_id desc, spill_id desc"
+	RET=$?
+	test $RET -eq 0 && break
+	echo "  II=$II"
+	sleep 1
+    done
+    test $RET -ne 0 && echo "FindAvailableData failed with ret = $RET."
+    return $RET
+}
+
+function SetStatus {
+    local -r   RUN=$1
+    local -r SPILL=$2
+    local -r VALUE=$3
+
+    local RET=
+    for (( II = 0 ; II < 5 ; II++ )) ; do
+	sqlite3 $STATUS_DB \
+	    "insert or ignore into $TABLE_ANA (run_id, spill_id)
+                            values ($RUN, $SPILL) ;
+             update $TABLE_ANA set utime_ana_cpu = strftime('%s', 'now'),
+                              status_ana_cpu = $VALUE
+              where run_id = $RUN and spill_id = $SPILL"
+	RET=$?
+	test $RET -eq 0 && break
+	echo "  II=$II"
+	sleep 1
+    done
+    test $RET -ne 0 && echo "SetStatus failed with ret = $RET."
+    return $RET
+}
+
+##
+## Main
+##
+source $DIR_SCRIPT/setup.sh
+umask 0002
+
+if ! TableExists $STATUS_DB $TABLE_ANA ; then
+    CreateTable $STATUS_DB $TABLE_ANA
+    RET=$?
+    if [ $? -ne 0 ] ; then
+	echo "!!ERROR!!  CreateTable returned $RET.  Abort."
+	exit 0
+    fi
+fi
+
+while true ; do
+    echo "Looping..."
+    N_FILE=2 # Only a limited number of files is analyzed for now.
+    FindAvailableData | while read RUN SPILL ; do
+	echo "Run $RUN, Spill $SPILL, N $N_FILE"
+	SetStatus $RUN $SPILL $DB_VAL_START
+
+	$DIR_SCRIPT/exec_ana.sh $RUN $SPILL &>/dev/null
+	RET=$?
+	test $RET -ne 0 && echo "  Return = $RET"
+	SetStatus $RUN $SPILL $DB_VAL_END
+
+	test $(( --N_FILE )) -eq 0 && break
+    done
+    #echo "Wait for 30 s..."
+    sleep 30
+done
+
+
+# create index idx_data_status on data_status (run_id desc, spill_id desc);
+# PRAGMA index_list('data_status');
+# PRAGMA index_info('idx_data_status');
+# drop index idx_data_status;


### PR DESCRIPTION
This update is to modify and add functions of kTThreads so that the online reconstruction can keep running for the cosmic data. 

The key changes are
* Set `NTHREADS` to 16 (it seems valid according to "top"),
* Made `KScheduler::Init()` so that we can change some configurations before the initialization, and
* Used `KalmanFastTrackletting` instead of `KalmanFastTracking`, in order to reconstruct and store local tracklets.

Shell scripts and ROOT macros were added to `macros/`, which can be used to automatically launch the reconstruction per online data file.  They also launch an analysis program that extracts a set of parameters from reconstructed data for the monitoring purpose.

The modified code can be built fine and is running on `e1039trackcpu`.  It does not affect any other program, since kTThreads is not being used.  I see kTThreads still has room for improvement for the beam data as well as the cosmic data.  It might be easier for us to move it to e1039-analysis, as Abi suggested in the past.