### PR TITLE
New SQVertexing package to (hopefully) handle dimuon vertexing correctly

### DIFF
--- a/framework/phool/recoConsts.cc
+++ b/framework/phool/recoConsts.cc
@@ -163,7 +163,7 @@ void recoConsts::set_defaults()
   set_DoubleFlag("FMAG_HOLE_LENGTH", 27.94);
   set_DoubleFlag("FMAG_HOLE_RADIUS", 1.27);
   set_DoubleFlag("FMAG_LENGTH", 502.92);
-  set_DoubleFlag("Z_UPSTREAM", -500.);
+  set_DoubleFlag("Z_UPSTREAM", -700.);
   set_DoubleFlag("Z_DOWNSTREAM", 500.);
 }
 

--- a/packages/reco/SQGenFit/GFField.cxx
+++ b/packages/reco/SQGenFit/GFField.cxx
@@ -6,7 +6,10 @@
 
 namespace SQGenFit
 {
-GFField::GFField(const PHField* field): _field(field)
+GFField::GFField(const PHField* field): 
+  _field(field),
+  _scale(1.),
+  _offset(0.) 
 {
   _scale = 1.;
   _disable = false;
@@ -34,7 +37,7 @@ void GFField::get(const double& x, const double& y, const double& z, double& Bx,
     return;
   }
 
-  const double Point[] = {x*CLHEP::cm, y*CLHEP::cm, z*CLHEP::cm, 0.};
+  const double Point[] = {x*CLHEP::cm, y*CLHEP::cm, (z + _offset)*CLHEP::cm, 0.};
   double Bfield[6];
   for(int i = 0; i < 6; ++i)
   {

--- a/packages/reco/SQGenFit/GFField.h
+++ b/packages/reco/SQGenFit/GFField.h
@@ -17,12 +17,14 @@ public:
   TVector3 get(const TVector3& pos) const;
   void get(const double& posX, const double& posY, const double& posZ, double& Bx, double& By, double& Bz) const;
 
-  void setScale(double scale) { _scale = scale; }
+  void setScale(double scale   = 1.) { _scale = scale; }
+  void setOffset(double offset = 0.) { _offset = offset; }
   void disable() { _disable = true; }
 
 private:
   const PHField* _field;
   double _scale;
+  double _offset;
   bool   _disable;
 
 };

--- a/packages/reco/SQGenFit/GFTrack.cxx
+++ b/packages/reco/SQGenFit/GFTrack.cxx
@@ -422,15 +422,6 @@ SRecTrack GFTrack::getSRecTrack()
   strack.swimToVertex(nullptr, nullptr, false);
 
   //Hypothesis test should be implemented here
-  TVector3 pO(0., 0., Z_UPSTREAM);
-  TVector3 pU(1., 0., 0.);
-  TVector3 pV(0., 1., 0.);
-  TVectorD beamCenter(2);
-  beamCenter[0] = X_BEAM; beamCenter[1] = Y_BEAM; 
-  TMatrixDSym beamCov(2);
-  beamCov.Zero();
-  beamCov(0, 0) = SIGX_BEAM*SIGX_BEAM; beamCov(1, 1) = SIGY_BEAM*SIGY_BEAM;
-
   //test Z_UPSTREAM
   strack.setChisqUpstream(swimToVertex(Z_UPSTREAM));
 
@@ -461,7 +452,10 @@ SRecTrack GFTrack::getSRecTrack()
   */
 
   //test Z_VERTEX
-  strack.setChisqVertex(swimToVertex(strack.getVertexPos().Z()));
+  TVector3 pos, mom;
+  strack.setChisqVertex(swimToVertex(strack.getVertexPos().Z(), &pos, &mom));
+  strack.setVertexPos(pos);
+  strack.setVertexMom(mom);
 
   strack.setKalmanStatus(1);
   return strack;

--- a/packages/reco/interface/SRecEvent.cxx
+++ b/packages/reco/interface/SRecEvent.cxx
@@ -608,6 +608,23 @@ void SRecDimuon::calcVariables(int choice)
         pos = p_pos_dump;
         neg = p_neg_dump;
     }
+    else
+    {
+        std::cout << "ERROR!!! In SRecDimuon::calcVariables(choice), only three dimuon vertex choice numbers are provided - ";
+        std::cout << " 0 (default) = fitted vertex position, 1 = target position, 2 = dump position" << std::endl;
+        
+        //Unphysical error values
+        mass = -1.;
+        xF = -10.;
+        x1 = -10.;
+        x2 = -10.;
+        pT = -1.;
+        costh = -10.;
+        phi = -10.;
+        mass_single = -1.;
+
+        return;
+    }
 
     Double_t mp = 0.938;
     Double_t ebeam = 120.;

--- a/packages/reco/interface/SRecEvent.cxx
+++ b/packages/reco/interface/SRecEvent.cxx
@@ -590,8 +590,25 @@ void SRecTrack::print(std::ostream& os) const
   os << "Chi square at vertex: " << fChisqVertex << std::endl;
 }
 
