### PR TITLE
Manual selection of plane geometry version.

### DIFF
--- a/framework/phool/recoConsts.cc
+++ b/framework/phool/recoConsts.cc
@@ -171,6 +171,7 @@ void recoConsts::init(int runNo, bool verbose)
   if (runNo < 10) { // E906 data.  We will need dataset-dependent settings.
     set_DoubleFlag("FMAGSTR", -1.044);
     set_DoubleFlag("KMAGSTR", -1.025);
+    set_CharFlag  ("TRIGGER_L1", "78");
     set_DoubleFlag("RejectWinDC0" , 0.12);
     set_DoubleFlag("RejectWinDC1" , 0.25);
     set_DoubleFlag("RejectWinDC2" , 0.15);

--- a/packages/geom_svc/GeomSvc.cxx
+++ b/packages/geom_svc/GeomSvc.cxx
@@ -419,14 +419,20 @@ void GeomSvc::initPlaneDirect() {
 void GeomSvc::initPlaneDbSvc() {
   using namespace std;
   recoConsts* rc = recoConsts::instance();
-  int run = rc->get_IntFlag("RUNNUMBER");
-  cout << "GeomSvc:  Load the plane geometry info for run = " << run << "." << endl;
-
   GeomParamPlane* geom = new GeomParamPlane();
-  geom->SetMapIDbyDB(run);
-  rc->get_CharFlag("GeomPlane", geom->GetMapID());
 
+  if (rc->FlagExist("GeomPlane") && rc->get_CharFlag("GeomPlane") != "") {
+    string map_id = rc->get_CharFlag("GeomPlane");
+    cout << "GeomSvc:  Load the plane geometry info for map_id = " << map_id << "." << endl;    
+    geom->SetMapID(map_id);
+  } else {
+    int run_id = rc->get_IntFlag("RUNNUMBER");
+    cout << "GeomSvc:  Load the plane geometry info for run_id = " << run_id << "." << endl;
+    geom->SetMapIDbyDB(run_id);
+    rc->set_CharFlag("GeomPlane", geom->GetMapID());
+  }
   geom->ReadFromDB();
+
   int dummy = 0;
   for (int ii = 0; ii < geom->GetNumPlanes(); ii++) {
     GeomParamPlane::Plane* pl = geom->GetPlane(ii);

--- a/packages/geom_svc/GeomSvc.h
+++ b/packages/geom_svc/GeomSvc.h
@@ -127,6 +127,31 @@ public:
     std::vector<double> elementPos;
 };
 
+/// User interface class about the geometry of detector planes.
+/**
+ * When you need the geometry information, such as the name and the z position of detector ID = 1,
+ * you first get the instance of this class and then call corresponding member functions;
+ * @code
+ * int det_id = 1;
+ * GeomSvc* geom = GeomSvc::instance();
+ * string det_name = geom->getDetectorName(det_id);
+ * double det_zc   = getPlaneCenterZ(det_id);
+ * @endcode
+ *
+ * Usually a version of the geometry information is selected based on run ID.
+ * Thus you need set the RUNNUMBER flag before instantiating this object, namely
+ * @code
+ * recoConsts* rc = recoConsts::instance();
+ * rc->set_IntFlag("RUNNUMBER", 1234);
+ * GeomSvc* geom = GeomSvc::instance();
+ * @endcode
+ * Or you might manually select a version via the GeomPlane flag;
+ * @code
+ * recoConsts* rc = recoConsts::instance();
+ * rc->set_CharFlag("GeomPlane", "2022111601");
+ * GeomSvc* geom = GeomSvc::instance();
+ * @endcode
+ */
 class GeomSvc
 {
 public:

--- a/script/setup-install.sh
+++ b/script/setup-install.sh
@@ -60,7 +60,7 @@ elif [ ${HOSTNAME:0:12} = 'seaquestgpvm' -o \
        ${HOSTNAME:0:13} = 'spinquestgpvm' ] ; then
     echo "Use the environment for seaquestgpvm/spinquestgpvm."
     {
-	echo 'export E1039_ROOT=/e906/app/software/osg/software/e1039'
+	echo 'export E1039_ROOT=/exp/seaquest/app/software/osg/software/e1039'
 	echo 'if [ ! -d $E1039_ROOT ] ; then '
 	echo '    E1039_ROOT=/cvmfs/seaquest.opensciencegrid.org/seaquest/software/e1039'
 	echo 'fi'

--- a/script/setup-install.sh
+++ b/script/setup-install.sh
@@ -26,7 +26,7 @@ if [ -z "$1" ] ; then
 elif [ "X$1" = 'Xauto' ] ; then
     DIR_INST=$(readlink -f $DIR_SCRIPT/../../core-inst)
 elif [ "X$1" = 'Xosg-user' ] ; then
-    DIR_INST=/e906/app/software/osg/users/$USER/e1039/core
+    DIR_INST=/exp/seaquest/app/software/osg/users/$USER/e1039/core
 else
     DIR_INST=$(readlink -m "$1")
 fi


### PR DESCRIPTION
This update is mainly to add a method of manually selecting the plane geometry version.  Usually the plane geometry is selected based on the `RUNNUMBER` flag.  But if the `GeomPlane` flag exists (before instantiating `GeomSvc`) the ID given by `GeomPlane` is selected.