### PR TITLE
Addition of utility classes to handle trigger roadset

### DIFF
--- a/packages/UtilAna/LinkDef.h
+++ b/packages/UtilAna/LinkDef.h
@@ -9,4 +9,8 @@
 #pragma link C++ class UtilDimuon-!;
 #pragma link C++ class UtilBeam-!;
 
+#pragma link C++ class UtilTrigger::TrigRoad-!;
+#pragma link C++ class UtilTrigger::TrigRoads-!;
+#pragma link C++ class UtilTrigger::TrigRoadset-!;
+
 #endif

--- a/packages/UtilAna/TrigRoad.cc
+++ b/packages/UtilAna/TrigRoad.cc
@@ -41,11 +41,5 @@ std::string TrigRoad::str(const int level) const
   if (level > 1) oss << (charge > 0 ? '+' : '-');
   return oss.str();
 }
-
-//std::ostream& operator<<(std::ostream& os, const TrigRoad& rd)
-//{
-//  os << setw(6) << rd.road_id << ": " << rd.charge << " (" << rd.H1X << ", " << rd.H2X << ", " << rd.H3X << ", " << rd.H4X << ")";
-//  return os;
-//}
   
 }; // End of "namespace UtilTrigger"

--- a/packages/UtilAna/TrigRoad.cc
+++ b/packages/UtilAna/TrigRoad.cc
@@ -1,0 +1,51 @@
+#include <iostream>
+#include <sstream>
+#include <cstring>
+#include "TrigRoad.h"
+using namespace std;
+namespace UtilTrigger {
+  
+TrigRoad::TrigRoad()
+  : road_id(0)
+  , charge (0)
+  , H1X    (0)
+  , H2X    (0)
+  , H3X    (0)
+  , H4X    (0)
+{
+  ;
+}
+
+void TrigRoad::Road2Hodo(const int road, int& h1, int& h2, int& h3, int& h4, int& tb)
+{
+  int rr = abs(road) - 1;
+  h1 = 1 + (rr / 4096);
+  h2 = 1 + (rr /  256) % 16;
+  h3 = 1 + (rr /   16) % 16;
+  h4 = 1 +  rr         % 16;
+  tb = road / abs(road);
+}
+
+int TrigRoad::Hodo2Road(const int h1, const int h2, const int h3, const int h4, const int tb)
+{
+  int rr = 4096*(h1-1) + 256*(h2-1) + 16*(h3-1) + h4;
+  if (tb < 0) rr *= -1;
+  return rr;
+}
+
+std::string TrigRoad::str(const int level) const
+{
+  ostringstream oss;
+  oss << road_id;
+  if (level > 0) oss << "[" << H1X << "," << H2X << "," << H3X << "," << H4X << "]";
+  if (level > 1) oss << (charge > 0 ? '+' : '-');
+  return oss.str();
+}
+
+//std::ostream& operator<<(std::ostream& os, const TrigRoad& rd)
+//{
+//  os << setw(6) << rd.road_id << ": " << rd.charge << " (" << rd.H1X << ", " << rd.H2X << ", " << rd.H3X << ", " << rd.H4X << ")";
+//  return os;
+//}
+  
+}; // End of "namespace UtilTrigger"

--- a/packages/UtilAna/TrigRoad.h
+++ b/packages/UtilAna/TrigRoad.h
@@ -1,0 +1,28 @@
+#ifndef _TRIG_ROAD__H_
+#define _TRIG_ROAD__H_
+#include <string>
+
+namespace UtilTrigger {
+  
+class TrigRoad {
+ public:
+  int road_id;
+  int charge;
+  int H1X;
+  int H2X;
+  int H3X;
+  int H4X;
+  
+  TrigRoad();
+  virtual ~TrigRoad() {;}
+  
+  static void Road2Hodo(const int road, int& h1, int& h2, int& h3, int& h4, int& tb);
+  static int  Hodo2Road(const int h1, const int h2, const int h3, const int h4, const int tb);
+  
+  std::string str(const int level=0) const;
+  //friend std::ostream& operator<<(std::ostream& os, const TrigRoad& rd);
+};
+  
+}; // namespace UtilTrigger
+
+#endif // _TRIG_ROAD__H_