-void SRecDimuon::calcVariables()
+void SRecDimuon::calcVariables(int choice)
 {
+    TLorentzVector pos, neg;
+    if(choice == 0)
+    {
+        pos = p_pos;
+        neg = p_neg;
+    }
+    else if(choice == 1)
+    {
+        pos = p_pos_target;
+        neg = p_neg_target;
+    }
+    else if(choice == 2)
+    {
+        pos = p_pos_dump;
+        neg = p_neg_dump;
+    }
+
     Double_t mp = 0.938;
     Double_t ebeam = 120.;
 
@@ -599,7 +616,7 @@ void SRecDimuon::calcVariables()
     TLorentzVector p_target(0., 0., 0., mp);
 
     TLorentzVector p_cms = p_beam + p_target;
-    TLorentzVector p_sum = p_pos + p_neg;
+    TLorentzVector p_sum = pos + neg;
 
     mass = p_sum.M();
     pT = p_sum.Perp();
@@ -612,8 +629,8 @@ void SRecDimuon::calcVariables()
     p_sum.Boost(-bv_cms);
     xF = 2.*p_sum.Pz()/TMath::Sqrt(s)/(1. - mass*mass/s);
 
-    costh = 2.*(p_neg.E()*p_pos.Pz() - p_pos.E()*p_neg.Pz())/mass/sqrt(mass*mass + pT*pT);
-    phi = atan2(2.*sqrt(mass*mass + pT*pT)*(p_neg.X()*p_pos.Y() - p_pos.X()*p_neg.Y()), mass*(p_pos.X()*p_pos.X() - p_neg.X()*p_neg.X() + p_pos.Y()*p_pos.Y() - p_neg.Y()*p_neg.Y()));
+    costh = 2.*(p_neg.E()*pos.Pz() - pos.E()*neg.Pz())/mass/sqrt(mass*mass + pT*pT);
+    phi = atan2(2.*sqrt(mass*mass + pT*pT)*(neg.X()*pos.Y() - pos.X()*neg.Y()), mass*(pos.X()*pos.X() - neg.X()*neg.X() + pos.Y()*pos.Y() - neg.Y()*neg.Y()));
     mass_single = (p_pos_single + p_neg_single).M();
 }
 

--- a/packages/reco/interface/SRecEvent.h
+++ b/packages/reco/interface/SRecEvent.h
@@ -343,8 +343,8 @@ public:
     //Get the total momentum of the virtual photon
     TLorentzVector getVPhoton() { return p_pos + p_neg; }
 
-    //Calculate the kinematic vairables
-    void calcVariables();
+    //Calculate the kinematic vairables, 0 = vertex, 1 = target, 2 = dump
+    void calcVariables(int choice = 0);
 
     //Dimuon quality cut
     //bool isValid();
@@ -362,6 +362,12 @@ public:
     //4-momentum of the muon tracks after vertex fit
     TLorentzVector p_pos;
     TLorentzVector p_neg;
+
+    //Track momentum projections at different location
+    TLorentzVector p_pos_target;
+    TLorentzVector p_neg_target;
+    TLorentzVector p_pos_dump;
+    TLorentzVector p_neg_dump;
 
     //4-momentum of the muon tracks before vertex fit
     TLorentzVector p_pos_single;
@@ -398,7 +404,7 @@ public:
     Double_t chisq_dump;
     Double_t chisq_upstream;
 
-    ClassDef(SRecDimuon, 6)
+    ClassDef(SRecDimuon, 7)
 };
 
 class SRecEvent: public PHObject

--- a/packages/reco/interface/SRecEvent.h
+++ b/packages/reco/interface/SRecEvent.h
@@ -181,7 +181,7 @@ public:
     Double_t getVtxPar(Int_t i) { return fVertexPos[i]; }
     Double_t getChisqVertex() { return fChisqVertex; }
 
-    //Get mom/pos at a given location
+    ///Get mom/pos at a given location
     TVector3 getDumpPos() { return fDumpPos; }
     TVector3 getDumpFacePos() { return fDumpFacePos; }
     TVector3 getTargetPos() { return fTargetPos; }
@@ -198,7 +198,7 @@ public:
     Double_t getChisqTarget() { return fChisqTarget; }
     Double_t getChisqUpstream() { return fChisqUpstream; }
 
-    //Set mom/pos at a given location
+    ///Set mom/pos at a given location
     void setDumpPos(TVector3 pos) { fDumpPos = pos; }
     void setDumpFacePos(TVector3 pos) { fDumpFacePos = pos; }
     void setTargetPos(TVector3 pos) { fTargetPos = pos; }
@@ -216,11 +216,11 @@ public:
     void setChisqUpstream(Double_t chisq) { fChisqUpstream = chisq; }
     void setChisqVertex(Double_t chisq) { fChisqVertex = chisq; }
 
-    //Trigger road info
+    ///Trigger road info
     void setTriggerRoad(Int_t roadID) { fTriggerID = roadID; }
     Int_t getTriggerRoad() { return fTriggerID; }
 
