### PR TITLE
Development for beam commissioning

### DIFF
--- a/interface_main/SQRun.h
+++ b/interface_main/SQRun.h
@@ -50,6 +50,9 @@ public:
 	virtual int  get_nim_prescale(const int chan) const {return std::numeric_limits<int>::max();} ///< Return the prescale factor of the given channel ('chan') of the NIM trigger in this run.
 	virtual void set_nim_prescale(const int chan, const int a) {}
 
+        virtual int  get_v1495_id(const int chan) const {return std::numeric_limits<int>::max();} ///< Return the ID of the `chan`-th V1495 boards.
+        virtual void set_v1495_id(const int chan, const int id) {}
+
 	virtual std::string get_run_desc() const {return "";} ///< Return the run description of this run.
 	virtual void        set_run_desc(const std::string a) {}
 

--- a/interface_main/SQRun_v2.cxx
+++ b/interface_main/SQRun_v2.cxx
@@ -1,0 +1,64 @@
+/*
+ * SQRun_v2.C
+ *
+ *  Created on: Oct 29, 2017
+ *      Author: yuhw
+ */
+
+
+
+#include "SQRun_v2.h"
+
+using namespace std;
+
+ClassImp(SQRun_v2)
+
+SQRun_v2::SQRun_v2() :
+  _run_id(INT_MAX),
+  _utime_b(INT_MAX),
+  _utime_e(INT_MAX),
+  _run_desc(""),
+  _n_fee_event(INT_MAX),
+  _n_fee_prescale(INT_MAX),
+  _n_run_desc(INT_MAX),
+  _n_spill(INT_MAX),
+  _n_evt_all(INT_MAX),
+  _n_evt_dec(INT_MAX),
+  _n_phys_evt(INT_MAX),
+  _n_phys_evt_bad(INT_MAX),
+  _n_flush_evt(INT_MAX),
+  _n_flush_evt_bad(INT_MAX),
+  _n_hit(INT_MAX),
+  _n_t_hit(INT_MAX),
+  _n_hit_bad(INT_MAX),
+  _n_t_hit_bad(INT_MAX), 
+  _n_v1495(INT_MAX), 
+  _n_v1495_d1ad(INT_MAX),
+  _n_v1495_d2ad(INT_MAX),
+  _n_v1495_d3ad(INT_MAX)
+
+{
+  memset(_fpga_enabled , 0, sizeof(_fpga_enabled ));
+  memset( _nim_enabled , 0, sizeof( _nim_enabled ));
+  memset(_fpga_prescale, 0, sizeof(_fpga_prescale));
+  memset( _nim_prescale, 0, sizeof( _nim_prescale));
+  memset(     _v1495_id, 0, sizeof(_v1495_id));
+}
+
+SQRun_v2::~SQRun_v2() {
+	Reset();
+}
+
+void SQRun_v2::Reset() {
+	return;
+}
+
+void SQRun_v2::identify(std::ostream& os) const {
+	  cout << "---SQRun_v2::identify:--------------------------" << endl;
+	  cout
+	  << "runID: " << _run_id
+            //<< "spillID: " << _spill_count
+	  <<endl;
+	  cout <<endl;
+	  return;
+}

--- a/interface_main/SQRun_v2.h
+++ b/interface_main/SQRun_v2.h
@@ -1,0 +1,149 @@
+/*
+ * SQRun_v2.h
+ *
+ *  Created on: Oct 29, 2017
+ *      Author: yuhw
+ */
+
+#ifndef _H_SQRun_v2_H_
+#define _H_SQRun_v2_H_
+
+#include <phool/PHObject.h>
+
+#include <map>
+#include <iostream>
+#include <limits>
+#include <climits>
+
+#include "SQRun.h"
+
+class SQRun_v2: public SQRun {
+
+public:
+
+	SQRun_v2();
+
+	virtual ~SQRun_v2();
+
+	void Reset();
+
+	virtual void identify(std::ostream& os = std::cout) const;
+
+	virtual int get_run_id() const {return _run_id;}
+	virtual void set_run_id(const int a) {_run_id = a;}
+
+	virtual int  get_unix_time_begin() const { return _utime_b; }
+	virtual void set_unix_time_begin(const int a)   { _utime_b = a; }
+
+	virtual int  get_unix_time_end() const { return _utime_e; }
+	virtual void set_unix_time_end(const int a)   { _utime_e = a; }
+
+	virtual int  get_fpga_enabled(const int chan) const { return _fpga_enabled[chan]; }
+	virtual void set_fpga_enabled(const int chan, const int a) { _fpga_enabled[chan] = a; }
+
+	virtual int  get_nim_enabled(const int chan) const { return _nim_enabled[chan]; }
+	virtual void set_nim_enabled(const int chan, const int a) { _nim_enabled[chan] = a; }
+
+	virtual int  get_fpga_prescale(const int chan) const { return _fpga_prescale[chan]; }
+	virtual void set_fpga_prescale(const int chan, const int a) { _fpga_prescale[chan] = a; }
+
+	virtual int  get_nim_prescale(const int chan) const { return _nim_prescale[chan]; }
+	virtual void set_nim_prescale(const int chan, const int a) { _nim_prescale[chan] = a; }
+
+        virtual int  get_v1495_id(const int chan) const  { return _v1495_id[chan]; }
+        virtual void set_v1495_id(const int chan, const int id) { _v1495_id[chan] = id; }
+
+	virtual std::string get_run_desc() const       { return _run_desc; }
+	virtual void        set_run_desc(const std::string a) { _run_desc = a; }
+
+	virtual int  get_n_fee_event() const { return _n_fee_event; }
+	virtual void set_n_fee_event(const int a)   { _n_fee_event = a; }
+
+	virtual int  get_n_fee_prescale() const { return _n_fee_prescale; }
+	virtual void set_n_fee_prescale(const int a)   { _n_fee_prescale = a; }
+
+	virtual int  get_n_run_desc() const { return _n_run_desc; }
+	virtual void set_n_run_desc(const int a)   { _n_run_desc = a; }
+
+	virtual int  get_n_spill() const { return _n_spill; }
+	virtual void set_n_spill(const int a)   { _n_spill = a; }
+
+	virtual int  get_n_evt_all() const { return _n_evt_all; }
+	virtual void set_n_evt_all(const int a)   { _n_evt_all = a; }
+
+	virtual int  get_n_evt_dec() const { return _n_evt_dec; }
+	virtual void set_n_evt_dec(const int a)   { _n_evt_dec = a; }
+
+	virtual int  get_n_phys_evt() const { return _n_phys_evt; }
+	virtual void set_n_phys_evt(const int a)   { _n_phys_evt = a; }
+
+	virtual int  get_n_phys_evt_bad() const { return _n_phys_evt_bad; }
+	virtual void set_n_phys_evt_bad(const int a)   { _n_phys_evt_bad = a; }
+
+	virtual int  get_n_flush_evt() const { return _n_flush_evt; }
+	virtual void set_n_flush_evt(const int a)   { _n_flush_evt = a; }
+
+	virtual int  get_n_flush_evt_bad() const { return _n_flush_evt_bad; }
+	virtual void set_n_flush_evt_bad(const int a)   { _n_flush_evt_bad = a; }
+
+	virtual int  get_n_hit() const { return _n_hit; }
+	virtual void set_n_hit(const int a)   { _n_hit = a; }
+
+	virtual int  get_n_t_hit() const { return _n_t_hit; }
+	virtual void set_n_t_hit(const int a)   { _n_t_hit = a; }
+
+	virtual int  get_n_hit_bad() const { return _n_hit_bad; }
+	virtual void set_n_hit_bad(const int a)   { _n_hit_bad = a; }
+
+	virtual int  get_n_t_hit_bad() const { return _n_t_hit_bad; }
+	virtual void set_n_t_hit_bad(const int a)   { _n_t_hit_bad = a; }
+
+	virtual int  get_n_v1495() const { return _n_v1495; }
+	virtual void set_n_v1495(const int a)   { _n_v1495 = a; }
+
+	virtual int  get_n_v1495_d1ad() const { return _n_v1495_d1ad; }
+	virtual void set_n_v1495_d1ad(const int a)   { _n_v1495_d1ad = a; }
+
+	virtual int  get_n_v1495_d2ad() const { return _n_v1495_d2ad; }
+	virtual void set_n_v1495_d2ad(const int a)   { _n_v1495_d2ad = a; }
+
+	virtual int  get_n_v1495_d3ad() const { return _n_v1495_d3ad; }
+	virtual void set_n_v1495_d3ad(const int a)   { _n_v1495_d3ad = a; }
+
+protected:
+	int _run_id;
+
+  int _utime_b; //< Unix time of run beginning
+  int _utime_e; //< Unix time of run end
+
+  int _fpga_enabled [5];
+  int  _nim_enabled [5];
+  int _fpga_prescale[5];
+  int  _nim_prescale[3];
+  int _v1495_id[5];
+
+  std::string _run_desc;
+  
+  int _n_fee_event;
+  int _n_fee_prescale;
+  int _n_run_desc;
+  int _n_spill;
+  int _n_evt_all;   //< N of all real (i.e. triggered) events
+  int _n_evt_dec;   //< N of decoded real events
+  int _n_phys_evt;  //< N of Coda standard-physics events
+  int _n_phys_evt_bad;
+  int _n_flush_evt; //< N of Coda flush events
+  int _n_flush_evt_bad;
+  int _n_hit;       //< N of Taiwan-TDC hits
+  int _n_t_hit;     //< N of v1495-TDC hits
+  int _n_hit_bad;   //< N of bad hits
+  int _n_t_hit_bad; //< N of bad t-hits.  Not implemented
+  int _n_v1495;     //< N of all v1495 events
+  int _n_v1495_d1ad;//< N of d1ad v1495 events
+  int _n_v1495_d2ad;//< N of d2ad v1495 events
+  int _n_v1495_d3ad;//< N of d3ad v1495 events
+
+ClassDef(SQRun_v2, 1);
+};
+
+#endif /* _H_SQRun_v2_H_ */

