### PR TITLE
Fixiation of track chisq_target value

### DIFF
--- a/packages/UtilAna/TrigRoads.cc
+++ b/packages/UtilAna/TrigRoads.cc
@@ -31,6 +31,8 @@ TrigRoad* TrigRoads::FindRoad(const int road_id)
 int TrigRoads::LoadConfig(const std::string file_name)
 {
   //cout << "TrigRoads::LoadConfig(" << file_name << ")\n";
+  m_roads.clear();
+  m_idx_map.clear();
   m_file_name = file_name;
   ifstream ifs(file_name);
   if (! ifs) return 1;

--- a/packages/reco/interface/SRecEvent.h
+++ b/packages/reco/interface/SRecEvent.h
@@ -82,9 +82,10 @@ public:
     virtual void           set_mom_st3(const TLorentzVector a) { throw std::logic_error(__PRETTY_FUNCTION__); }
 
     virtual double get_chisq() const          { return fChisq; }
-    virtual double get_chisq_target() const   { return fChisqVertex; }
+    virtual double get_chisq_target() const   { return fChisqTarget; }
     virtual double get_chisq_dump() const     { return fChisqDump; } 
     virtual double get_chsiq_upstream() const { return fChisqUpstream; } 
+    virtual double get_chisq_upstream() const { return fChisqUpstream; } 
 
     virtual TVector3 get_pos_target() const   { return fTargetPos; }
     virtual TVector3 get_pos_dump() const     { return fDumpPos; }


### PR DESCRIPTION
This update is mainly to fix the return value of `SRecTrack::get_chisq_target()`, which was chi2_vertex by mistake.

I also added `SRecTrack::get_chisq_upstream()`, where the name of the existing accessor is not right (`chsiq`).  The typo exists in the parent class (`SQTrack`), and it is too much for me to correct all this time.

In addition I modified `TrigRoads::LoadConfig()` to clear the member variables.  I found this necessary since we might load the roadset twice or more.