--- a/packages/UtilAna/TrigRoad.h
+++ b/packages/UtilAna/TrigRoad.h
@@ -20,7 +20,6 @@ class TrigRoad {
   static int  Hodo2Road(const int h1, const int h2, const int h3, const int h4, const int tb);
   
   std::string str(const int level=0) const;
-  //friend std::ostream& operator<<(std::ostream& os, const TrigRoad& rd);
 };
   
 }; // namespace UtilTrigger

--- a/packages/UtilAna/TrigRoads.cc
+++ b/packages/UtilAna/TrigRoads.cc
@@ -66,13 +66,4 @@ std::string TrigRoads::str(const int level) const
   return oss.str();
 }
 
-//std::ostream& operator<<(std::ostream& os, const TrigRoads& tr)
-//{
-//  ostringstream oss;
-//  oss << showpos << "Charge = " << tr.Charge() << ", TopBot = " << tr.TopBot() << ", N of roads = "
-//      << noshowpos << tr.GetNumRoads();
-//  os << oss.str();
-//  return os;
-//}
-
 }; // End of "namespace UtilTrigger"

--- a/packages/UtilAna/TrigRoads.cc
+++ b/packages/UtilAna/TrigRoads.cc
@@ -1,0 +1,78 @@
+#include <iostream>
+#include <fstream>
+#include <sstream>
+#include <cstring>
+#include <vector>
+#include "TrigRoads.h"
+using namespace std;
+namespace UtilTrigger {
+  
+TrigRoads::TrigRoads(const int pol, const int top_bot)
+  : m_file_name("")
+  , m_pol(pol)
+  , m_top_bot(top_bot)
+{
+  ;
+}
+
+TrigRoad* TrigRoads::GetRoad(const int idx)
+{
+  if (idx < 0 || idx > (int)m_roads.size()) return 0;
+  return &m_roads[idx];
+}
+
+TrigRoad* TrigRoads::FindRoad(const int road_id)
+{
+  auto it = m_idx_map.find(road_id);
+  if (it != m_idx_map.end()) return &m_roads[it->second];
+  return 0;
+}
+
+int TrigRoads::LoadConfig(const std::string file_name)
+{
+  //cout << "TrigRoads::LoadConfig(" << file_name << ")\n";
+  m_file_name = file_name;
+  ifstream ifs(file_name);
+  if (! ifs) return 1;
+
+  int idx = 0;
+  string buffer;
+  istringstream iss;
+  while (getline(ifs, buffer)) {
+    if (buffer[0] == '#' || buffer[0] == 'r') continue; // 'r' of 'roadID'
+    iss.clear(); // clear any error flags
+    iss.str(buffer);
+
+    TrigRoad road;
+    if (! (iss >> road.road_id >> road.charge
+               >> road.H1X >> road.H2X >> road.H3X >> road.H4X)) continue;
+    if (road.road_id * m_top_bot <= 0) continue; // top-bottom mismatch
+    if (road.charge  * m_pol     <= 0) continue; // charge mismatch
+    m_roads.push_back(road);
+    m_idx_map[road.road_id] = idx++;
+  }
+  ifs.close();
+  return 0; // no validation so far
+}
+
+std::string TrigRoads::str(const int level) const
+{
+  ostringstream oss;
+  oss << (m_pol > 0 ? '+' : '-') << (m_top_bot > 0 ? 'T' : 'B');
+  if (level > 0) oss << "[" << m_roads.size() << "]";
+  if (level > 1) {
+    for (auto it = m_roads.begin(); it != m_roads.end(); it++) oss << "  " << it->str(level - 2);
+  }
+  return oss.str();
+}
+
+//std::ostream& operator<<(std::ostream& os, const TrigRoads& tr)
+//{
+//  ostringstream oss;
+//  oss << showpos << "Charge = " << tr.Charge() << ", TopBot = " << tr.TopBot() << ", N of roads = "
+//      << noshowpos << tr.GetNumRoads();
+//  os << oss.str();
+//  return os;
+//}
+
+}; // End of "namespace UtilTrigger"