--- a/interface_main/SQRun_v2LinkDef.h
+++ b/interface_main/SQRun_v2LinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class SQRun_v2+;
+
+#endif /* __CINT__ */

--- a/online/decoder_maindaq/CalibMergeH4.cc
+++ b/online/decoder_maindaq/CalibMergeH4.cc
@@ -10,7 +10,10 @@
 #include "CalibMergeH4.h"
 using namespace std;
 
-CalibMergeH4::CalibMergeH4(const std::string& name) : SubsysReco(name), m_and_mode(false), m_remove_mode(false)
+CalibMergeH4::CalibMergeH4(const std::string& name)
+  : SubsysReco(name)
+  , m_and_mode   (false)
+  , m_remove_mode(false)
 {
   ;
 }

--- a/online/decoder_maindaq/CodaInputManager.h
+++ b/online/decoder_maindaq/CodaInputManager.h
@@ -52,7 +52,7 @@ enum { STANDARD_PHYSICS =  14 }; //
 enum { FLUSH_EVENTS     =  10 }; // previous IGNORE_ME type
 enum { SLOW_CONTROL     = 130 };
 enum { RUN_DESCRIPTOR   = 140 };
-enum { PRESTART_INFO    = 150 };
+enum { PRESTART_INFO    = 150 }; // 132 = 0x84.  Was 150 in E906?
 enum { BEGIN_SPILL      =  11 };
 enum { END_SPILL        =  12 };
 enum { SPILL_COUNTER    = 129 };

--- a/online/decoder_maindaq/DbUpRun.h
+++ b/online/decoder_maindaq/DbUpRun.h
@@ -16,6 +16,7 @@ class DbUpRun: public SubsysReco {
  private:
   void UploadRun(SQRun* sq);
   void UploadParam(const int run, const SQParamDeco* sq);
+  void UploadV1495(SQRun* sq);
 };
 
 #endif /* _DB_UP_RUN__H_ */

--- a/online/decoder_maindaq/DecoData.cc
+++ b/online/decoder_maindaq/DecoData.cc
@@ -34,6 +34,7 @@ RunData::RunData() :
 
   memset(trig_bit, 0, sizeof(trig_bit));
   memset(prescale, 0, sizeof(prescale));
+  memset(v1495_id, 0, sizeof(v1495_id));
 }
 
 

