### PR TITLE
Updates for commissioning

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -88,11 +88,11 @@ else # 'all' or 'resume'
     packages/reco/SQGenFit
     packages/reco/kfitter
     packages/reco/ktracker
-    packages/kTThreads
+    #packages/kTThreads
     packages/embedding
     packages/rs_Reader
     simulation/g4dst
-    online/onlmonserver
+    #online/onlmonserver
     packages/Display/display
     packages/Display/modules
     packages/Display/interface

--- a/framework/phool/recoConsts.cc
+++ b/framework/phool/recoConsts.cc
@@ -26,6 +26,7 @@ void recoConsts::set_CharFlag(const std::string& name, const std::string& flag)
 
 std::string recoConsts::ExpandEnvironmentals(const std::string& input)
 {
+  if (input.length() == 00) return ""; // Treat specially since exp_result.we_wordc = 0 when input is "".
   wordexp_t exp_result;
   if(wordexp(input.c_str(), &exp_result, 0) != 0)
   {

--- a/online/decoder_maindaq/DecoData.h
+++ b/online/decoder_maindaq/DecoData.h
@@ -172,7 +172,7 @@ struct HitData {
   int   event;
   int   id;
   short roc;
-  short board;
+  int   board;
   short chan;
   short det;
   short ele;

--- a/online/decoder_maindaq/DecoParam.h
+++ b/online/decoder_maindaq/DecoParam.h
@@ -38,7 +38,7 @@ struct DecoParam {
   short targPos_slow; // from slow-control event
 
   unsigned int event_count; ///< current event count
-  unsigned int codaID; ///< current Coda event ID
+  int codaID; ///< current Coda event ID
   short spillType; ///< current spill type
   short rocID; ///< current ROC ID
   int eventIDstd; ///< current event ID of standard physics events

--- a/online/decoder_maindaq/Fun4AllEVIOInputManager.cc
+++ b/online/decoder_maindaq/Fun4AllEVIOInputManager.cc
@@ -644,3 +644,13 @@ void Fun4AllEVIOInputManager::PretendSpillInterval(const int sec)
 {
   parser->dec_par.time_wait = sec;
 }
+
+void Fun4AllEVIOInputManager::UseLocalSpillID(const bool use)
+{
+  parser->UseLocalSpillID(use);
+}
+
+bool Fun4AllEVIOInputManager::UseLocalSpillID() const
+{
+  return parser->UseLocalSpillID();
+}

--- a/online/decoder_maindaq/Fun4AllEVIOInputManager.h
+++ b/online/decoder_maindaq/Fun4AllEVIOInputManager.h
@@ -33,6 +33,9 @@ class Fun4AllEVIOInputManager : public Fun4AllInputManager
   void EventSamplingFactor(const int factor);
   void DirParam(const std::string dir);
   void PretendSpillInterval(const int sec);
+
+  void UseLocalSpillID(const bool use);
+  bool UseLocalSpillID() const;
   
  protected:
   int OpenNextFile();

--- a/online/decoder_maindaq/MainDaqParser.cc
+++ b/online/decoder_maindaq/MainDaqParser.cc
@@ -34,6 +34,7 @@ MainDaqParser::MainDaqParser()
   , m_timer_sp_input (new PHTimer2("timer_sp_input"))
   , m_timer_sp_decode(new PHTimer2("timer_sp_decode"))
   , m_timer_sp_map   (new PHTimer2("timer_sp_map"))
+  , m_use_local_spill_id(false)
 {
   coda = new CodaInputManager();
   list_sd = new SpillDataMap();
@@ -596,11 +597,10 @@ int MainDaqParser::ProcessPhysBOSEOS(int* words, const int event_type)
       return 1;
     }
 
-    /// Temporary adjustment (modified on 2020-01-15).
-    /// Since spill ID is not always available in the cosmic-ray commissioning,
-    /// a temporary ID is given here.
+    /// Use a temporary spill ID if requested.
+    /// Useful in the cosmic-ray commissioning since spill ID is not always available.
     static int spillID_local = 0;
-    dec_par.spillID_cntr = ++spillID_local;
+    if (m_use_local_spill_id) dec_par.spillID_cntr = ++spillID_local;
 
     /// Regard the Slow Control info as primary (rather than Spill Counter)
     dec_par.spillID     = dec_par.spillID_cntr;

--- a/online/decoder_maindaq/MainDaqParser.h
+++ b/online/decoder_maindaq/MainDaqParser.h
@@ -34,6 +34,8 @@ class MainDaqParser {
   PHTimer2* m_timer_sp_decode;
   PHTimer2* m_timer_sp_map;
 
+  bool m_use_local_spill_id;
+
   // Handlers of CODA Event
   int ProcessCodaPrestart   (int* words);
   int ProcessCodaEnd        (int* words);
@@ -83,6 +85,9 @@ public:
   bool NextPhysicsEvent(EventData*& ed, SpillData*& sd, RunData*& rd);
   RunData* GetRunData() { return &run_data; }
   int End();
+
+  void UseLocalSpillID(const bool use) { m_use_local_spill_id = use; }
+  bool UseLocalSpillID() const  { return m_use_local_spill_id; }
 
   DecoParam dec_par;
   DecoError dec_err;

--- a/online/macros/Fun4MainDaq.C
+++ b/online/macros/Fun4MainDaq.C
@@ -40,6 +40,7 @@ int Fun4MainDaq(const int run=46, const int nevent=0, const bool is_online=false
   Fun4AllEVIOInputManager *in = new Fun4AllEVIOInputManager("MainDaq");
   in->Verbosity(3);
   in->SetOnline(is_online);
+  //in->UseLocalSpillID(true); // default = false
   //if (is_online) in->PretendSpillInterval(20);
   in->fileopen(fn_in);
   se->registerInputManager(in);
@@ -117,6 +118,7 @@ int Fun4MainDaq(const int run=46, const int nevent=0, const bool is_online=false
   if (is_online) {
     Fun4AllSRawEventOutputManager *om_sraw = new Fun4AllSRawEventOutputManager("/data2/e1039/online");
     om_sraw->Verbosity(10);
+    om_sraw->EnableDB();
     se->registerOutputManager(om_sraw);
   }
 

--- a/online/macros/Fun4MainDaq.C
+++ b/online/macros/Fun4MainDaq.C
@@ -97,7 +97,7 @@ int Fun4MainDaq(const int run=46, const int nevent=0, const bool is_online=false
 
   if (output_spill_dst) {
     Fun4AllSpillDstOutputManager *om_spdst = new Fun4AllSpillDstOutputManager(UtilOnline::GetDstFileDir(), "SPILLDSTOUT");
-    om_spdst->SetSpillStep(100);
+    om_spdst->SetSpillStep(1);
     om_spdst->EnableDB();
     se->registerOutputManager(om_spdst);
   }
@@ -106,7 +106,7 @@ int Fun4MainDaq(const int run=46, const int nevent=0, const bool is_online=false
     se->registerSubsystem(new EvtDispFilter(1000, 1)); // (step, max per spill)
 
     oss.str("");
-    oss << "/data2/e1039/online/evt_disp";
+    oss << "/data4/e1039_data/online/evt_disp";
     gSystem->mkdir(oss.str().c_str(), true);
     oss << "/run_" << setfill('0') << setw(6) << run << "_evt_disp.root";
     Fun4AllDstOutputManager *om_eddst = new Fun4AllDstOutputManager("EDDST", oss.str());
@@ -116,7 +116,7 @@ int Fun4MainDaq(const int run=46, const int nevent=0, const bool is_online=false
   }
 
   if (is_online) {
-    Fun4AllSRawEventOutputManager *om_sraw = new Fun4AllSRawEventOutputManager("/data2/e1039/online");
+    Fun4AllSRawEventOutputManager *om_sraw = new Fun4AllSRawEventOutputManager("/data4/e1039_data/online");
     om_sraw->Verbosity(10);
     om_sraw->EnableDB();
     se->registerOutputManager(om_sraw);

--- a/packages/geom_svc/ChanMapV1495.cc
+++ b/packages/geom_svc/ChanMapV1495.cc
@@ -24,7 +24,8 @@ int ChanMapV1495::ReadFileCont(LineList& lines)
     iss.clear(); // clear any error flags
     iss.str(*it);
     string det;
-    short  ele, lvl, roc, board, chan;
+    short  ele, lvl, roc, chan;
+    int board;
     if (! (iss >> det >> ele >> lvl >> roc >> board >> chan)) continue;
     Add(roc, board, chan, det, ele, lvl);
     nn++;
@@ -50,7 +51,7 @@ void ChanMapV1495::ReadDbTable(DbSvc& db)
   TSQLStatement* stmt = db.Process(oss.str());
   while (stmt->NextResultRow()) {
     short  roc      = stmt->GetInt   (0);
-    short  board    = stmt->GetInt   (1);
+    int    board    = stmt->GetInt   (1);
     short  chan     = stmt->GetInt   (2);
     string det_name = stmt->GetString(3);
     short  det      = stmt->GetInt   (4);
@@ -65,8 +66,8 @@ void ChanMapV1495::WriteDbTable(DbSvc& db)
 {
   string name_table = MapTableName();
 
-  const char* list_var [] = {      "roc",    "board",     "chan",    "det_name",      "det",      "ele",      "lvl" };
-  const char* list_type[] = { "SMALLINT", "SMALLINT", "SMALLINT", "VARCHAR(32)", "SMALLINT", "SMALLINT", "SMALLINT" };
+  const char* list_var [] = {      "roc", "board",     "chan",    "det_name",      "det",      "ele",      "lvl" };
+  const char* list_type[] = { "SMALLINT",   "INT", "SMALLINT", "VARCHAR(32)", "SMALLINT", "SMALLINT", "SMALLINT" };
   const int   n_var       = 7;
   db.CreateTable(name_table, n_var, list_var, list_type);
 
@@ -88,7 +89,7 @@ void ChanMapV1495::WriteDbTable(DbSvc& db)
  * todo: The "STOP" and "L1PX*" detectors should be handled by GeomSvc properly.
  */
 void ChanMapV1495::Add(
-  const short roc, const short board, const short chan, 
+  const short roc, const int board, const short chan, 
   const std::string det, const short ele, const short lvl)
 {
   GeomSvc* geom = GeomSvc::instance();
@@ -115,7 +116,7 @@ void ChanMapV1495::Add(
 }
 
 void ChanMapV1495::Add(
-  const short roc, const short board, const short chan, 
+  const short roc, const int board, const short chan, 
   const std::string det_name, const short det_id, const short ele, const short lvl)
 {
   MapItem item;
@@ -130,7 +131,7 @@ void ChanMapV1495::Add(
   m_map[RocBoardChan_t(roc, board, chan)] = DetEleLvl_t(det_id, ele, lvl);
 }
 
-//bool ChanMapV1495::Find(const short roc, const short board, const short chan,  std::string& det, short& ele, short& lvl)
+//bool ChanMapV1495::Find(const short roc, const int board, const short chan,  std::string& det, short& ele, short& lvl)
 //{
 //  RocBoardChan_t key(roc, board, chan);
 //  if (m_map.find(key) != m_map.end()) {
@@ -145,7 +146,7 @@ void ChanMapV1495::Add(
 //  return false;
 //}  
 
-bool ChanMapV1495::Find(const short roc, const short board, const short chan,  short& det, short& ele, short& lvl)
+bool ChanMapV1495::Find(const short roc, const int board, const short chan,  short& det, short& ele, short& lvl)
 {
   RocBoardChan_t key(roc, board, chan);
   if (m_map.find(key) != m_map.end()) {

--- a/packages/geom_svc/ChanMapV1495.h
+++ b/packages/geom_svc/ChanMapV1495.h
@@ -6,7 +6,7 @@
 class ChanMapV1495 : public ChanMapBase {
   struct MapItem {
     short roc;
-    short board;
+    int   board;
     short chan;
     std::string det_name;
     short det;
@@ -24,11 +24,11 @@ class ChanMapV1495 : public ChanMapBase {
   ChanMapV1495();
   virtual ~ChanMapV1495() {;}
 
-  void Add (const short roc, const short board, const short chan, const std::string det, const short ele, const short lvl);
-  void Add (const short roc, const short board, const short chan, const std::string det_name, const short det_id, const short ele, const short lvl);
+  void Add (const short roc, const int board, const short chan, const std::string det, const short ele, const short lvl);
+  void Add (const short roc, const int board, const short chan, const std::string det_name, const short det_id, const short ele, const short lvl);
 
-  //bool Find(const short roc, const short board, const short chan,  std::string& det, short& ele, short& lvl);
-  bool Find(const short roc, const short board, const short chan,        short& det, short& ele, short& lvl);
+  //bool Find(const short roc, const int board, const short chan,  std::string& det, short& ele, short& lvl);
+  bool Find(const short roc, const int board, const short chan,        short& det, short& ele, short& lvl);
   void Print(std::ostream& os);
 
  protected:

--- a/packages/reco/ktracker/Fun4AllSRawEventOutputManager.h
+++ b/packages/reco/ktracker/Fun4AllSRawEventOutputManager.h
@@ -10,6 +10,7 @@ class SRawEvent;
 class SQEvent;
 class SQSpillMap;
 class SQHitVector;
+class DbSvc;
 
 class Fun4AllSRawEventOutputManager: public Fun4AllOutputManager
 {
@@ -34,12 +35,17 @@ class Fun4AllSRawEventOutputManager: public Fun4AllOutputManager
   SQHitVector* m_hit_vec;
   SQHitVector* m_trig_hit_vec;
 
+  DbSvc* m_db;
+  std::string m_name_schema;
+  std::string m_name_table;
+
  public:
   Fun4AllSRawEventOutputManager(const std::string &dir_base, const std::string &myname = "SRAWEVENTOUT");
   virtual ~Fun4AllSRawEventOutputManager();
 
   void SetTreeName  (const std::string name) { m_tree_name   = name; }
   void SetBranchName(const std::string name) { m_branch_name = name; }
+  void EnableDB(const std::string name_schema="user_e1039_maindaq", const std::string name_table="sraw_file_status", const bool refresh_db=false);
 
   virtual int Write(PHCompositeNode *startNode);
 


### PR DESCRIPTION
The following changes were made to be used for the beam commissioning;
* The spill ID given by the spill counter is used by default.
* The status of spill-by-spill SRawEvent output files is written to MySQL DB.
* The mapping for V1495 TDC was updated.
* The Coda event count is saved in DST (instead of coda ID). 

The updated version is running fine for the online decoding.