--- a/packages/UtilAna/TrigRoads.h
+++ b/packages/UtilAna/TrigRoads.h
@@ -27,7 +27,6 @@ class TrigRoads {
   int LoadConfig(const std::string file_name);
 
   std::string str(const int level=0) const;
-  //friend std::ostream& operator<<(std::ostream& os, const TrigRoads& tr);
 };
 
 }; // namespace UtilTrigger

--- a/packages/UtilAna/TrigRoads.h
+++ b/packages/UtilAna/TrigRoads.h
@@ -1,0 +1,35 @@
+#ifndef _TRIG_ROADS__H_
+#define _TRIG_ROADS__H_
+#include <string>
+#include <vector>
+#include <unordered_map>
+#include "TrigRoad.h"
+
+namespace UtilTrigger {
+  
+class TrigRoads {
+  std::string m_file_name;
+  int m_pol; // mu+ = +1, mu- = -1
+  int m_top_bot; // Top = +1, Bottom = -1
+  std::vector<TrigRoad> m_roads;
+  std::unordered_map<int, int> m_idx_map;
+ 
+ public:  
+  TrigRoads(const int pol, const int top_bot); // const std::string file_name
+  virtual ~TrigRoads() {;}
+
+  unsigned int GetNumRoads() const { return m_roads.size(); }
+  TrigRoad* GetRoad(const int idx);
+  TrigRoad* FindRoad(const int road_id);
+
+  int Charge() const { return m_pol; }
+  int TopBot() const { return m_top_bot; }
+  int LoadConfig(const std::string file_name);
+
+  std::string str(const int level=0) const;
+  //friend std::ostream& operator<<(std::ostream& os, const TrigRoads& tr);
+};
+
+}; // namespace UtilTrigger
+
+#endif // _TRIG_ROADS__H_