--- a/online/decoder_maindaq/DecoData.h
+++ b/online/decoder_maindaq/DecoData.h
@@ -81,6 +81,7 @@ struct RunData : public TObject {
 
   int trig_bit[10];
   int prescale[ 8];
+  int v1495_id[10];
   FeeDataList fee;
   std::string run_desc;
   

--- a/online/decoder_maindaq/Fun4AllEVIOInputManager.cc
+++ b/online/decoder_maindaq/Fun4AllEVIOInputManager.cc
@@ -413,6 +413,7 @@ int Fun4AllEVIOInputManager::run(const int nevents)
   m_timers["run_set_hit_data"]->restart();
   for (HitDataList::iterator it = ed->list_hit.begin(); it != ed->list_hit.end(); it++) {
     HitData* hd = &*it;
+    if (hd->det == 0) continue;
     SQHit* hit = new SQHit_v1();
     hit->set_hit_id     (hd->id  );
     hit->set_detector_id(hd->det );
@@ -427,6 +428,7 @@ int Fun4AllEVIOInputManager::run(const int nevents)
 
   for (HitDataList::iterator it = ed->list_hit_trig.begin(); it != ed->list_hit_trig.end(); it++) {
     HitData* hd = &*it;
+    if (hd->det == 0) continue;
     SQHit* hit = new SQHit_v1();
     hit->set_hit_id     (hd->id  );
     hit->set_detector_id(hd->det );
@@ -660,4 +662,14 @@ void Fun4AllEVIOInputManager::UseLocalSpillID(const bool use)
 bool Fun4AllEVIOInputManager::UseLocalSpillID() const
 {
   return parser->UseLocalSpillID();
+}
+
+void Fun4AllEVIOInputManager::ForceLocalSpillID(const bool force)
+{
+  parser->ForceLocalSpillID(force);
+}
+
+bool Fun4AllEVIOInputManager::ForceLocalSpillID() const
+{
+  return parser->ForceLocalSpillID();
 }

--- a/online/decoder_maindaq/Fun4AllEVIOInputManager.cc
+++ b/online/decoder_maindaq/Fun4AllEVIOInputManager.cc
@@ -10,7 +10,7 @@
 #include <interface_main/SQHitVector_v1.h>
 #include <interface_main/SQEvent_v2.h>
 #include <interface_main/SQHardEvent_v1.h>
-#include <interface_main/SQRun_v1.h>
+#include <interface_main/SQRun_v2.h>
 #include <interface_main/SQSpill_v2.h>
 #include <interface_main/SQSpillMap_v1.h>
 #include <interface_main/SQHardSpill_v1.h>
@@ -76,7 +76,7 @@ Fun4AllEVIOInputManager::Fun4AllEVIOInputManager(const string &name, const strin
     topNode->addNode(runNode);
   }
 
-  PHIODataNode<PHObject>* runHeaderNode = new PHIODataNode<PHObject>(new SQRun_v1(), "SQRun", "PHObject");
+  PHIODataNode<PHObject>* runHeaderNode = new PHIODataNode<PHObject>(new SQRun_v2(), "SQRun", "PHObject");
   runNode->addNode(runHeaderNode);
   
   PHIODataNode<PHObject>* spillNode = new PHIODataNode<PHObject>(new SQSpillMap_v1(), "SQSpillMap", "PHObject");
@@ -297,6 +297,13 @@ int Fun4AllEVIOInputManager::run(const int nevents)
   for (int ii = 0; ii < 3; ii++) {
     run_header->set_nim_prescale(ii, rd->nim_prescale[ii]);
   }
+  if (rd->v1495_id[0] != 5) {
+    cout << "  N of V1495 IDs != 5 but " << rd->v1495_id[0] << "." << endl;
+  }
+  for (int ii = 0; ii < 5; ii++) {
+    run_header->set_v1495_id(ii, rd->v1495_id[ii+1]);
+  }
+
   run_header->set_run_desc       (rd->run_desc);
   run_header->set_n_fee_event    (rd->n_fee_event);
   run_header->set_n_fee_prescale (rd->n_fee_prescale);

--- a/online/decoder_maindaq/Fun4AllEVIOInputManager.h
+++ b/online/decoder_maindaq/Fun4AllEVIOInputManager.h
@@ -36,6 +36,8 @@ class Fun4AllEVIOInputManager : public Fun4AllInputManager
 
   void UseLocalSpillID(const bool use);
   bool UseLocalSpillID() const;
+  void ForceLocalSpillID(const bool force);
+  bool ForceLocalSpillID() const;
   
  protected:
   int OpenNextFile();

--- a/online/decoder_maindaq/Fun4AllTriggerDstOutputManager.cc
+++ b/online/decoder_maindaq/Fun4AllTriggerDstOutputManager.cc
@@ -1,0 +1,53 @@
+#include <sstream>
+//#include <TSystem.h>
+//#include <TSQLServer.h>
+#include <interface_main/SQEvent.h>
+#include <phool/getClass.h>
+#include <fun4all/Fun4AllServer.h>
+//#include <db_svc/DbSvc.h>
+//#include <UtilAna/UtilOnline.h>
+#include "Fun4AllTriggerDstOutputManager.h"
+using namespace std;
+
+Fun4AllTriggerDstOutputManager::Fun4AllTriggerDstOutputManager(const string &myname, const string &filename)
+  : Fun4AllDstOutputManager(myname, filename)
+  , m_trig_mask(0)
+{
+  ;
+}
+
+Fun4AllTriggerDstOutputManager::~Fun4AllTriggerDstOutputManager()
+{
+  ;
+}
+
+void Fun4AllTriggerDstOutputManager::SetTriggerMask(const int fpga_mask, const int nim_mask)
+{
+  m_trig_mask = (fpga_mask << SQEvent::MATRIX1) | (nim_mask << SQEvent::NIM1);
+}
+
+void Fun4AllTriggerDstOutputManager::SetTriggerMask(const bool fpga1, const bool fpga2, const bool fpga3, const bool fpga4, const bool fpga5, const bool nim1, const bool nim2, const bool nim3, const bool nim4, const bool nim5)
+{
+  m_trig_mask = 0;
+  if (fpga1) m_trig_mask |= (0x1 << SQEvent::MATRIX1);
+  if (fpga2) m_trig_mask |= (0x1 << SQEvent::MATRIX2);
+  if (fpga3) m_trig_mask |= (0x1 << SQEvent::MATRIX3);
+  if (fpga4) m_trig_mask |= (0x1 << SQEvent::MATRIX4);
+  if (fpga5) m_trig_mask |= (0x1 << SQEvent::MATRIX5);
+  if (nim1 ) m_trig_mask |= (0x1 << SQEvent::NIM1);
+  if (nim2 ) m_trig_mask |= (0x1 << SQEvent::NIM2);
+  if (nim3 ) m_trig_mask |= (0x1 << SQEvent::NIM3);
+  if (nim4 ) m_trig_mask |= (0x1 << SQEvent::NIM4);
+  if (nim5 ) m_trig_mask |= (0x1 << SQEvent::NIM5);
+}
+
+int Fun4AllTriggerDstOutputManager::Write(PHCompositeNode *startNode)
+{
+  SQEvent* evt = findNode::getClass<SQEvent>(startNode, "SQEvent");
+  if (! evt) {
+    cout << PHWHERE << "SQEvent not found.  Abort." << endl;
+    exit(1);
+  }
+  if (evt->get_trigger() & m_trig_mask) return Fun4AllDstOutputManager::Write(startNode);
+  return 0;
+}

--- a/online/decoder_maindaq/Fun4AllTriggerDstOutputManager.h
+++ b/online/decoder_maindaq/Fun4AllTriggerDstOutputManager.h
@@ -1,0 +1,18 @@
+#ifndef __FUN4ALL_TRIGGER_DST_OUTPUT_MANAGER_H__
+#define __FUN4ALL_TRIGGER_DST_OUTPUT_MANAGER_H__
+#include <fun4all/Fun4AllDstOutputManager.h>
+
+/// A Fun4All output manger that creates one DST file per run containing events selected with trigger.
+class Fun4AllTriggerDstOutputManager: public Fun4AllDstOutputManager {
+  int m_trig_mask; ///< Trigger bit mask to selected events to be saved.
+
+ public:
+  Fun4AllTriggerDstOutputManager(const std::string &myname, const std::string &filename);
+  virtual ~Fun4AllTriggerDstOutputManager();
+
+  void SetTriggerMask(const int fpga_mask, const int nim_mask);
+  void SetTriggerMask(const bool fpga1, const bool fpga2, const bool fpga3, const bool fpga4, const bool fpga5, const bool nim1, const bool nim2, const bool nim3, const bool nim4, const bool nim5);
+  virtual int Write(PHCompositeNode *startNode);
+};
+
+#endif /* __FUN4ALL_TRIGGER_DST_OUTPUT_MANAGER_H__ */

--- a/online/decoder_maindaq/Fun4AllTriggerDstOutputManagerLinkDef.h
+++ b/online/decoder_maindaq/Fun4AllTriggerDstOutputManagerLinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class Fun4AllTriggerDstOutputManager-!;
+
+#endif /* __CINT__ */

--- a/online/decoder_maindaq/MainDaqParser.cc
+++ b/online/decoder_maindaq/MainDaqParser.cc
@@ -273,6 +273,8 @@ int MainDaqParser::ProcessCodaFee(int* words)
     } else if (words[3] == (int)0xe906f012) {
       if (dec_par.verb) cout << "feePrescale: event " << dec_par.event_count << endl;
       return ProcessCodaFeePrescale(words);
+    } else if (words[3] == (int)0xe906f005) {
+      return ProcessCodaFeeV1495(words);
     }
   }
   return 0;
@@ -282,9 +284,9 @@ int MainDaqParser::ProcessCodaFeeBoard(int* words)
 {
   if (dec_par.verb > 1) cout << "CodaFeeBoard: event " << dec_par.event_count << endl;
 
-    FeeData data;
-    int size = words[0];
-    data.roc = words[2];
+  FeeData data;
+  int size = words[0];
+  data.roc = words[2];
     int i_wd = 3;
     while (i_wd < size)
     {
@@ -357,6 +359,26 @@ int MainDaqParser::ProcessCodaFeePrescale(int* words)
     cout << "\n  feeP ";
     for (int ii = 0; ii <  8; ii++) cout << " " << run_data.prescale[ii];
     cout << endl;
+  }
+  return 0;
+}
+
+// Words: 0=size 1=0x00840100 2=ROC 3=0xe906f005 4=N 5=v1 v2 v3 v4 v5
+int MainDaqParser::ProcessCodaFeeV1495(int* words)
+{
+  if (dec_par.verb > 0) cout << "CodaFeeV1495: event " << dec_par.event_count << endl;
+  int size = words[0];
+  //data.roc = words[2];
+  int num = words[4];
+  if (run_data.v1495_id[0] != 0) {
+    if (dec_par.verb > 0) cout << "  Multiple events.  Overwriting." << endl;
+    memset(run_data.v1495_id, 0, sizeof(run_data.v1495_id));
+  }
+  run_data.v1495_id[0] = num;
+  for (int ii = 0; ii < num; ii++) {
+    int value = words[5+ii];
+    run_data.v1495_id[ii+1] = value;
+    if (dec_par.verb > 0) cout << "  feeV1495\t" << ii << "\t" << value << "\n";
   }
   return 0;
 }

--- a/online/decoder_maindaq/MainDaqParser.cc
+++ b/online/decoder_maindaq/MainDaqParser.cc
@@ -35,6 +35,7 @@ MainDaqParser::MainDaqParser()
   , m_timer_sp_decode(new PHTimer2("timer_sp_decode"))
   , m_timer_sp_map   (new PHTimer2("timer_sp_map"))
   , m_use_local_spill_id(false)
+  , m_force_local_spill_id(false)
 {
   coda = new CodaInputManager();
   list_sd = new SpillDataMap();
@@ -367,7 +368,7 @@ int MainDaqParser::ProcessCodaFeePrescale(int* words)
 int MainDaqParser::ProcessCodaFeeV1495(int* words)
 {
   if (dec_par.verb > 0) cout << "CodaFeeV1495: event " << dec_par.event_count << endl;
-  int size = words[0];
+  //int size = words[0];
   //data.roc = words[2];
   int num = words[4];
   if (run_data.v1495_id[0] != 0) {
@@ -618,7 +619,8 @@ int MainDaqParser::ProcessPhysBOSEOS(int* words, const int event_type)
     /// Use a temporary spill ID if requested.
     /// Useful in the cosmic-ray commissioning since spill ID is not always available.
     static int spillID_local = 0;
-    if (m_use_local_spill_id) dec_par.spillID_cntr = ++spillID_local;
+    if (m_force_local_spill_id ||
+        (m_use_local_spill_id && dec_par.spillID_cntr == 0)) dec_par.spillID_cntr = ++spillID_local;
 
     /// Regard the Slow Control info as primary (rather than Spill Counter)
     dec_par.spillID     = dec_par.spillID_cntr;
@@ -1541,7 +1543,7 @@ void MainDaqParser::SetEventInfo(EventInfo* evt, const int eventID)
   if        (evt->codaEventID == 0) {
     evt->codaEventID = dec_par.event_count;
   } else if ((unsigned int)evt->codaEventID != dec_par.event_count) {
-    if (dec_par.verb > 0) cout << "  CodaEventID Mismatch @ eventID " << eventID << ", rocID " << dec_par.rocID << ": " << evt->codaEventID << " vs " << dec_par.event_count << "\n";
+    if (dec_par.verb > 10) cout << "  CodaEventID Mismatch @ eventID " << eventID << ", rocID " << dec_par.rocID << ": " << evt->codaEventID << " vs " << dec_par.event_count << "\n";
     if ((unsigned int)evt->codaEventID > dec_par.event_count) dec_par.event_count = evt->codaEventID;
   }
 }

--- a/online/decoder_maindaq/MainDaqParser.h
+++ b/online/decoder_maindaq/MainDaqParser.h
@@ -35,6 +35,7 @@ class MainDaqParser {
   PHTimer2* m_timer_sp_map;
 
   bool m_use_local_spill_id;
+  bool m_force_local_spill_id;
 
   // Handlers of CODA Event
   int ProcessCodaPrestart   (int* words);
@@ -89,6 +90,8 @@ public:
 
   void UseLocalSpillID(const bool use) { m_use_local_spill_id = use; }
   bool UseLocalSpillID() const  { return m_use_local_spill_id; }
+  void ForceLocalSpillID(const bool force) { m_force_local_spill_id = force; }
+  bool ForceLocalSpillID() const  { return m_force_local_spill_id; }
 
   DecoParam dec_par;
   DecoError dec_err;

--- a/online/decoder_maindaq/MainDaqParser.h
+++ b/online/decoder_maindaq/MainDaqParser.h
@@ -42,6 +42,7 @@ class MainDaqParser {
   int ProcessCodaFee        (int* words);
   int ProcessCodaFeeBoard   (int* words);
   int ProcessCodaFeePrescale(int* words);
+  int ProcessCodaFeeV1495   (int* words);
   int ProcessCodaPhysics    (int* words);
 
   // Handlers of CODA PHYSICS Event

--- a/packages/Display/interface/EventDispUI.cxx
+++ b/packages/Display/interface/EventDispUI.cxx
@@ -20,6 +20,7 @@ using namespace std;
 
 EventDispUI::EventDispUI()
   : m_run(0)
+  , m_spill(0)
   , m_n_evt(0)
   , m_i_evt(0)
   , m_fr_main(0)
@@ -39,9 +40,13 @@ EventDispUI::EventDispUI()
   ;
 }
 
-std::string EventDispUI::GetDstPath(const int run)
+std::string EventDispUI::GetDstPath(const int run, const int spill)
 {
-  return m_online_mode ? UtilOnline::GetEDDstFilePath(run) : UtilOnline::GetDstFilePath(run);
+  if (m_online_mode) {
+    return UtilOnline::GetEDDstFilePath(run);
+  } else {
+    return UtilOnline::GetSpillDstDir(run) + "/" + UtilOnline::GetSpillDstFile(run, spill);
+  }
 }
 
 bool EventDispUI::FindNewRuns()
@@ -49,7 +54,7 @@ bool EventDispUI::FindNewRuns()
   int nn = m_list_run.size();
   int run = nn > 0  ? m_list_run[nn-1] : RUN_MIN;
   while (++run < RUN_MAX) {
-    string fname = GetDstPath(run);
+    string fname = GetDstPath(run, 0);
     if (! gSystem->AccessPathName(fname.c_str())) { // if exists
       m_list_run.push_back(run);
     }
@@ -57,10 +62,30 @@ bool EventDispUI::FindNewRuns()
   return m_list_run.size() > nn;
 }
 
-int EventDispUI::FetchNumEvents(const int run)
+bool EventDispUI::FindSpillDSTs()
+{
+  m_list_spill.clear();
+  string dir_dst = UtilOnline::GetSpillDstDir(m_run);
+  cout << "\nSpill-level DST directory: " << dir_dst << endl;
+  void *dirp = gSystem->OpenDirectory(dir_dst.c_str());
+  if (dirp == 0) return false; // The directory does not exist.
+  const char* name_char;
+  while ((name_char = gSystem->GetDirEntry(dirp))) {
+    string name = name_char;
+    if (name.length() != 36) continue; // run_005638_spill_001907985_spin.root
+    if (name.substr(0, 4) != "run_") continue; // easy check
+    int spill = atoi(name.substr(17, 9).c_str());
+    m_list_spill.push_back(spill);
+  }
+  gSystem->FreeDirectory(dirp);
+  sort(m_list_spill.begin(), m_list_spill.end());
+  return m_list_spill.size() > 0;
+}
+
+int EventDispUI::FetchNumEvents(const int run, const int spill)
 {
   int ret = -1;
-  TFile* file = new TFile(GetDstPath(run).c_str());
+  TFile* file = new TFile(GetDstPath(run, spill).c_str());
   if (file->IsOpen()) {
     TTree* tree = (TTree*)file->Get("T");
     if (tree) ret = tree->GetEntries();
@@ -69,15 +94,18 @@ int EventDispUI::FetchNumEvents(const int run)
   return ret;
 }
 
-int EventDispUI::OpenRunFile(const int run)
+int EventDispUI::OpenRunFile(const int run, const int spill)
 {
-  cout << "EventDispUI::OpenRunFile(): run = " << run << endl;
-  m_run = run;
-  m_n_evt = FetchNumEvents(run);
+  string fname = GetDstPath(run, spill);
+  cout << "EventDispUI::OpenRunFile(): run = " << run << "\n"
+       << "  " << fname << endl;
+  m_run   = run;
+  m_spill = spill;
+  m_n_evt = FetchNumEvents(run, spill);
   m_i_evt = 0;
   UpdateLabels();
   Fun4AllInputManager *in = Fun4AllServer::instance()->getInputManager("DSTIN");
-  return in->fileopen(GetDstPath(run));
+  return in->fileopen(fname);
 }
 
 void EventDispUI::NextEvent()
@@ -111,7 +139,7 @@ void EventDispUI::PrevEvent()
   }
   int i_new = m_i_evt - 1;
   cout << "Prev: " << i_new << " / " << m_n_evt << endl;
-  if (OpenRunFile(m_run) != 0) {
+  if (OpenRunFile(m_run, m_spill) != 0) {
     cout << "PrevEvent(): Cannot reopen DST." << endl;
     return;
   }
@@ -127,7 +155,7 @@ void EventDispUI::PrevEvent()
 void EventDispUI::MoveEvent(const int i_evt)
 {
   if (i_evt > m_n_evt) {
-    OpenRunFile(m_run);
+    OpenRunFile(m_run, m_spill);
     if (i_evt > m_n_evt) {
       cout << "Unexpected!!" << endl;
       return;
@@ -214,18 +242,44 @@ void EventDispUI::Init(const bool online_mode)
   m_run = m_list_run.back();
   if (! online_mode) {
     cout << "\nHit only 'Enter' to select the last run, " << m_list_run.back() << ".\n"
-         << "Or input a run number that you select.\n";
-    while (true) {
-      cout << "Run? " << flush;
-      char line[64];
-      cin.getline(line, 64);
-      if (line[0] == '\0') {
-        m_run = m_list_run.back();
-      } else if ((m_run = atoi(line)) <= 0) {
-        cout << "  Invalid input." << endl;
-        continue;
-      }
-      break;
+         << "Or input a run number to select.\n";
+    m_run = ReadNumber("Run?");
+    cout << "Run = " << m_run << endl;
+    if (m_run < 0) m_run = m_list_run.back();
+    cout << "Run = " << m_run << endl;
+
+    if (! FindSpillDSTs()) {
+      cout << "Found no spill-level DST file.  Abort." << endl;
+      exit(2);
+    }
+    cout << "Available spill-level DST files:\n";
+    for (unsigned int ii = 0; ii < m_list_spill.size(); ii++) {
+      cout << "  " << setw(9) << m_list_spill[ii];
+      if (ii % 5 == 4) cout << "\n";
+    }
+
+    cout << "\nHit only 'Enter' to select the last spill, " << m_list_spill.back() << ".\n"
+         << "Or input a spill number to select.\n";
+    m_spill = ReadNumber("Spill?");
+    if (m_spill < 0) m_spill = m_list_spill.back();
+  }
+}
+
+int EventDispUI::ReadNumber(const std::string msg)
+{
+  int number;
+  while (true) {
+    cout << msg << " " << flush;
+    char line[64];
+    cin.getline(line, 64);
+    if (line[0] == '\0') {
+      return -1;
+    } else if (line[0] == '0') {
+      return 0;
+    } else if ((number = atoi(line)) > 0) {
+      return number;
+    } else {
+      cout << "  Invalid input." << endl;
     }
   }
 }
@@ -233,7 +287,7 @@ void EventDispUI::Init(const bool online_mode)
 void EventDispUI::Run()
 {
   BuildInterface();
-  OpenRunFile(m_run);
+  OpenRunFile(m_run, m_spill);
   MoveEvent(1); // Need process one event here, before calling "FuncNewEventCheck"
   if (m_online_mode) {
     pthread_create(&m_tid1, NULL, FuncNewEventCheck, this);
@@ -383,7 +437,7 @@ void EventDispUI::UpdateInterface()
     m_fr_menu->HideFrame(m_fr_evt_mode);
     m_fr_menu->ShowFrame(m_fr_evt_sel);
     m_fr_menu->ShowFrame(m_fr_evt_next);
-    m_fr_menu->HideFrame(m_fr_evt_prev);
+    m_fr_menu->ShowFrame(m_fr_evt_prev); // HideFrame(m_fr_evt_prev);
   }
   m_fr_menu->Resize(); // (m_fr_menu->GetDefaultSize());
   m_fr_menu->MapWindow();

--- a/packages/Display/interface/EventDispUI.h
+++ b/packages/Display/interface/EventDispUI.h
@@ -13,9 +13,12 @@ class EventDispUI {
   static const int RUN_MIN =  1000; //< Min of search range
   static const int RUN_MAX = 40000; //< Max of search range
   typedef std::vector<int> RunList_t;
+  typedef std::vector<int> SpillList_t;
   RunList_t m_list_run;
+  SpillList_t m_list_spill;
 
   int m_run;
+  int m_spill;
   int m_n_evt;
   int m_i_evt;
   
@@ -40,11 +43,12 @@ class EventDispUI {
   EventDispUI();
   ~EventDispUI() {;}
 
-  std::string GetDstPath(const int run);
+  std::string GetDstPath(const int run, const int spill=0);
   bool FindNewRuns();
+  bool FindSpillDSTs();
 
-  int FetchNumEvents(const int run);
-  int OpenRunFile(const int run);
+  int FetchNumEvents(const int run, const int spill=0);
+  int OpenRunFile(const int run, const int spill=0);
   void NextEvent();
   void PrevEvent();
   void MoveEvent(const int i_evt);
@@ -64,6 +68,8 @@ class EventDispUI {
 
   static void* FuncNewEventCheck(void* arg);
   void ExecNewEventCheck();
+
+  int ReadNumber(const std::string msg="Run?");
 };
 
 #endif /* _EVENT_DISP_UI__H_ */

--- a/packages/UtilAna/UtilOnline.cc
+++ b/packages/UtilAna/UtilOnline.cc
@@ -108,6 +108,38 @@ std::string UtilOnline::GetSpillDstFile(const int run, const int spill)
   return oss.str();
 }
 
+std::string UtilOnline::GetSpillDstPath(const int run, const int spill)
+{
+  return GetSpillDstDir(run) + "/" + GetSpillDstFile(run, spill);
+}
+
+std::vector<std::string> UtilOnline::GetListOfSpillDSTs(const int run, const std::string dir_dst)
+{
+  ostringstream oss;
+  if (dir_dst != "") oss << dir_dst;
+  else               oss << UtilOnline::GetDstFileDir();
+  oss << "/run_" << Run6(run);
+  string dir_run = oss.str();
+
+  vector<string> list_dst;
+
+  void* dirp = gSystem->OpenDirectory(dir_run.c_str());
+  if (dirp == 0) return list_dst; // The directory does not exist.
+
+  const char* name_char;
+  while ((name_char = gSystem->GetDirEntry(dirp))) {
+    string name = name_char;
+    int length = name.length();
+    if (length < 10 ||
+        name.substr(0, 4) != "run_" ||
+        name.substr(length-10, 10) != "_spin.root") continue;
+    list_dst.push_back(dir_run+"/"+name);
+  }
+  gSystem->FreeDirectory(dirp);
+  sort(list_dst.begin(), list_dst.end());
+  return list_dst;
+}
+
 std::string UtilOnline::GetCodaFilePath(const int run)
 {
   return GetCodaFileDir() + "/" + RunNum2CodaFile(run);

--- a/packages/UtilAna/UtilOnline.cc
+++ b/packages/UtilAna/UtilOnline.cc
@@ -8,7 +8,7 @@ using namespace std;
 std::string UtilOnline::m_dir_end     = "/seaquest/e906daq/coda/data/END";
 std::string UtilOnline::m_dir_coda    = "/localdata/codadata"; // could be "/data3/data/mainDAQ" or "/data2/e1039/codadata".
 std::string UtilOnline::m_dir_dst     = "/data2/e1039/dst";
-std::string UtilOnline::m_dir_eddst   = "/data2/e1039/online/evt_disp";
+std::string UtilOnline::m_dir_eddst   = "/data4/e1039_data/online/evt_disp";
 std::string UtilOnline::m_dir_onlmon  = "/data2/e1039/onlmon/plots";
 std::string UtilOnline::m_sch_maindaq = "user_e1039_maindaq";
 
@@ -89,6 +89,22 @@ std::string UtilOnline::RunNum2EDDstFile(const int run)
 {
   ostringstream oss;
   oss << setfill('0') << "run_" << setw(6) << run << "_evt_disp.root";
+  return oss.str();
+}
+
+/// Get a directory of spill-level DST files.
+std::string UtilOnline::GetSpillDstDir(const int run)
+{
+  ostringstream oss;
+  oss << setfill('0') << m_dir_dst << "/run_" << setw(6) << run;
+  return oss.str();
+}
+
+/// Convert a run+spill number to the corresponding name of DST file.
+std::string UtilOnline::GetSpillDstFile(const int run, const int spill)
+{
+  ostringstream oss;
+  oss << setfill('0') << "run_" << setw(6) << run << "_spill_" << setw(9) << spill << "_spin.root";
   return oss.str();
 }
 

--- a/packages/UtilAna/UtilOnline.cc
+++ b/packages/UtilAna/UtilOnline.cc
@@ -64,7 +64,7 @@ int UtilOnline::CodaFile2RunNum(const std::string name)
 std::string UtilOnline::RunNum2CodaFile(const int run)
 {
   ostringstream oss;
-  oss << setfill('0') << "run_" << setw(6) << run << "_spin.dat";
+  oss << setfill('0') << "run_" << Run6(run) << "_spin.dat";
   return oss.str();
 }
 
@@ -80,7 +80,7 @@ std::string UtilOnline::RunNum2EndFile(const int run)
 std::string UtilOnline::RunNum2DstFile(const int run)
 {
   ostringstream oss;
-  oss << setfill('0') << "run_" << setw(6) << run << "_spin.root";
+  oss << setfill('0') << "run_" << Run6(run) << "_spin.root";
   return oss.str();
 }
 
@@ -88,7 +88,7 @@ std::string UtilOnline::RunNum2DstFile(const int run)
 std::string UtilOnline::RunNum2EDDstFile(const int run)
 {
   ostringstream oss;
-  oss << setfill('0') << "run_" << setw(6) << run << "_evt_disp.root";
+  oss << setfill('0') << "run_" << Run6(run) << "_evt_disp.root";
   return oss.str();
 }
 
@@ -96,7 +96,7 @@ std::string UtilOnline::RunNum2EDDstFile(const int run)
 std::string UtilOnline::GetSpillDstDir(const int run)
 {
   ostringstream oss;
-  oss << setfill('0') << m_dir_dst << "/run_" << setw(6) << run;
+  oss << setfill('0') << m_dir_dst << "/run_" << Run6(run);
   return oss.str();
 }
 
@@ -104,7 +104,7 @@ std::string UtilOnline::GetSpillDstDir(const int run)
 std::string UtilOnline::GetSpillDstFile(const int run, const int spill)
 {
   ostringstream oss;
-  oss << setfill('0') << "run_" << setw(6) << run << "_spill_" << setw(9) << spill << "_spin.root";
+  oss << setfill('0') << "run_" << Run6(run) << "_spill_" << Spill9(spill) << "_spin.root";
   return oss.str();
 }
 
@@ -126,4 +126,18 @@ std::string UtilOnline::GetDstFilePath(const int run)
 std::string UtilOnline::GetEDDstFilePath(const int run)
 {
   return GetEDDstFileDir() + "/" + RunNum2EDDstFile(run);
+}
+
+std::string UtilOnline::Run6(const int run, const int digit)
+{
+  ostringstream oss;
+  oss << setfill('0') << setw(digit) << run;
+  return oss.str();
+}
+
+std::string UtilOnline::Spill9(const int spill, const int digit)
+{
+  ostringstream oss;
+  oss << setfill('0') << setw(digit) << spill;
+  return oss.str();
 }

--- a/packages/UtilAna/UtilOnline.h
+++ b/packages/UtilAna/UtilOnline.h
@@ -1,6 +1,7 @@
 #ifndef _UTIL_ONLINE__H_
 #define _UTIL_ONLINE__H_
 #include <string>
+#include <vector>
 
 class UtilOnline {
   static std::string m_dir_end;
@@ -35,6 +36,8 @@ class UtilOnline {
 
   static std::string GetSpillDstDir (const int run);
   static std::string GetSpillDstFile(const int run, const int spill);
+  static std::string GetSpillDstPath(const int run, const int spill);
+  static std::vector<std::string> GetListOfSpillDSTs(const int run, const std::string dir_dst="");
 
   static std::string GetCodaFilePath(const int run);
   static std::string GetEndFilePath(const int run);

--- a/packages/UtilAna/UtilOnline.h
+++ b/packages/UtilAna/UtilOnline.h
@@ -33,6 +33,9 @@ class UtilOnline {
   static std::string RunNum2DstFile(const int run);
   static std::string RunNum2EDDstFile(const int run);
 
+  static std::string GetSpillDstDir (const int run);
+  static std::string GetSpillDstFile(const int run, const int spill);
+
   static std::string GetCodaFilePath(const int run);
   static std::string GetEndFilePath(const int run);
   static std::string GetDstFilePath(const int run);

--- a/packages/UtilAna/UtilOnline.h
+++ b/packages/UtilAna/UtilOnline.h
@@ -40,6 +40,9 @@ class UtilOnline {
   static std::string GetEndFilePath(const int run);
   static std::string GetDstFilePath(const int run);
   static std::string GetEDDstFilePath(const int run);
+
+  static std::string Run6(const int run, const int digit=6);
+  static std::string Spill9(const int spill, const int digit=9);
 };
 
 #endif /* _UTIL_ONLINE__H_ */

--- a/packages/calibrator/CalibHitElementPos.cc
+++ b/packages/calibrator/CalibHitElementPos.cc
@@ -10,6 +10,8 @@ using namespace std;
 
 CalibHitElementPos::CalibHitElementPos(const std::string& name)
   : SubsysReco(name)
+  , m_cal_hit   (true)
+  , m_cal_tr_hit(true)
   , m_vec_hit   (0)
   , m_vec_trhit (0)
 {
@@ -36,14 +38,23 @@ int CalibHitElementPos::InitRun(PHCompositeNode* topNode)
 
 int CalibHitElementPos::process_event(PHCompositeNode* topNode)
 {
+  if (Verbosity() > 10) cout << "CalibHitElementPos::process_event()"<< endl;
   GeomSvc* geom = GeomSvc::instance();
-  for (SQHitVector::Iter it = m_vec_hit->begin(); it != m_vec_hit->end(); it++) {
-    SQHit* hit = *it;
-    hit->set_pos(geom->getMeasurement(hit->get_detector_id(), hit->get_element_id()));
+  if (m_cal_hit) {
+    for (SQHitVector::Iter it = m_vec_hit->begin(); it != m_vec_hit->end(); it++) {
+      SQHit* hit = *it;
+      if (Verbosity() > 10) cout << "  hit " << hit->get_detector_id() << " " << hit->get_element_id() << endl;
+      if (hit->get_detector_id() <= 0 || hit->get_detector_id() >= 1000) continue; // temporary solution to avoid a seg fault on strange hits.
+      hit->set_pos(geom->getMeasurement(hit->get_detector_id(), hit->get_element_id()));
+    }
   }
-  for (SQHitVector::Iter it = m_vec_trhit->begin(); it != m_vec_trhit->end(); it++) {
-    SQHit* hit = *it;
-    hit->set_pos(geom->getMeasurement(hit->get_detector_id(), hit->get_element_id()));
+  if (m_cal_tr_hit) {
+    for (SQHitVector::Iter it = m_vec_trhit->begin(); it != m_vec_trhit->end(); it++) {
+      SQHit* hit = *it;
+      if (Verbosity() > 10) cout << "  trig hit " << hit->get_detector_id() << " " << hit->get_element_id() << endl;
+      if (hit->get_detector_id() <= 0 || hit->get_detector_id() >= 1000) continue; // temporary solution to avoid a seg fault on strange hits.
+      hit->set_pos(geom->getMeasurement(hit->get_detector_id(), hit->get_element_id()));
+    }
   }
   return Fun4AllReturnCodes::EVENT_OK;
 }

--- a/packages/calibrator/CalibHitElementPos.h
+++ b/packages/calibrator/CalibHitElementPos.h
@@ -5,6 +5,8 @@ class SQHitVector;
 
 /// SubsysReco module to set the position of SQHit using GeomSvc.
 class CalibHitElementPos: public SubsysReco {
+  bool m_cal_hit;
+  bool m_cal_tr_hit;
   SQHitVector* m_vec_hit;
   SQHitVector* m_vec_trhit;
 
@@ -15,6 +17,9 @@ class CalibHitElementPos: public SubsysReco {
   int InitRun(PHCompositeNode *topNode);
   int process_event(PHCompositeNode *topNode);
   int End(PHCompositeNode *topNode);
+
+  void CalibHit       (const bool cal) { m_cal_hit    = cal; }
+  void CalibTriggerHit(const bool cal) { m_cal_tr_hit = cal; }
 };
 
 #endif // __CALIB_HIT_ELEMENT_POS_H__

--- a/packages/calibrator/CalibHodoInTime.cc
+++ b/packages/calibrator/CalibHodoInTime.cc
@@ -76,15 +76,14 @@ int CalibHodoInTime::process_event(PHCompositeNode* topNode)
   for (SQHitVector::Iter it = m_vec_hit->begin(); it != m_vec_hit->end(); it++) {
     SQHit* hit = *it;
     int det = hit->get_detector_id();
-    if (!geom->isHodo(det)) continue;
+    if (!geom->isHodo(det) && !geom->isDPHodo(det) && !geom->isInh(det)) continue;
 
     int ele = hit->get_element_id();
     double center, width;
     if (! m_cal_taiwan->Find(det, ele, center, width)) {
-      cerr << "  WARNING:  Cannot find the in-time parameter for det=" << det << " ele=" << ele << ".\n";
-      hit->set_in_time(false);
+      if (Verbosity() > 1) cerr << "  WARNING:  Cannot find the in-time parameter for det=" << det << " ele=" << ele << ".\n";
+      //hit->set_in_time(false);
       continue;
-      //return Fun4AllReturnCodes::ABORTEVENT;
     }
     hit->set_in_time( fabs(hit->get_tdc_time() - center) <= width / 2 );
     hit->set_drift_distance(0);
@@ -99,10 +98,9 @@ int CalibHodoInTime::process_event(PHCompositeNode* topNode)
     int lvl = hit->get_level();
     double center, width;
     if (! m_cal_v1495->Find(det, ele, lvl, center, width)) {
-      cerr << "  WARNING:  Cannot find the in-time parameter for trigger det=" << det << " ele=" << ele << " lvl=" << lvl << ".\n";
-      hit->set_in_time(false);
+      if (Verbosity() > 1) cerr << "  WARNING:  Cannot find the in-time parameter for trigger det=" << det << " ele=" << ele << " lvl=" << lvl << ".\n";
+      //hit->set_in_time(false);
       continue;
-      //return Fun4AllReturnCodes::ABORTEVENT;
     }
     hit->set_in_time( fabs(hit->get_tdc_time() - center) <= width / 2 );
     hit->set_drift_distance(0);

--- a/packages/geom_svc/GeomSvc.cxx
+++ b/packages/geom_svc/GeomSvc.cxx
@@ -801,6 +801,16 @@ bool GeomSvc::isDPHodo(const std::string detectorName) const
   return detectorName.substr(0, 2) == "DP";
 }
 
+bool GeomSvc::isInh(const int detectorID) const
+{
+  return isInh(getDetectorName(detectorID));
+}
+
+bool GeomSvc::isInh(const std::string detectorName) const
+{
+  return detectorName.substr(0, 6) == "Before" || detectorName.substr(0, 5) == "After";
+}
+
 int GeomSvc::getHodoStation(const int detectorID) const
 {
   return getHodoStation(getDetectorName(detectorID));

--- a/packages/geom_svc/GeomSvc.cxx
+++ b/packages/geom_svc/GeomSvc.cxx
@@ -296,7 +296,7 @@ void GeomSvc::init()
     map_detectorID.insert(nameToID("H4T"  , ++idx));
     // Please make sure of "idx = nChamberPlanes + nHodoPlanes" here
 
-    map_detectorID.insert(nameToID("P1Y1", ++idx));
+    map_detectorID.insert(nameToID("P1Y1", ++idx)); // 47
     map_detectorID.insert(nameToID("P1Y2", ++idx));
     map_detectorID.insert(nameToID("P1X1", ++idx));
     map_detectorID.insert(nameToID("P1X2", ++idx));
@@ -306,7 +306,7 @@ void GeomSvc::init()
     map_detectorID.insert(nameToID("P2Y2", ++idx));
     // Please make sure of "idx = nChamberPlanes + nHodoPlanes + nPropPlanes" here
 
-    map_detectorID.insert(nameToID("DP1TL", ++idx));
+    map_detectorID.insert(nameToID("DP1TL", ++idx)); // 55
     map_detectorID.insert(nameToID("DP1TR", ++idx));
     map_detectorID.insert(nameToID("DP1BL", ++idx));
     map_detectorID.insert(nameToID("DP1BR", ++idx));
@@ -316,7 +316,7 @@ void GeomSvc::init()
     map_detectorID.insert(nameToID("DP2BR", ++idx));
     // Please make sure of "idx = nChamberPlanes + nHodoPlanes + nPropPlanes + nDarkPhotonPlanes" here
 
-    map_detectorID.insert(nameToID("BeforeInhNIM"   , ++idx));
+    map_detectorID.insert(nameToID("BeforeInhNIM"   , ++idx)); // 63
     map_detectorID.insert(nameToID("BeforeInhMatrix", ++idx));
     map_detectorID.insert(nameToID("AfterInhNIM"    , ++idx));
     map_detectorID.insert(nameToID("AfterInhMatrix" , ++idx));
@@ -335,7 +335,7 @@ void GeomSvc::init()
     map_detectorID.insert(nameToID("L1NIMyb"        , ++idx));
     // No constant for this name group is defined in GlobalConsts.h.
 
-    map_detectorID.insert(nameToID("H4Y1Ll", ++idx));
+    map_detectorID.insert(nameToID("H4Y1Ll", ++idx)); // 80
     map_detectorID.insert(nameToID("H4Y1Lr", ++idx));
     map_detectorID.insert(nameToID("H4Y1Rl", ++idx));
     map_detectorID.insert(nameToID("H4Y1Rr", ++idx));

--- a/packages/geom_svc/GeomSvc.h
+++ b/packages/geom_svc/GeomSvc.h
@@ -260,6 +260,8 @@ public:
     bool isPropTube(const std::string detectorName) const; ///< Return "true" for prop tube planes.
     bool isDPHodo(const int detectorID) const; ///< Return "true" for DP hodo planes.
     bool isDPHodo(const std::string detectorName) const; ///< Return "true" for DP hodo planes.
+    bool isInh(const int detectorID) const; ///< Return "true" for BeforeInh and AfterInh signals.
+    bool isInh(const std::string detectorName) const;
 
     int getHodoStation(const int detectorID) const; ///< Return a station number (1-4) for hodo planes or "0" for others.
     int getHodoStation(const std::string detectorName) const; ///< Return a station number (1-4) for hodo planes or "0" for others.

--- a/packages/reco/interface/SRawEvent.cxx
+++ b/packages/reco/interface/SRawEvent.cxx
@@ -84,7 +84,7 @@ SRawEvent::SRawEvent() : fRunID(-1), fEventID(-1), fSpillID(-1), fTriggerBits(-1
 {
     fAllHits.clear();
     fTriggerHits.clear();
-    for(Int_t i = 0; i < nChamberPlanes+nHodoPlanes+nPropPlanes+1; i++)
+    for(Int_t i = 0; i < nChamberPlanes+nHodoPlanes+nPropPlanes+nDarkPhotonPlanes+1; i++)
     {
         fNHits[i] = 0;
     }
@@ -112,7 +112,7 @@ void SRawEvent::DeepClone(SRawEvent *c)
     for(int i=0; i<4; ++i)  fNRoads[i]    = c->getNRoads()[i];
 
 
-    for(Short_t i = 0; i < nChamberPlanes+nHodoPlanes+nPropPlanes+1; i++) {
+    for(Short_t i = 0; i < nChamberPlanes+nHodoPlanes+nPropPlanes+nDarkPhotonPlanes+1; i++) {
         fNHits[i] = c->getNHitsInDetector(i);
     }
     fAllHits      = c->getAllHits();
@@ -130,7 +130,7 @@ void SRawEvent::setEventInfo(Int_t runID, Int_t spillID, Int_t eventID)
 
 void SRawEvent::insertHit(Hit h)
 {
-    if(h.detectorID < 1 || h.detectorID > nChamberPlanes+nHodoPlanes+nPropPlanes) return;
+    if(h.detectorID < 1 || h.detectorID > nChamberPlanes+nHodoPlanes+nPropPlanes+nDarkPhotonPlanes) return;
     fAllHits.push_back(h);
 
     fNHits[0]++;
@@ -139,7 +139,7 @@ void SRawEvent::insertHit(Hit h)
 
 Int_t SRawEvent::findHit(Short_t detectorID, Short_t elementID)
 {
-    if(detectorID < 1 || detectorID > nChamberPlanes+nHodoPlanes+nPropPlanes) return -1;
+    if(detectorID < 1 || detectorID > nChamberPlanes+nHodoPlanes+nPropPlanes+nDarkPhotonPlanes) return -1;
     if(elementID < 0) return -1;
 
     /*
@@ -417,7 +417,7 @@ Int_t SRawEvent::getNHitsInDetectors(std::vector<Int_t>& detectorIDs)
     UInt_t nDetectors = detectorIDs.size();
     for(UInt_t i = 0; i < nDetectors; i++)
     {
-        for(Int_t j = 0; j <= nChamberPlanes+nHodoPlanes+nPropPlanes; j++)
+        for(Int_t j = 0; j <= nChamberPlanes+nHodoPlanes+nPropPlanes+nDarkPhotonPlanes; j++)
         {
             if(detectorIDs[i] == j)
             {
@@ -561,7 +561,7 @@ void SRawEvent::reIndex(bool doSort)
     if(doSort) std::sort(fAllHits.begin(), fAllHits.end());
 
     ///Reset the number of hits on each plane
-    for(Int_t i = 0; i < nChamberPlanes+nHodoPlanes+nPropPlanes+1; i++) fNHits[i] = 0;
+    for(Int_t i = 0; i < nChamberPlanes+nHodoPlanes+nPropPlanes+nDarkPhotonPlanes+1; i++) fNHits[i] = 0;
     for(UInt_t i = 0; i < fAllHits.size(); i++) ++fNHits[fAllHits[i].detectorID];
 
     fNHits[0] = fAllHits.size();
@@ -605,7 +605,7 @@ void SRawEvent::clear()
 {
     //set everything to empty or impossible numbers
     fAllHits.clear();
-    for(Int_t i = 0; i < nChamberPlanes+nHodoPlanes+nPropPlanes+1; i++) fNHits[i] = 0;
+    for(Int_t i = 0; i < nChamberPlanes+nHodoPlanes+nPropPlanes+nDarkPhotonPlanes+1; i++) fNHits[i] = 0;
 
     fRunID = -1;
     fSpillID = -1;

--- a/packages/reco/interface/SRawEvent.h
+++ b/packages/reco/interface/SRawEvent.h
@@ -268,7 +268,7 @@ private:
     Short_t fNRoads[4];       //0, positive top; 1, positive bottom; 2, negative top; 3, negative bottom
 
     ///Hits of this event
-    Int_t fNHits[nChamberPlanes+nHodoPlanes+nPropPlanes+1];  //0 for all hits, 1, 2, ..., 24 for number of hits in plane 1, 2, ..., 24
+    Int_t fNHits[nChamberPlanes+nHodoPlanes+nPropPlanes+nDarkPhotonPlanes+1];  //0 for all hits, 1, 2, ..., 24 for number of hits in plane 1, 2, ..., 24
     std::vector<Hit> fAllHits;
     std::vector<Hit> fTriggerHits;
 


### PR DESCRIPTION
I made multiple changes to meet our needs during the commissioning.  The updated version has been running fine for the online Main-DAQ decoding.

* Added DP-hodo hits to the SRawEvent output file.
* Updated the 3D event display to handle the spill-level DST. 
* Updated the decoder to read the V1495 version information.  Made `SQRun_v2` to store it.
* Added Fun4AllTriggerDstOutputManager, to record NIM4 events in dedicated files. 
* Changed the handling of spill ID in the Main-DAQ decoder.  When the spill counter event is not available for a spill, the spill is given an incremental ID (which was always 0 in the previous version).
* Changed the behavior of CalibHodoInTime, so that it doesn't touch unmapped channels. 
* Added `isInh()` to `GeomSvc`. 
* Add functions to `UtilOnline` to handle spill-level DSTs.