### PR TITLE
Correct KMag position and better decoding error handling

### DIFF
--- a/framework/phool/recoConsts.cc
+++ b/framework/phool/recoConsts.cc
@@ -146,7 +146,7 @@ void recoConsts::set_defaults()
   set_DoubleFlag("PT_KICK_KMAG", 0.4016);
   set_DoubleFlag("PT_KICK_FMAG", 2.909);
 
-  set_DoubleFlag("Z_KMAG_BEND", 1064.26);
+  set_DoubleFlag("Z_KMAG_BEND", 1042.01722);
   set_DoubleFlag("Z_FMAG_BEND", 251.4);
   set_DoubleFlag("Z_KFMAG_BEND", 375.);
   set_DoubleFlag("ELOSS_KFMAG", 8.12);

--- a/framework/phool/recoConsts.cc
+++ b/framework/phool/recoConsts.cc
@@ -167,8 +167,21 @@ void recoConsts::set_defaults()
 
 void recoConsts::init(int runNo, bool verbose)
 {
-  //TODO: initialization based on run range
   set_IntFlag("RUNNUMBER", runNo);
+  if (runNo < 10) { // E906 data.  We will need dataset-dependent settings.
+    set_DoubleFlag("FMAGSTR", -1.044);
+    set_DoubleFlag("KMAGSTR", -1.025);
+    set_DoubleFlag("RejectWinDC0" , 0.12);
+    set_DoubleFlag("RejectWinDC1" , 0.25);
+    set_DoubleFlag("RejectWinDC2" , 0.15);
+    set_DoubleFlag("RejectWinDC3p", 0.16);
+    set_DoubleFlag("RejectWinDC3m", 0.14);
+    set_IntFlag("MaxHitsDC0" , 350);
+    set_IntFlag("MaxHitsDC1" , 350);
+    set_IntFlag("MaxHitsDC2" , 170);
+    set_IntFlag("MaxHitsDC3p", 140);
+    set_IntFlag("MaxHitsDC3m", 140);
+  }
   return;
 }
 

--- a/online/decoder_maindaq/MainDaqParser.h
+++ b/online/decoder_maindaq/MainDaqParser.h
@@ -9,6 +9,13 @@ class PHTimer2;
 class MainDaqParser {
   static const std::vector<std::string> LIST_TIMERS;
 
+  typedef enum {
+    IDX_NONE       =  0,
+    IDX_SKIP_EVENT = -1,
+    IDX_SKIP_ROC   = -2,
+    IDX_SKIP_BOARD = -3
+  } SpecialWordIndex_t;
+
   long m_file_size_min;
   int m_sec_wait;
   int m_n_wait;

--- a/online/macros/Fun4MainDaq.C
+++ b/online/macros/Fun4MainDaq.C
@@ -8,6 +8,8 @@ R__LOAD_LIBRARY(libktracker)
 int Fun4MainDaq(const int run=46, const int nevent=0, const bool is_online=false)
 {
   gSystem->Umask(0002);
+  const bool output_full_dst = false;
+  const bool output_spill_dst = true;
   const bool use_onlmon = true;
   const bool use_evt_disp = true;
 
@@ -87,13 +89,17 @@ int Fun4MainDaq(const int run=46, const int nevent=0, const bool is_online=false
     se->registerSubsystem(new OnlMonProp (OnlMonProp::P2));
   }
 
-  Fun4AllDstOutputManager *om_dst = new Fun4AllDstOutputManager("DSTOUT", fn_out);
-  se->registerOutputManager(om_dst);
+  if (output_full_dst) {
+    Fun4AllDstOutputManager *om_dst = new Fun4AllDstOutputManager("DSTOUT", fn_out);
+    se->registerOutputManager(om_dst);
+  }
 
-  Fun4AllSpillDstOutputManager *om_spdst = new Fun4AllSpillDstOutputManager(UtilOnline::GetDstFileDir(), "SPILLDSTOUT");
-  om_spdst->SetSpillStep(100);
-  om_spdst->EnableDB();
-  se->registerOutputManager(om_spdst);
+  if (output_spill_dst) {
+    Fun4AllSpillDstOutputManager *om_spdst = new Fun4AllSpillDstOutputManager(UtilOnline::GetDstFileDir(), "SPILLDSTOUT");
+    om_spdst->SetSpillStep(100);
+    om_spdst->EnableDB();
+    se->registerOutputManager(om_spdst);
+  }
 
   if (use_evt_disp) {
     se->registerSubsystem(new EvtDispFilter(1000, 1)); // (step, max per spill)

--- a/packages/Display/interface/EventDispUI.h
+++ b/packages/Display/interface/EventDispUI.h
@@ -10,8 +10,8 @@ class TGLabel;
 class TGNumberEntry;
 
 class EventDispUI {
-  static const int RUN_MIN = 1000; //< Min of search range
-  static const int RUN_MAX = 4000; //< Max of search range
+  static const int RUN_MIN =  1000; //< Min of search range
+  static const int RUN_MAX = 40000; //< Max of search range
   typedef std::vector<int> RunList_t;
   RunList_t m_list_run;
 

--- a/packages/PHField/PHFieldSeaQuest.cc
+++ b/packages/PHField/PHFieldSeaQuest.cc
@@ -1,5 +1,5 @@
 #include "PHFieldSeaQuest.h"
-
+#include <phool/recoConsts.h>
 #include <TFile.h>
 #include <TNtuple.h>
 
@@ -24,7 +24,7 @@ PHFieldSeaQuest::PHFieldSeaQuest(
 		targetmag(targermag_y)
 
 {
-  kmagZOffset = 1064.26*cm;
+  kmagZOffset = recoConsts::instance()->get_DoubleFlag("Z_KMAG_BEND")*cm;
 
   zValues[0] = fmag.GetZMin();                // front of fmag field map
   zValues[1] = kmag.GetZMin() + kmagZOffset;  // front of kmag field map


### PR DESCRIPTION
This PR includes two updates.

1. 
The KMag z-position was found incorrect, which should have been taken from an old E906 code.  It was corrected (from 1064.26 to 1042.01722 cm) in `recoConsts.cc`.  Also `PHFieldSeaQuest.cc` was modified not to use the hard-coded value in  it.

I added to `recoConsts::init(runNo)` the default parameter set for the E906 Run-6 data.  I plan to use this way of integrating all parameter sets for E1039 datasets.

2.
The Main-DAQ decoder was modified so that it can skip words from ROC or event in case of word-format errors, instead of discarding the whole event.  The modified code has already been used for the online decoding. 