--- a/packages/UtilAna/TrigRoadset.cc
+++ b/packages/UtilAna/TrigRoadset.cc
@@ -1,0 +1,103 @@
+#include <iostream>
+#include <fstream>
+#include <sstream>
+#include <cstring>
+#include <TSystem.h>
+#include "TrigRoadset.h"
+using namespace std;
+namespace UtilTrigger {
+
+TrigRoadset::TrigRoadset() 
+  : m_dir_conf("")
+  , m_roadset(0)
+  , m_LBTop(0)
+  , m_LBBot(0)
+  , m_pos_top(+1, +1)
+  , m_pos_bot(+1, -1)
+  , m_neg_top(-1, +1)
+  , m_neg_bot(-1, -1)
+{ 
+  ;
+}
+
+int TrigRoadset::LoadConfig(const std::string dir)
+{
+  int ret = 0;
+  ret += m_pos_top.LoadConfig(dir+"/rs_LB_pos_top.txt");
+  ret += m_pos_bot.LoadConfig(dir+"/rs_LB_pos_bot.txt");
+  ret += m_neg_top.LoadConfig(dir+"/rs_LB_neg_top.txt");
+  ret += m_neg_bot.LoadConfig(dir+"/rs_LB_neg_bot.txt");
+  return ret;
+}
+
+int TrigRoadset::LoadConfig(const int roadset_id)
+{
+  m_roadset = roadset_id;
+  ostringstream oss;
+  if (m_dir_conf != "") oss << m_dir_conf;
+  else oss << gSystem->Getenv("E1039_RESOURCE") << "/trigger/rs";
+  oss << "/rs" << roadset_id;
+  return LoadConfig(oss.str());
+}
+
+int TrigRoadset::LoadConfig(const int firmware_LBTop, const int firmware_LBBot)
+{
+  ostringstream oss;
+  oss << gSystem->Getenv("E1039_RESOURCE") << "/trigger/rs/firmware_ctrl.txt";
+  string fn_ctrl = oss.str();
+  //cout << "TrigRoadset::LoadConfig(" << firmware_LBTop << ", " << firmware_LBBot << "): " << fn_ctrl << endl;
+  ifstream ifs(fn_ctrl);
+  if (! ifs) return 1;
+
+  int roadset_id = -1;
+  string buffer;
+  istringstream iss;
+  while (getline(ifs, buffer)) {
+    if (buffer[0] == '#') continue;
+    iss.clear(); // clear any error flags
+    iss.str(buffer);
+
+    int id;
+    string str_top, str_bot;
+    if (! (iss >> id >> str_top >> str_bot)) continue;
+    if (str_top.substr(0, 4) != "0xB0") continue;
+    if (str_bot.substr(0, 4) != "0xB1") continue;
+    int top = stoi(str_top.substr(2), 0, 16);
+    int bot = stoi(str_bot.substr(2), 0, 16);
+    if (top == firmware_LBTop && bot == firmware_LBBot) {
+      roadset_id = id;
+      m_LBTop = top;
+      m_LBBot = bot;
+      break;
+    }
+  }
+  ifs.close();
+  if (roadset_id < 0) return 2;
+  return LoadConfig(roadset_id);
+}
+
+std::string TrigRoadset::str(const int level) const
+{
+  ostringstream oss;
+  oss << m_roadset;
+  if (level > 0) oss << "[" << hex << m_LBTop << "," << m_LBBot << dec << "]";
+  if (level > 1) {
+    oss << "\n  " << m_pos_top.str(level-2)
+        << "\n  " << m_pos_bot.str(level-2)
+        << "\n  " << m_neg_top.str(level-2)
+        << "\n  " << m_neg_bot.str(level-2);
+  }
+  return oss.str();
+}
+
+//std::ostream& operator<<(std::ostream& os, const TrigRoadset& rs)
+//{
+//  os << "Roadset = " << rs.RoadsetID() << ", LBTop = " << hex << rs.LBTop() << ", LBBot = " << rs.LBBot() << dec << "\n"
+//     << "  " << *rs.PosTop() << "\n"
+//     << "  " << *rs.PosBot() << "\n"
+//     << "  " << *rs.NegTop() << "\n"
+//     << "  " << *rs.NegBot() << "\n";
+//  return os;
+//}
+
+}; // End of "namespace UtilTrigger"

--- a/packages/UtilAna/TrigRoadset.cc
+++ b/packages/UtilAna/TrigRoadset.cc
@@ -90,14 +90,4 @@ std::string TrigRoadset::str(const int level) const
   return oss.str();
 }
 
-//std::ostream& operator<<(std::ostream& os, const TrigRoadset& rs)
-//{
-//  os << "Roadset = " << rs.RoadsetID() << ", LBTop = " << hex << rs.LBTop() << ", LBBot = " << rs.LBBot() << dec << "\n"
-//     << "  " << *rs.PosTop() << "\n"
-//     << "  " << *rs.PosBot() << "\n"
-//     << "  " << *rs.NegTop() << "\n"
-//     << "  " << *rs.NegBot() << "\n";
-//  return os;
-//}
-
 }; // End of "namespace UtilTrigger"

