### PR TITLE
Inclusion of setup scripts.

### DIFF
--- a/script/change-default.sh
+++ b/script/change-default.sh
@@ -1,0 +1,30 @@
+#!/bin/bash -e
+## A script to change "default".  It is supposed to be placed under 'share' or 'core'.
+## Usage:
+##   ./change-default.sh pr.138
+DIR_BASE=$(dirname $(readlink -f $0))
+NAME_DEF=default
+
+cd $DIR_BASE
+DEST_NEW=$(basename $1)
+echo "DIR_BASE = $DIR_BASE"
+echo "NAME_DEF = $NAME_DEF"
+echo "DEST_NEW = $DEST_NEW"
+
+if [ ! -e $DEST_NEW ] ; then
+    echo "ERROR: Cannot find the new link destination '$DEST_NEW'.  Abort."
+    exit
+fi
+
+DEST_ORG='n/a'
+test -e $NAME_DEF && DEST_ORG=$(readlink $NAME_DEF)
+echo "DEST_ORG = $DEST_ORG"
+
+echo -n "Enter 'yes' to make the change: "
+read YESNO
+if [ "X$YESNO" != 'Xyes' ] ; then
+    echo "Abort."
+    exit
+fi
+
+ln -nfs $DEST_NEW $NAME_DEF

--- a/script/this-e1039-org.sh
+++ b/script/this-e1039-org.sh
@@ -1,0 +1,31 @@
+# An all-in-one script to make use of "resource", "share" and "core" under
+# a directory where this script is placed.  User can simply execute
+#   source /path/to/this-e1039.sh
+# or write it in ~/.bashrc.  
+#
+# User can change the "share" and/or "core" versions by setting 
+# "E1039_SHARE_VERSION" and/or "E1039_CORE_VERSION" beforehand;
+#   E1039_SHARE_VERSION=20240312
+#   E1039_CORE_VERSION=daily
+#   source /path/to/this-e1039.sh
+export E1039_ROOT=$(dirname $(readlink -f $BASH_SOURCE))
+
+if    [ -e $E1039_ROOT/resource/this-resource.sh ] ; then
+    source $E1039_ROOT/resource/this-resource.sh
+else
+    echo "!!WARNING!!  Cannot find the resource directory: '$E1039_ROOT/resource'.  Your program might not work."
+fi
+
+test -z "$E1039_SHARE_VERSION" && E1039_SHARE_VERSION=default
+if    [ -e $E1039_ROOT/share/$E1039_SHARE_VERSION/this-share.sh ] ; then
+    source $E1039_ROOT/share/$E1039_SHARE_VERSION/this-share.sh
+else
+    echo "!!WARNING!!  Cannot find the share directory: '$E1039_ROOT/share/$E1039_SHARE_VERSION'.  Your program might not work."
+fi
+
+test -z "$E1039_CORE_VERSION" && E1039_CORE_VERSION=default
+if    [ -e $E1039_ROOT/core/$E1039_CORE_VERSION/this-core.sh ] ; then
+    source $E1039_ROOT/core/$E1039_CORE_VERSION/this-core.sh
+else
+    echo "!!WARNING!!  Cannot find the core directory: '$E1039_ROOT/core/$E1039_CORE_VERSION'.  Your program might not work."
+fi


### PR DESCRIPTION
This update is just to add two scripts that are being used to set up the E1039 software (including "resource" and "share") on E1039 servers.  The scripts are not in any repository at present.