-    //Prop. tube muon ID info
+    ///Prop. tube muon ID info
     void setPTSlope(Double_t slopeX, Double_t slopeY) { fPropSlopeX = slopeX; fPropSlopeY = slopeY; }
     void setNHitsInPT(Int_t nHitsX, Int_t nHitsY) { fNPropHitsX = nHitsX; fNPropHitsY = nHitsY; }
     Double_t getPTSlopeX() { return fPropSlopeX; }
@@ -230,7 +230,7 @@ public:
     Int_t getNHitsInPTX() { return fNPropHitsX; }
     Int_t getNHitsInPTY() { return fNPropHitsY; }
 
-    //Overall track quality cut
+    ///Overall track quality cut
     //bool isValid();
     bool isTarget();
     bool isDump();
@@ -281,12 +281,12 @@ private:
     Double_t fPropSlopeX;
     Double_t fPropSlopeY;
 
-    //Chisq of three test position
+    ///Chisq of three test position
     Double_t fChisqTarget;
     Double_t fChisqDump;
     Double_t fChisqUpstream;
 
-    //GenFit track info - only available if the track comes from GF fitter
+    ///GenFit track info - only available if the track comes from GF fitter
     std::vector<TVector3> fGFDetPlaneVec[3];
     std::vector<TVectorD> fGFAuxInfo;
     std::vector<TVectorD> fGFStateVec;
@@ -305,7 +305,7 @@ public:
     int          isValid() const;
     SRecDimuon*  Clone() const { return (new SRecDimuon(*this)); }
 
-    //SQDimuon virtual functions
+    /// SQDimuon virtual functions
     virtual int  get_dimuon_id() const      { return 0; }
     virtual void set_dimuon_id(const int a) { throw std::logic_error(__PRETTY_FUNCTION__); }
 
@@ -340,51 +340,51 @@ public:
 
     virtual double get_chisq() const { return chisq_kf; }
 
-    //Get the total momentum of the virtual photon
+    /// Get the total momentum of the virtual photon
     TLorentzVector getVPhoton() { return p_pos + p_neg; }
 
-    //Calculate the kinematic vairables, 0 = vertex, 1 = target, 2 = dump
+    /// Calculate the kinematic vairables, 0 = vertex, 1 = target, 2 = dump
     void calcVariables(int choice = 0);
 
     //Dimuon quality cut
     //bool isValid();
 
-    //Target dimuon
+    /// Target dimuon
     bool isTarget();
 
-    //Dump dimuon
+    /// Dump dimuon
     bool isDump();
 
-    //Index of muon track used in host SRecEvent
+    /// Index of muon track used in host SRecEvent
     Int_t trackID_pos;
     Int_t trackID_neg;
 
-    //4-momentum of the muon tracks after vertex fit
+    /// 4-momentum of the muon tracks after vertex fit
     TLorentzVector p_pos;
     TLorentzVector p_neg;
 
-    //Track momentum projections at different location
+    /// Track momentum projections at different location
     TLorentzVector p_pos_target;
     TLorentzVector p_neg_target;
     TLorentzVector p_pos_dump;
     TLorentzVector p_neg_dump;
 
-    //4-momentum of the muon tracks before vertex fit
+    /// 4-momentum of the muon tracks before vertex fit
     TLorentzVector p_pos_single;
     TLorentzVector p_neg_single;
 
-    //3-vector vertex position
+    /// 3-vector vertex position
     TVector3 vtx;
     TVector3 vtx_pos;
     TVector3 vtx_neg;
 
-    //Track projections at different location
+    /// Track projections at different location
     TVector3 proj_target_pos;
     TVector3 proj_dump_pos;
     TVector3 proj_target_neg;
     TVector3 proj_dump_neg;
 
-    //Kinematic variables
+    /// Kinematic variables
     Double_t mass;
     Double_t pT;
     Double_t xF;
@@ -395,11 +395,11 @@ public:
     Double_t mass_single;
     Double_t chisq_single;
 
-    //Vertex fit chisqs
+    /// Vertex fit chisqs
     Double_t chisq_kf;
     Double_t chisq_vx;
 
-    //Chisq of three test position
+    /// Chisq of three test position
     Double_t chisq_target;
     Double_t chisq_dump;
     Double_t chisq_upstream;
@@ -444,7 +444,7 @@ public:
 
     Int_t getLocalID(Int_t hitID) { return fLocalID[hitID]; }
 
-    //Event source set/get
+    ///Event source set/get
     void setEventSource(Int_t id1, Int_t id2) { fSource1 = id1; fSource2 = id2; }
     Int_t getSourceID1() { return fSource1; }
     Int_t getSourceID2() { return fSource2; }

--- a/packages/reco/ktracker/SQVertexing.cxx
+++ b/packages/reco/ktracker/SQVertexing.cxx
@@ -191,10 +191,9 @@ double SQVertexing::refitTrkToVtx(SQGenFit::GFTrack& track, double z, TVector3* 
     chi2 = swimTrackToVertex(track, z, pos, mom);
 
     //update scatter plane location
-    //std::cout << " 1 " << z_offset_prev << "  " << z_offset_curr << "  " << mom->Mag() << "   " <<  chi2 << std::endl;
     z_offset_prev = z_offset_curr;
     z_offset_curr = calcZsclp(mom->Mag());
-    //std::cout << " 2 " << z_offset_prev << "  " << z_offset_curr << "  " << mom->Mag() << "   " <<  chi2 << std::endl;
+  
     gfield->setOffset(-z_offset_curr);
   }
 