--- a/packages/UtilAna/TrigRoadset.h
+++ b/packages/UtilAna/TrigRoadset.h
@@ -4,7 +4,33 @@
 #include "TrigRoads.h"
 
 namespace UtilTrigger {
-  
+
+/// Class to handle the trigger roadset.
+/**
+ * Typical usage:
+ * @code
+ * #include <UtilAna/TrigRoadset.h>
+ * 
+ * UtilTrigger::TrigRoadset m_rs;
+ * 
+ * SQRun* sq_run = findNode::getClass<SQRun>(topNode, "SQRun");
+ * if (!sq_run) return Fun4AllReturnCodes::ABORTEVENT;
+ * int LBtop = sq_run->get_v1495_id(2);
+ * int LBbot = sq_run->get_v1495_id(3);
+ * int ret = m_rs.LoadConfig(LBtop, LBbot);
+ * if (ret != 0) cout << "LoadConfig() returned " << ret << ".\n";
+ * else          cout << "Roadset " << m_rs.str(1) << endl;
+ * 
+ * int road_pos = trk_pos.getTriggerRoad();
+ * int road_neg = trk_neg.getTriggerRoad();
+ * bool pos_top = m_rs.PosTop()->FindRoad(road_pos);
+ * bool pos_bot = m_rs.PosBot()->FindRoad(road_pos);
+ * bool neg_top = m_rs.NegTop()->FindRoad(road_neg);
+ * bool neg_bot = m_rs.NegBot()->FindRoad(road_neg);
+ * cout << "Roads: " << road_pos << " " << road_neg << " "
+ *      << pos_top << pos_bot << neg_top << neg_bot << endl;
+ * @endcode
+ */
 class TrigRoadset {
   std::string m_dir_conf;
   int m_roadset;
@@ -37,7 +63,6 @@ class TrigRoadset {
   int LoadConfig(const int firmware_LBTop, const int firmware_LBBot);
 
   std::string str(const int level=0) const;
-  //friend std::ostream& operator<<(std::ostream& os, const TrigRoadset& rs);
 };
 
 }; // namespace UtilTrigger

--- a/packages/UtilAna/TrigRoadset.h
+++ b/packages/UtilAna/TrigRoadset.h
@@ -1,0 +1,45 @@
+#ifndef _TRIGGER_ROADSET__H_
+#define _TRIGGER_ROADSET__H_
+#include <string>
+#include "TrigRoads.h"
+
+namespace UtilTrigger {
+  
+class TrigRoadset {
+  std::string m_dir_conf;
+  int m_roadset;
+  int m_LBTop;
+  int m_LBBot;
+  TrigRoads m_pos_top;
+  TrigRoads m_pos_bot;
+  TrigRoads m_neg_top;
+  TrigRoads m_neg_bot;
+ 
+ public:  
+  TrigRoadset();
+  virtual ~TrigRoadset() {;}
+
+  int RoadsetID() const { return m_roadset; }
+  int LBTop    () const { return m_LBTop; }
+  int LBBot    () const { return m_LBBot; }
+
+  TrigRoads* PosTop() { return &m_pos_top; }
+  TrigRoads* PosBot() { return &m_pos_bot; }
+  TrigRoads* NegTop() { return &m_neg_top; }
+  TrigRoads* NegBot() { return &m_neg_bot; }
+  const TrigRoads* PosTop() const { return &m_pos_top; }
+  const TrigRoads* PosBot() const { return &m_pos_bot; }
+  const TrigRoads* NegTop() const { return &m_neg_top; }
+  const TrigRoads* NegBot() const { return &m_neg_bot; }
+
+  int LoadConfig(const std::string dir);
+  int LoadConfig(const int roadset_id);
+  int LoadConfig(const int firmware_LBTop, const int firmware_LBBot);
+
+  std::string str(const int level=0) const;
+  //friend std::ostream& operator<<(std::ostream& os, const TrigRoadset& rs);
+};
+
+}; // namespace UtilTrigger
+
+#endif // _TRIGGER_ROADSET__H_


### PR DESCRIPTION
This update is just to add utility classes (`UtilTrigger::TrigRoadset` etc.) that handle the trigger roadset.  A key feature is that `TrigRoadset::LoadConfig()` accepts a roadset ID or a pair of LBTop and LBBot IDs to load the corresponding configuration file under `$E1039_RESOURCE/trigger/rs`.

`DPTriggerAnalyzer` can handle the trigger roadset, but it assumes that the configuration file is in a special line format.  Thus I plan to obsolete it.

`ktracker/TriggerAnalyzer` also can handle the trigger roadset, but is entangled with the tracking code where the trigger is independent of the tracking in principle.  I plan to replace/merge it with `UtilTrigger::TrigRoadset`.

I have confirmed that the updated code can be built fine and works as expected (using `e1039-analysis/RecoData2024`).