### PR TITLE
Control option for hit-level hodo masking in KalmanFastTracking

### DIFF
--- a/framework/phool/recoConsts.cc
+++ b/framework/phool/recoConsts.cc
@@ -53,6 +53,7 @@ void recoConsts::set_defaults()
   set_BoolFlag("MC_MODE", false);
   set_BoolFlag("COSMIC_MODE", false);
   set_BoolFlag("REQUIRE_MUID", true);
+  set_CharFlag("HIT_MASK_MODE", "AUTO");
 
   set_BoolFlag("TARGETONLY", false);
   set_BoolFlag("DUMPONLY", false);

--- a/packages/reco/interface/SRawEvent.cxx
+++ b/packages/reco/interface/SRawEvent.cxx
@@ -80,7 +80,7 @@ bool Hit::operator==(const Hit& elem) const
     return false;
 }
 
-SRawEvent::SRawEvent() : fRunID(-1), fEventID(-1), fSpillID(-1), fTriggerBits(-1), fTriggerEmu(-1)
+SRawEvent::SRawEvent() : fRunID(-1), fEventID(-1), fSpillID(-1), fTriggerBits(0), fTriggerEmu(-1)
 {
     fAllHits.clear();
     fTriggerHits.clear();

--- a/packages/reco/ktracker/KalmanFastTracking.h
+++ b/packages/reco/ktracker/KalmanFastTracking.h
@@ -34,7 +34,7 @@ class PHTimer;
 class KalmanFastTracking
 {
 public:
-    explicit KalmanFastTracking(const PHField* field, const TGeoManager *geom, bool flag = true);
+  explicit KalmanFastTracking(const PHField* field, const TGeoManager *geom, bool flag = true, const int verb=0);
     virtual ~KalmanFastTracking();
 
     //set/get verbosity

--- a/packages/reco/ktracker/KalmanFastTrackletting.cxx
+++ b/packages/reco/ktracker/KalmanFastTrackletting.cxx
@@ -6,8 +6,8 @@
 #include "KalmanFastTrackletting.h"
 using namespace std;
 
-KalmanFastTrackletting::KalmanFastTrackletting(const PHField* field, const TGeoManager* geom, bool flag)
-  : KalmanFastTracking(field, geom, flag)
+KalmanFastTrackletting::KalmanFastTrackletting(const PHField* field, const TGeoManager* geom, bool flag, const int verb)
+  : KalmanFastTracking(field, geom, flag, verb)
 {
   recoConsts* rc = recoConsts::instance();
   TX_MAX = rc->get_DoubleFlag("TX_MAX");

--- a/packages/reco/ktracker/KalmanFastTrackletting.h
+++ b/packages/reco/ktracker/KalmanFastTrackletting.h
@@ -10,7 +10,7 @@ class KalmanFastTrackletting : public KalmanFastTracking
   double Y0_MAX;
 
 public:
-    explicit KalmanFastTrackletting(const PHField* field, const TGeoManager *geom, bool flag = true);
+  explicit KalmanFastTrackletting(const PHField* field, const TGeoManager *geom, bool flag=true, const int verb=0);
     virtual ~KalmanFastTrackletting();
 
     virtual int setRawEvent(SRawEvent* event_input);

--- a/packages/reco/ktracker/SQReco.cxx
+++ b/packages/reco/ktracker/SQReco.cxx
@@ -165,15 +165,7 @@ int SQReco::InitRun(PHCompositeNode* topNode)
 
 int SQReco::InitField(PHCompositeNode* topNode)
 {
-  if(Verbosity() > 1)
-  {
-    std::cout << "SQReco::InitField" << std::endl;
-    if(!_enable_KF)
-    {
-      std::cout << " KF is disabled thus phfield is not needed. Skip InitField for SQReco." << std::endl;
-      return Fun4AllReturnCodes::EVENT_OK;
-    }
-  }
+  if(Verbosity() > 1) std::cout << "SQReco::InitField" << std::endl;
 
   std::unique_ptr<PHFieldConfig> default_field_cfg(new PHFieldConfig_v3(rc->get_CharFlag("fMagFile"), rc->get_CharFlag("kMagFile"), rc->get_DoubleFlag("FMAGSTR"), rc->get_DoubleFlag("KMAGSTR"), 5.));
   _phfield = PHFieldUtility::GetFieldMapNode(default_field_cfg.get(), topNode, 0);
@@ -192,15 +184,7 @@ int SQReco::InitField(PHCompositeNode* topNode)
 
 int SQReco::InitGeom(PHCompositeNode* topNode)
 {
-  if(Verbosity() > 1) 
-  {
-    std::cout << "SQReco::InitGeom" << std::endl;
-    if(!_enable_KF)
-    {
-      std::cout << " KF is disabled thus TGeo is not needed. Skip InitGeom for SQReco." << std::endl;
-      return Fun4AllReturnCodes::EVENT_OK;
-    }
-  }
+  if(Verbosity() > 1) std::cout << "SQReco::InitGeom" << std::endl;
 
   if (_geom_file_name != "")
   {
@@ -240,10 +224,7 @@ int SQReco::InitGeom(PHCompositeNode* topNode)
 
 int SQReco::InitFastTracking()
 {
-  _fastfinder = new KalmanFastTracking(_phfield, _t_geo_manager, false);
-
-  _fastfinder->Verbosity(Verbosity());
-
+  _fastfinder = new KalmanFastTracking(_phfield, _t_geo_manager, false, Verbosity());
   if (_output_list_idx > 0) _fastfinder->setOutputListIndex(_output_list_idx);
   return 0;
 }

--- a/packages/reco/ktracker/SQTrackletReco.cxx
+++ b/packages/reco/ktracker/SQTrackletReco.cxx
@@ -59,10 +59,7 @@ int SQTrackletReco::process_event(PHCompositeNode* topNode)
  */
 int SQTrackletReco::InitFastTracking()
 {
-  _fastfinder = new KalmanFastTrackletting(_phfield, _t_geo_manager, false);
-
-  _fastfinder->Verbosity(Verbosity());
-
+  _fastfinder = new KalmanFastTrackletting(_phfield, _t_geo_manager, false, Verbosity());
   if (_output_list_idx >= 0) _fastfinder->setOutputListIndex(_output_list_idx);
   return 0;
 }


### PR DESCRIPTION
This update is mainly to add a constant to `recoConsts` to control the hit-level hodo masking in `KalmanFastTracking`.

The new constant, `HIT_MASK_MODE`, is `AUTO` by default, which keeps the original behavior of the hit-level hodo masking, namely X-hodo hits are used when `MC_MODE` is true, `COSMIC_MODE` is true or event is triggered by FPGA.

When it is set to `X`, `Y` or `XY`, the specified hodo plane is always used.  When it is set to `NONE`, the hit-level hodo masking is disabled.

A new (4th) argument was added to the constructor of `KalmanFastTracking` in order to change the verbosity in the constructor.

The default value of `SRawEvent::fTriggerBits` was changed from `-1` to `0`, because `-1` means all bits are `1` by default, which seemed strange.  Indeed it had caused a problem as `SRawEvent::SetTriggerBits()` hadn't changed bit from `1` to `0`.