@@ -229,6 +228,7 @@ bool SQVertexing::processOneDimuon(SRecTrack* track1, SRecTrack* track2, SRecDim
   dimuon.vtx.SetXYZ(0., 0., z_vtx);
 
   //Vertex info based on the dimuon vertex
+  //TODO: consider using addjustable bend-plane for vertex test as well
   TVector3 pos, mom;
   dimuon.chisq_kf = swimTrackToVertex(gtrk1, z_vtx, &pos, &mom);
   dimuon.p_pos.SetVectM(mom, M_MU);
@@ -245,6 +245,7 @@ bool SQVertexing::processOneDimuon(SRecTrack* track1, SRecTrack* track2, SRecDim
   dimuon.p_neg_target.SetVectM(mom, M_MU);
 
   //Test dump hypothesis
+  //TODO: consider using addjustable bend-plane for dump test as well
   swimTrackToVertex(gtrk1, Z_DUMP, &pos, &mom);
   dimuon.p_pos_dump.SetVectM(mom, M_MU);
   swimTrackToVertex(gtrk2, Z_DUMP, &pos, &mom);
@@ -256,6 +257,7 @@ bool SQVertexing::processOneDimuon(SRecTrack* track1, SRecTrack* track2, SRecDim
 
 double SQVertexing::findDimuonZVertex(SRecDimuon& dimuon, SQGenFit::GFTrack& track1, SQGenFit::GFTrack& track2)
 {
+  //TODO: consider using addjustable bend-plane for vertex finding as well
   double stepsize[3] = {25., 5., 1.};
 
   double z_min = 200.;

--- a/packages/reco/ktracker/SQVertexing.cxx
+++ b/packages/reco/ktracker/SQVertexing.cxx
@@ -93,6 +93,7 @@ int SQVertexing::process_event(PHCompositeNode* topNode)
   for(int i = 0; i < nTracks; ++i)
   {
     SRecTrack* recTrack = legacyContainer ? &(recEvent->getTrack(i)) : dynamic_cast<SRecTrack*>(recTrackVec->at(i));
+    if(!recTrack->isKalmanFitted()) continue;
 
     if(recTrack->getCharge() == charge1) trackIDs1.push_back(i);
     if(recTrack->getCharge() == charge2) trackIDs2.push_back(i);
@@ -205,8 +206,7 @@ double SQVertexing::refitTrkToVtx(SQGenFit::GFTrack& track, double z, TVector3* 
 
 double SQVertexing::calcZsclp(double p)
 {
-  //return 293.745 - 0.716984*p + 0.00841544*p*p - 3.44278e-05*p*p*p - 271.;
-  return 301.84 - 1.27137*p + 0.0218294*p*p - 0.000170711*p*p*p + 4.94683e-07*p*p*p*p - 271.;
+  return 301.84 - 1.27137*p + 0.0218294*p*p - 0.000170711*p*p*p + 4.94683e-07*p*p*p*p - 266.;
 }
 
 bool SQVertexing::processOneDimuon(SRecTrack* track1, SRecTrack* track2, SRecDimuon& dimuon)

--- a/packages/reco/ktracker/SQVertexing.cxx
+++ b/packages/reco/ktracker/SQVertexing.cxx
@@ -235,7 +235,7 @@ double SQVertexing::refitTrkToVtx(SRecTrack* track, double z, TVector3* pos, TVe
 
 double SQVertexing::calcZsclp(double p)
 {
-  return 301.84 - 1.27137*p + 0.0218294*p*p - 0.000170711*p*p*p + 4.94683e-07*p*p*p*p - 266.;
+  return 301.84 - 1.27137*p + 0.0218294*p*p - 0.000170711*p*p*p + 4.94683e-07*p*p*p*p - 271.;
 }
 
 bool SQVertexing::processOneDimuon(SRecTrack* track1, SRecTrack* track2, SRecDimuon& dimuon)

--- a/packages/reco/ktracker/SQVertexing.cxx
+++ b/packages/reco/ktracker/SQVertexing.cxx
@@ -100,8 +100,6 @@ int SQVertexing::process_event(PHCompositeNode* topNode)
   }
   if(trackIDs1.empty() || trackIDs2.empty()) return Fun4AllReturnCodes::EVENT_OK;
 
-  recEvent->identify();
-
   for(int i = 0; i < trackIDs1.size(); ++i)
   {
     for(int j = charge1 == charge2 ? i+1 : 0; j < trackIDs2.size(); ++j)

--- a/packages/reco/ktracker/SQVertexing.cxx
+++ b/packages/reco/ktracker/SQVertexing.cxx
@@ -1,0 +1,268 @@
+#include "SQVertexing.h"
+
+#include <fun4all/Fun4AllReturnCodes.h>
+#include <phool/PHNodeIterator.h>
+#include <phool/PHIODataNode.h>
+#include <phool/PHRandomSeed.h>
+#include <phool/getClass.h>
+#include <phool/recoConsts.h>
+#include <interface_main/SQTrack_v1.h>
+#include <interface_main/SQDimuon_v1.h>
+#include <interface_main/SQTrackVector_v1.h>
+#include <interface_main/SQDimuonVector_v1.h>
+#include <GenFit/FieldManager.h>
+
+#include "SRecEvent.h"
+#include "GFTrack.h"
+
+#include <iostream>
+#include <vector>
+
+namespace
+{
+  //static flag to indicate the initialized has been done
+  static bool inited = false;
+
+  static double Z_TARGET;
+  static double Z_DUMP;
+  static double Z_UPSTREAM;
+
+  static double X_BEAM;
+  static double Y_BEAM;
+  static double SIGX_BEAM;
+  static double SIGY_BEAM;
+
+  //initialize global variables
+  void initGlobalVariables()
+  {
+    if(!inited) 
+    {
+      inited = true;
+
+      recoConsts* rc = recoConsts::instance();
+      Z_TARGET   = rc->get_DoubleFlag("Z_TARGET");
+      Z_DUMP     = rc->get_DoubleFlag("Z_DUMP");
+      Z_UPSTREAM = rc->get_DoubleFlag("Z_UPSTREAM");
+
+      X_BEAM    = rc->get_DoubleFlag("X_BEAM");
+      Y_BEAM    = rc->get_DoubleFlag("Y_BEAM");
+      SIGX_BEAM = rc->get_DoubleFlag("SIGX_BEAM");
+      SIGY_BEAM = rc->get_DoubleFlag("SIGY_BEAM");
+    }
+  }
+};
+
+SQVertexing::SQVertexing(const std::string& name, int sign1, int sign2):
+  SubsysReco(name),
+  legacyContainer(false),
+  gfield(nullptr),
+  recEvent(nullptr),
+  recTrackVec(nullptr),
+  recDimuonVec(nullptr),
+  charge1(sign1),
+  charge2(sign2)
+{}
+
+SQVertexing::~SQVertexing()
+{}
+
+int SQVertexing::Init(PHCompositeNode* topNode)
+{
+  initGlobalVariables();
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int SQVertexing::InitRun(PHCompositeNode* topNode)
+{
+  int ret = GetNodes(topNode);
+  if(ret != Fun4AllReturnCodes::EVENT_OK) return ret;
+
+  ret = MakeNodes(topNode);
+  if(ret != Fun4AllReturnCodes::EVENT_OK) return ret;
+
+  gfield = dynamic_cast<SQGenFit::GFField*>(genfit::FieldManager::getInstance()->getField());
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int SQVertexing::process_event(PHCompositeNode* topNode)
+{
+  std::vector<int> trackIDs1;
+  std::vector<int> trackIDs2;
+  int nTracks = legacyContainer ? recEvent->getNTracks() : recTrackVec->size();
+  for(int i = 0; i < nTracks; ++i)
+  {
+    SRecTrack* recTrack = legacyContainer ? &(recEvent->getTrack(i)) : dynamic_cast<SRecTrack*>(recTrackVec->at(i));
+
+    if(recTrack->getCharge() == charge1) trackIDs1.push_back(i);
+    if(recTrack->getCharge() == charge2) trackIDs2.push_back(i);
+   
+  }
+  if(trackIDs1.empty() || trackIDs2.empty()) return Fun4AllReturnCodes::EVENT_OK;
+
+  recEvent->identify();
+
+  for(int i = 0; i < trackIDs1.size(); ++i)
+  {
+    for(int j = charge1 == charge2 ? i+1 : 0; j < trackIDs2.size(); ++j)
+    {
+      //A protection, probably not really needed
+      if(trackIDs1[i] == trackIDs2[j]) continue;
+
+      SRecTrack* recTrack1 = legacyContainer ? &(recEvent->getTrack(trackIDs1[i])) : dynamic_cast<SRecTrack*>(recTrackVec->at(trackIDs1[i]));
+      SRecTrack* recTrack2 = legacyContainer ? &(recEvent->getTrack(trackIDs2[j])) : dynamic_cast<SRecTrack*>(recTrackVec->at(trackIDs2[j]));
+
+      SRecDimuon recDimuon;
+      if(processOneDimuon(recTrack1, recTrack2, recDimuon))
+      {
+        //recDimuon.set_rec_dimuon_id(legacyContainer ? recEvent->getNDimuons() : recDimuonVec->size());
+        recDimuon.set_track_id_pos(trackIDs1[i]);
+        recDimuon.set_track_id_neg(trackIDs2[j]);
+
+        if(legacyContainer)
+          recEvent->insertDimuon(recDimuon);
+        else
+          recDimuonVec->push_back(&recDimuon);
+      }
+    }
+  }
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int SQVertexing::End(PHCompositeNode* topNode)
+{
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int SQVertexing::GetNodes(PHCompositeNode* topNode)
+{
+  if(legacyContainer)
+  {
+    recEvent = findNode::getClass<SRecEvent>(topNode, "SRecEvent");
+  }
+  else
+  {
+    recTrackVec = findNode::getClass<SQTrackVector>(topNode, "SQRecTrackVector");
+  }
+
+  if((!recEvent) && (!recTrackVec))
+  {
+    std::cerr << Name() << ": failed finding rec track info, abort." << std::endl;
+    return Fun4AllReturnCodes::ABORTRUN;
+  }
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int SQVertexing::MakeNodes(PHCompositeNode* topNode)
+{
+  if(!legacyContainer)
+  {
+    PHNodeIterator iter(topNode);
+    PHCompositeNode* dstNode = static_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "DST"));
+    if(!dstNode) 
+    {
+      std::cerr << Name() << ": cannot locate DST node, abort." << std::endl;
+      return Fun4AllReturnCodes::ABORTEVENT;
+    }
+
+    recDimuonVec = new SQDimuonVector_v1();
+    TString dimuonVecName = TString::Format("SQRecDimuonVector_%s%s", (charge1 == 1 ? "P" : "M"), (charge2 == 1 ? "P" : "M"));
+    dstNode->addNode(new PHIODataNode<PHObject>(recDimuonVec, dimuonVecName.Data(), "PHObject"));
+  }
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+double SQVertexing::swimTrackToVertex(SQGenFit::GFTrack& track, double z, TVector3* pos, TVector3* mom)
+{
+  //TODO: adjust FMag bend plan here
+  //gfield->setOffset(xxx);
+
+  double chi2 = track.swimToVertex(z, pos, mom);
+  if(chi2 < 0.) return chi2;
+
+  //TODO: re-adjust FMag bend plane here
+  //gfield->setOffset(-xxx);
+
+  return chi2;
+}
+
+bool SQVertexing::processOneDimuon(SRecTrack* track1, SRecTrack* track2, SRecDimuon& dimuon)
+{
+  //Pre-calculated variables
+  dimuon.proj_target_pos = track1->getTargetPos();
+  dimuon.proj_dump_pos   = track1->getDumpPos();
+  dimuon.proj_target_neg = track2->getTargetPos();
+  dimuon.proj_dump_neg   = track2->getDumpPos();
+  dimuon.chisq_target    = track1->getChisqTarget() + track2->getChisqTarget();
+  dimuon.chisq_dump      = track1->getChisqDump() + track2->getChisqDump();
+  dimuon.chisq_upstream  = track1->getChisqUpstream() + track2->getChisqUpstream();
+  dimuon.chisq_single    = 0.;  //no longer used
+  dimuon.chisq_vx        = 0.;  //no longer used
+
+  //Vertexing part
+  SQGenFit::GFTrack gtrk1(*track1);
+  SQGenFit::GFTrack gtrk2(*track2);
+  double z_vtx = findDimuonZVertex(dimuon, gtrk1, gtrk2);
+  dimuon.vtx.SetXYZ(0., 0., z_vtx);
+
+  //Vertex info based on the dimuon vertex
+  TVector3 pos, mom;
+  dimuon.chisq_kf = swimTrackToVertex(gtrk1, z_vtx, &pos, &mom);
+  dimuon.p_pos.SetVectM(mom, M_MU);
+  dimuon.vtx_pos = pos;
+
+  dimuon.chisq_kf += swimTrackToVertex(gtrk2, z_vtx, &pos, &mom);
+  dimuon.p_neg.SetVectM(mom, M_MU);
+  dimuon.vtx_neg = pos;
+
+  //Test target hypothesis
+  swimTrackToVertex(gtrk1, Z_TARGET, &pos, &mom);
+  dimuon.p_pos_target.SetVectM(mom, M_MU);
+  swimTrackToVertex(gtrk2, Z_TARGET, &pos, &mom);
+  dimuon.p_neg_target.SetVectM(mom, M_MU);
+
+  //Test dump hypothesis
+  swimTrackToVertex(gtrk1, Z_DUMP, &pos, &mom);
+  dimuon.p_pos_dump.SetVectM(mom, M_MU);
+  swimTrackToVertex(gtrk2, Z_DUMP, &pos, &mom);
+  dimuon.p_neg_dump.SetVectM(mom, M_MU);
+  
+  dimuon.calcVariables();
+  return true;
+}
+
+double SQVertexing::findDimuonZVertex(SRecDimuon& dimuon, SQGenFit::GFTrack& track1, SQGenFit::GFTrack& track2)
+{
+  double stepsize[3] = {25., 5., 1.};
+
+  double z_min = 200.;
+  double chi2_min = 1.E9;
+  for(int i = 0; i < 3; ++i)
+  {
+    double z_start, z_end;
+    if(i == 0)
+    {
+      z_start = 200.;
+      z_end   = Z_UPSTREAM;
+    }
+    else
+    {
+      z_start = z_min + stepsize[i-1];
+      z_end   = z_min - stepsize[i-1];
+    }
+
+    for(double z = z_start; z > z_end; z = z - stepsize[i])
+    {
+      double chi2 = swimTrackToVertex(track1, z) + swimTrackToVertex(track2, z);
+      if(chi2 < chi2_min)
+      {
+        z_min = z;
+        chi2_min = chi2;
+      }
+    }
+  }
+
+  return z_min;
+}

--- a/packages/reco/ktracker/SQVertexing.h
+++ b/packages/reco/ktracker/SQVertexing.h
@@ -33,7 +33,9 @@ private:
   int GetNodes(PHCompositeNode* topNode);
 
   double swimTrackToVertex(SQGenFit::GFTrack& track, double z, TVector3* pos = nullptr, TVector3* mom = nullptr);
+  double refitTrkToVtx(SQGenFit::GFTrack& track, double z, TVector3* pos = nullptr, TVector3* mom = nullptr);
   double findDimuonZVertex(SRecDimuon& dimuon, SQGenFit::GFTrack& track1, SQGenFit::GFTrack& track2);
+  double calcZsclp(double p);
   bool   processOneDimuon(SRecTrack* track1, SRecTrack* track2, SRecDimuon& dimuon);
 
   bool legacyContainer;

--- a/packages/reco/ktracker/SQVertexing.h
+++ b/packages/reco/ktracker/SQVertexing.h
@@ -27,6 +27,8 @@ public:
   int End(PHCompositeNode* topNode);
 
   void set_legacy_rec_container(const bool enable = true)  { legacyContainer = enable; }
+  void set_single_retracking(const bool enable = true)     { enableSingleRetracking = true; }
+
   void set_geom_file_name(const std::string& geomFileName) { geom_file_name = geomFileName; }
 
 private:
@@ -37,11 +39,13 @@ private:
 
   double swimTrackToVertex(SQGenFit::GFTrack& track, double z, TVector3* pos = nullptr, TVector3* mom = nullptr);
   double refitTrkToVtx(SQGenFit::GFTrack& track, double z, TVector3* pos = nullptr, TVector3* mom = nullptr);
+  double refitTrkToVtx(SRecTrack*         track, double z, TVector3* pos = nullptr, TVector3* mom = nullptr);
   double findDimuonZVertex(SRecDimuon& dimuon, SQGenFit::GFTrack& track1, SQGenFit::GFTrack& track2);
   double calcZsclp(double p);
   bool   processOneDimuon(SRecTrack* track1, SRecTrack* track2, SRecDimuon& dimuon);
 
   bool legacyContainer;
+  bool enableSingleRetracking;
 
   int charge1, charge2;
 

--- a/packages/reco/ktracker/SQVertexing.h
+++ b/packages/reco/ktracker/SQVertexing.h
@@ -6,6 +6,7 @@
 #include "GFField.h"
 #include "GFTrack.h"
 
+class TString;
 class TVector3;
 class SQTrack;
 class SQTrackVector;
@@ -25,12 +26,14 @@ public:
   int process_event(PHCompositeNode* topNode);
   int End(PHCompositeNode* topNode);
 
-  void set_legacy_rec_container(const bool enable = true) { legacyContainer = enable; }
-  void setFieldPtr(SQGenFit::GFField* field) { gfield = field; }
+  void set_legacy_rec_container(const bool enable = true)  { legacyContainer = enable; }
+  void set_geom_file_name(const std::string& geomFileName) { geom_file_name = geomFileName; }
 
 private:
+  int InitField(PHCompositeNode* topNode);
+  int InitGeom(PHCompositeNode*  topNode);
   int MakeNodes(PHCompositeNode* topNode);
-  int GetNodes(PHCompositeNode* topNode);
+  int GetNodes(PHCompositeNode*  topNode);
 
   double swimTrackToVertex(SQGenFit::GFTrack& track, double z, TVector3* pos = nullptr, TVector3* mom = nullptr);
   double refitTrkToVtx(SQGenFit::GFTrack& track, double z, TVector3* pos = nullptr, TVector3* mom = nullptr);
@@ -42,6 +45,7 @@ private:
 
   int charge1, charge2;
 
+  std::string geom_file_name;
   SQGenFit::GFField* gfield;
 
   SRecEvent*      recEvent;

--- a/packages/reco/ktracker/SQVertexing.h
+++ b/packages/reco/ktracker/SQVertexing.h
@@ -1,0 +1,51 @@
+#ifndef _SQVERTEXING_H
+#define _SQVERTEXING_H
+
+#include <fun4all/SubsysReco.h>
+
+#include "GFField.h"
+#include "GFTrack.h"
+
+class TVector3;
+class SQTrack;
+class SQTrackVector;
+class SQDimuonVector;
+class SRecEvent;
+class SRecTrack;
+class SRecDimuon;
+
+class SQVertexing: public SubsysReco
+{
+public:
+  SQVertexing(const std::string& name = "SQVertexing", int sign1 = 1, int sign2 = -1);
+  ~SQVertexing();
+
+  int Init(PHCompositeNode* topNode);
+  int InitRun(PHCompositeNode* topNode);
+  int process_event(PHCompositeNode* topNode);
+  int End(PHCompositeNode* topNode);
+
+  void set_legacy_rec_container(const bool enable = true) { legacyContainer = enable; }
+  void setFieldPtr(SQGenFit::GFField* field) { gfield = field; }
+
+private:
+  int MakeNodes(PHCompositeNode* topNode);
+  int GetNodes(PHCompositeNode* topNode);
+
+  double swimTrackToVertex(SQGenFit::GFTrack& track, double z, TVector3* pos = nullptr, TVector3* mom = nullptr);
+  double findDimuonZVertex(SRecDimuon& dimuon, SQGenFit::GFTrack& track1, SQGenFit::GFTrack& track2);
+  bool   processOneDimuon(SRecTrack* track1, SRecTrack* track2, SRecDimuon& dimuon);
+
+  bool legacyContainer;
+
+  int charge1, charge2;
+
+  SQGenFit::GFField* gfield;
+
+  SRecEvent*      recEvent;
+  SQTrackVector*  recTrackVec;
+
+  SQDimuonVector* recDimuonVec;
+};
+
+#endif

--- a/packages/reco/ktracker/SQVertexingLinkDef.h
+++ b/packages/reco/ktracker/SQVertexingLinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class SQVertexing-!;
+
+#endif /* __CINT__ */


### PR DESCRIPTION
I created a new package in ```packages/reco/ktracker``` named ```SQVertexing``` to handle the vertex finding and dimuon vertex fitting. 

# General usage
The primary usage is like this:

```
SQVertexing* vertex = new SQVertexing();
//Choose to save the output dimuons inside SRecEvent (if true), or in a Fun4All container (if false), default is false
vertex->set_legacy_rec_container(false); 
//Choose to update the target swim results with the ones after applying track refitting, default is false
vertex->set_single_retracking(false);
//Specify the input file name for ROOT geometry, only needed if it's run without track reconstruction, i.e. run without SQReco in the module list
vertex->set_geom_file_name("filename_for_ROOT_geometry.root")
se->registerSubsystem(vertex);
```

# Primary change and results
Under the hood, the primary change compared with the E906 legacy ```VertexFit``` is it utilizes single muon bend plan correction instead of the old "dimuon mass optimization" process. The single muon bend plane in FMag is decided entirely based on MC truth, based on the momentum of the muon. 

Here is some comparison of the mass resolution, single track $`P_x/P_z`$ resolution, and vertex resolution. All plots are based on DY MC from 3-9 GeV.

![Snipaste_2024-10-12_06-56-29](https://github.com/user-attachments/assets/e458607b-70f7-45e1-9ea0-be9d736772fb)
The plot above shows the relative mass resolution, which is defined as $`(M_{rec} - M_{true})/M_{true}`$.  Black line shows the result if both muons are constrained to go to the reconstructed `Zvtx`. Blue line shows the result if both muons are forced to go to the target center without bend plane correction. Red line shows the result if both muons are forced to go to the target center with the bend plane correction.

![Snipaste_2024-10-12_07-50-49](https://github.com/user-attachments/assets/722ce301-6541-44a4-abb5-e05520daa425)
Similarly, we have the single muon $`P_x/P_z`$ resolution shown in the plot above. The definition of the colors is the same.

![Snipaste_2024-10-13_05-59-06](https://github.com/user-attachments/assets/80bb0f0a-aca3-4f15-a046-f643404a6a6b)
We also have the reconstructed vertex resolution (~45cm) shown in the plot above.

# Changes to the data structure
In order to preserve all the information and leave them for the analyzer to decide. I made a change to the ```SRecDimuon``` data structure.  Four new ```TLorentzVector```s are added, combined with the original two we now have 6 to store the dimuon track information under different z_vertex hypothesis. At this the vertex fit package performs three hypothesis tests:
- Choice 1: assuming both tracks come from reconstructed $`Z_{vtx}`$, the result is saved in ```p_pos``` and ```p_neg```;
- Choice 2: assuming both tracks come from target center, the result is saved in ```p_pos_target``` and ```p_neg_target```;
- Choice 3: assuming both tracks come from dump face, the result is saved in ```p_pos_dump``` and ```p_neg_dump```;

Afterwards the use can access reconstructed kinematic variables ($`mass, x_F`$, etc.) by calling ```SRecDimuon::calcVariables(choice)```. The choice number in the argument refers to the choices listed above. Without any arguments the variables are calculated using momentum obtained by fitting both tracks to reconstructed $`Z_{vtx}`$. 

# To-do
This is the first attempt to get the vertex and dimuon reconstruction correct. One can see that even the muon angles are reconstructed very well, there is still a slight (~50MeV) shift in the reconstructed mass. This is believed to be due to the incorrect  dE/dx correction. This correct was performed by Abi 3-4 years ago but needs to be double-checked and also have the concrete shielding blocks included as well.

Also this package does not handle the need for like-sign dimuon reconstruction, which needs to be included in the future.
