### PR TITLE
Change in the condition when OnlMonServer suicides

### DIFF
--- a/framework/fun4all/Fun4AllServer.cc
+++ b/framework/fun4all/Fun4AllServer.cc
@@ -1636,20 +1636,24 @@ Fun4AllServer::getSyncManager(const string &name)
   return 0;
 }
 
+/**
+ * This function sets `RUNNUMBER` via recoConsts.
+ */
 int Fun4AllServer::setRun(const int runno)
 {
+  runnumber = runno;
   recoConsts *rc = recoConsts::instance();
   rc->set_IntFlag("RUNNUMBER", runno);
-  PHTimeStamp *tstamp = nullptr;
-  if (!tstamp)
-  {
-    tstamp = new PHTimeStamp(0);
-    cout << "Fun4AllServer::setRun(): could not get timestamp for run  " << runno
-         << ", using tics(0) timestamp: ";
-    tstamp->print();
-    cout << endl;
-  }
-  delete tstamp;
+  //PHTimeStamp *tstamp = nullptr;
+  //if (!tstamp)
+  //{
+  //  tstamp = new PHTimeStamp(0);
+  //  cout << "Fun4AllServer::setRun(): could not get timestamp for run  " << runno
+  //       << ", using tics(0) timestamp: ";
+  //  tstamp->print();
+  //  cout << endl;
+  //}
+  //delete tstamp;
   FrameWorkVars->SetBinContent(RUNNUMBERBIN, (Stat_t) runno);
   return 0;
 }

--- a/framework/fun4all/Fun4AllServer.h
+++ b/framework/fun4all/Fun4AllServer.h
@@ -107,6 +107,9 @@ class Fun4AllServer : public Fun4AllBase
   void ReadSpillTimer(double& time_subsys, double& time_output);
   void ResetSpillTimer();
 
+  int getRun() const { return runnumber; }
+  int setRun(const int runno);
+
  protected:
   Fun4AllServer(const std::string &name = "Fun4AllServer");
   int InitNodeTree(PHCompositeNode *topNode);
@@ -114,7 +117,6 @@ class Fun4AllServer : public Fun4AllBase
   int CountOutNodesRecursive(PHCompositeNode *startNode, const int icount);
   int UpdateEventSelector(Fun4AllOutputManager *manager);
   int unregisterSubsystemsNow();
-  int setRun(const int runnumber);
   static Fun4AllServer *__instance;
   int OutNodeCount;
   int bortime_override;

--- a/online/macros/Fun4MainDaq.C
+++ b/online/macros/Fun4MainDaq.C
@@ -32,11 +32,9 @@ int Fun4MainDaq(const int run=46, const int nevent=0, const bool is_online=false
   string fn_out = oss.str();
   gSystem->mkdir(UtilOnline::GetDstFileDir().c_str(), true);
 
-  recoConsts* rc = recoConsts::instance();
-  rc->set_IntFlag("RUNNUMBER", run);
-
   OnlMonServer* se = OnlMonServer::instance();
   //se->Verbosity(1);
+  se->setRun(run); // This sets the `RUNNUMBER` flag.
   se->SetOnline(is_online);
 
   Fun4AllEVIOInputManager *in = new Fun4AllEVIOInputManager("MainDaq");

--- a/online/onlmonserver/OnlMonServer.cc
+++ b/online/onlmonserver/OnlMonServer.cc
@@ -129,7 +129,7 @@ bool OnlMonServer::CloseExistingServer(const int port)
   TSocket sock(m_mon_host.c_str(), port);
   if (sock.IsValid()) {
     cout << "  Close the existing onlmon server at " << port << "." << endl;
-    sock.Send("Suicide");
+    sock.Send(("Suicide:"+to_string(runnumber)).c_str());
     //TMessage *mess = 0;
     //sock.Recv(mess); // Just check a response.
     //delete mess;
@@ -236,10 +236,15 @@ void OnlMonServer::HandleConnection(TSocket* sock)
       
       if (msg_str == "Finished") {
         break;
-      } else if (msg_str == "Suicide") {
-        cout << "OnlMonServer::HandleConnection():  Suicide." << endl;
-        sock->Send("OK");
-        m_go_end = true;
+      } else if (msg_str.substr(0, 8) == "Suicide:") {
+        int run_id = stoi(msg_str.substr(8));
+        cout << "OnlMonServer::HandleConnection():  Suicide " << run_id << "." << endl;
+        if (runnumber < run_id) {
+          sock->Send("OK");
+          m_go_end = true;
+        } else {
+          sock->Send("NG");
+        }
         break;
       } else if (msg_str == "Ping") {
         if (Verbosity() > 2) cout << "  Ping." << endl;


### PR DESCRIPTION
This update is to fix a problem that the OnlMonServer sometimes becomes unavailable.  OnlMonServer doesn't suicide the server process if its run number is larger than the one that sends the suicide request.