### PR TITLE
Updates on SQVertexing, Fun4AllSRawEventOutputManager and UtilSRawEvent

### DIFF
--- a/online/macros/Fun4MainDaq.C
+++ b/online/macros/Fun4MainDaq.C
@@ -116,7 +116,7 @@ int Fun4MainDaq(const int run=46, const int nevent=0, const bool is_online=false
   }
 
   if (is_online) {
-    Fun4AllSRawEventOutputManager *om_sraw = new Fun4AllSRawEventOutputManager("/data4/e1039_data/online");
+    Fun4AllSpillSRawEventOutputManager *om_sraw = new Fun4AllSpillSRawEventOutputManager("/data4/e1039_data/online");
     om_sraw->Verbosity(10);
     om_sraw->EnableDB();
     se->registerOutputManager(om_sraw);

--- a/packages/reco/ktracker/Fun4AllSRawEventOutputManager.h
+++ b/packages/reco/ktracker/Fun4AllSRawEventOutputManager.h
@@ -10,22 +10,14 @@ class SRawEvent;
 class SQEvent;
 class SQSpillMap;
 class SQHitVector;
-class DbSvc;
 
-class Fun4AllSRawEventOutputManager: public Fun4AllOutputManager
+/// Fun4AllOutputManager to generate SRawEvent output file.
+class Fun4AllSRawEventOutputManager : public Fun4AllOutputManager
 {
-  typedef enum {
-    UNDEF  = 0,
-    OPEN   = 1,
-    UPDATE = 2,
-    CLOSE  = 3
-  } Status_t;
-  std::string m_dir_base;
+  std::string m_file_name;
   std::string m_tree_name;
   std::string m_branch_name;
-  std::string m_file_name;
   int m_run_id;
-  int m_spill_id;
   TFile* m_file;
   TTree* m_tree;
   SRawEvent* m_sraw;
@@ -35,24 +27,19 @@ class Fun4AllSRawEventOutputManager: public Fun4AllOutputManager
   SQHitVector* m_hit_vec;
   SQHitVector* m_trig_hit_vec;
 
-  DbSvc* m_db;
-  std::string m_name_schema;
-  std::string m_name_table;
-
  public:
-  Fun4AllSRawEventOutputManager(const std::string &dir_base, const std::string &myname = "SRAWEVENTOUT");
+  Fun4AllSRawEventOutputManager(const std::string &myname="SRAWEVENTOUT");
   virtual ~Fun4AllSRawEventOutputManager();
 
+  void SetFileName  (const std::string name) { m_file_name   = name; }
   void SetTreeName  (const std::string name) { m_tree_name   = name; }
   void SetBranchName(const std::string name) { m_branch_name = name; }
-  void EnableDB(const std::string name_schema="user_e1039_maindaq", const std::string name_table="sraw_file_status", const bool refresh_db=false);
 
   virtual int Write(PHCompositeNode *startNode);
 
  protected:
   void CloseFile();
   void OpenFile();
-  void UpdateDBStatus(const int status);
 };
 
 #endif /* __FUN4ALLSRAWEVENTOUTPUTMANAGER_H__ */

--- a/packages/reco/ktracker/Fun4AllSpillSRawEventOutputManager.cxx
+++ b/packages/reco/ktracker/Fun4AllSpillSRawEventOutputManager.cxx
@@ -1,0 +1,196 @@
+#include <cstdlib>
+#include <string>
+#include <iostream>
+#include <iomanip>
+#include <TSystem.h>
+#include <TFile.h>
+#include <TTree.h>
+#include <TSQLServer.h>
+#include <phool/phool.h>
+#include <phool/getClass.h>
+#include <phool/PHNode.h>
+#include <phool/PHNodeIOManager.h>
+#include <phool/PHNodeIterator.h>
+#include <interface_main/SQEvent.h>
+#include <interface_main/SQSpillMap.h>
+#include <interface_main/SQHitVector.h>
+#include <ktracker/SRawEvent.h>
+#include <db_svc/DbSvc.h>
+#include "UtilSRawEvent.h"
+#include "Fun4AllSpillSRawEventOutputManager.h"
+using namespace std;
+
+Fun4AllSpillSRawEventOutputManager::Fun4AllSpillSRawEventOutputManager(const std::string &dir_base, const string &myname)
+  : Fun4AllOutputManager(myname)
+  , m_dir_base(dir_base)
+  , m_tree_name("save")
+  , m_branch_name("rawEvent")
+  , m_file_name("")
+  , m_run_id(0)
+  , m_spill_id(0)
+  , m_file(0)
+  , m_tree(0)
+  , m_sraw(0)
+  , m_evt(0)
+  , m_sp_map(0)
+  , m_hit_vec(0)
+  , m_trig_hit_vec(0)
+  , m_db(0)
+  , m_name_schema("")
+  , m_name_table("")
+  , m_use_sqlite(false)
+{
+  ;
+}
+
+Fun4AllSpillSRawEventOutputManager::~Fun4AllSpillSRawEventOutputManager()
+{
+  CloseFile();
+  if (m_sraw) delete m_sraw;
+  if (m_db) delete m_db;
+}
+
+void Fun4AllSpillSRawEventOutputManager::EnableDB(const std::string name_schema, const std::string name_table, const bool refresh_db)
+{
+  m_name_schema = name_schema;
+  m_name_table  = name_table;
+  m_db = new DbSvc(DbSvc::DB1);
+  m_db->UseSchema(m_name_schema, true);
+
+  if (refresh_db && m_db->HasTable(m_name_table)) m_db->DropTable(m_name_table);
+  if (! m_db->HasTable(m_name_table)) {
+    DbSvc::VarList list;
+    list.Add("run_id"   , "INT", true);
+    list.Add("spill_id" , "INT", true);
+    list.Add("file_name", "VARCHAR(256)");
+    list.Add("status"   , "INT");
+    list.Add("utime_b"  , "INT");
+    list.Add("utime_e"  , "INT");
+    m_db->CreateTable(m_name_table, list);
+  }
+}
+
+int Fun4AllSpillSRawEventOutputManager::Write(PHCompositeNode *startNode)
+{
+  if (! m_evt) {
+    m_evt          = findNode::getClass<SQEvent    >(startNode, "SQEvent");
+    m_sp_map       = findNode::getClass<SQSpillMap >(startNode, "SQSpillMap");
+    m_hit_vec      = findNode::getClass<SQHitVector>(startNode, "SQHitVector");
+    m_trig_hit_vec = findNode::getClass<SQHitVector>(startNode, "SQTriggerHitVector");
+    if (!m_evt || !m_hit_vec || !m_trig_hit_vec) {
+      cout << PHWHERE << "Cannot find the SQ data nodes.  Abort." << endl;
+      exit(1);
+    }
+  }
+  int run_id = m_evt->get_run_id();
+  int sp_id  = m_evt->get_spill_id();
+  if (m_run_id != run_id || m_spill_id != sp_id) { // New spill
+    CloseFile();
+    m_run_id   = run_id;
+    m_spill_id = sp_id;
+    OpenFile();
+  }
+  SQSpill* sp = m_sp_map ? m_sp_map->get(sp_id) : 0;
+  UtilSRawEvent::SetEvent     (m_sraw, m_evt);
+  UtilSRawEvent::SetSpill     (m_sraw, sp);
+  UtilSRawEvent::SetHit       (m_sraw, m_hit_vec);
+  UtilSRawEvent::SetTriggerHit(m_sraw, m_trig_hit_vec);
+  m_tree->Fill();
+  return 0;
+}
+
+void Fun4AllSpillSRawEventOutputManager::CloseFile()
+{
+  if (Verbosity() > 0) cout << "Fun4AllSpillSRawEventOutputManager::CloseFile(): run " << m_run_id << ", spill " << m_spill_id << endl;
+  if (! m_file) return;
+  m_file->Write();
+  m_file->Close();
+  delete m_file;
+  m_file = 0;
+  UpdateDBStatus(CLOSE);
+
+  if (m_db) { // MySQL DB
+    int utime = time(0);
+    ostringstream oss;
+    oss << "update " << m_name_table << " set status = " << CLOSE << ", utime_e = " << utime
+        << " where run_id = " << m_run_id << " and spill_id = " << m_spill_id;
+    if (! m_db->Con()->Exec(oss.str().c_str())) {
+      cerr << "!!ERROR!!  Fun4AllSpillSRawEventOutputManager::CloseFile():  " << oss.str() << endl;
+      return;
+    }
+  }
+}
+
+void Fun4AllSpillSRawEventOutputManager::OpenFile()
+{
+  if (Verbosity() > 0) cout << "Fun4AllSpillSRawEventOutputManager::OpenFile(): run " << m_run_id << ", spill " << m_spill_id << endl;
+  ostringstream oss;
+  oss << m_dir_base << "/sraw/run_" << setfill('0') << setw(6) << m_run_id;
+  gSystem->mkdir(oss.str().c_str(), true);
+  oss << "/run_" << setw(6) << m_run_id << "_spill_" << setw(9) << m_spill_id << "_sraw.root";
+  m_file_name = oss.str();
+  if (Verbosity() > 9) cout << "  " << m_file_name << endl;
+  m_file = new TFile(m_file_name.c_str(), "RECREATE");
+  if (!m_file->IsOpen()) {
+    cout << PHWHERE << "Could not open " << m_file_name << ".  Abort." << endl;
+    exit(1);
+  }
+  if (!m_sraw) m_sraw = new SRawEvent();
+  m_tree = new TTree(m_tree_name.c_str(), "");
+  m_tree->Branch(m_branch_name.c_str(), &m_sraw);
+  UpdateDBStatus(OPEN);
+
+  if (m_db) { // MySQL DB
+    int utime = time(0);
+    ostringstream oss;
+    oss << "insert into " << m_name_table
+        << " values(" << m_run_id << ", " << m_spill_id << ", '" << m_file_name << "', 1, " << utime << ", 0)"
+        << " on duplicate key update file_name = '" << m_file_name << "', status = " << OPEN << ", utime_b = " << utime << ", utime_e = 0";
+    if (! m_db->Con()->Exec(oss.str().c_str())) {
+      cerr << "!!ERROR!!  Fun4AllSpillSRawEventOutputManager::OpenFile(): " << oss.str() << endl;
+      return;
+    }
+  }
+}
+
+/// Update the status stored in SQLite DB.  Obsolete.
+/**
+ * This function assumes the SQLite DB file exists with the proper table contents.
+ * We have to manually execute the following commands beforehand;
+ * @code
+ * sqlite3 /path/to/data_status.db
+ * create table data_status (
+ *     run_id          INTEGER,
+ *     spill_id        INTEGER,
+ *      utime_deco     INTEGER DEFAULT 0,
+ *     status_deco     INTEGER DEFAULT 0,
+ *      utime_reco_cpu INTEGER DEFAULT 0,
+ *     status_reco_cpu INTEGER DEFAULT 0,
+ *      utime_reco_gpu INTEGER DEFAULT 0,
+ *     status_reco_gpu INTEGER DEFAULT 0,
+ *     UNIQUE(run_id, spill_id)
+ *   );
+ * @endcode
+ */
+void Fun4AllSpillSRawEventOutputManager::UpdateDBStatus(const int status)
+{
+  if (! m_use_sqlite) return;
+  
+  const char* table_name = "data_status";
+  ostringstream oss;
+  oss << m_dir_base << "/data_status.db";
+  DbSvc db(DbSvc::LITE, oss.str());
+
+  oss.str("");
+  oss << "insert or ignore into " << table_name << " (run_id, spill_id) values (" << m_run_id << ", " << m_spill_id << ")";
+  if (! db.Con()->Exec(oss.str().c_str())) {
+    cerr << "!!ERROR!!  Fun4AllSpillSRawEventOutputManager::UpdateDBStatus()." << endl;
+    return;
+  }
+  oss.str("");
+  oss << "update " << table_name << " set utime_deco = strftime('%s', 'now'), status_deco = " << status << " where run_id = " << m_run_id << " and spill_id = " << m_spill_id;
+  if (! db.Con()->Exec(oss.str().c_str())) {
+    cerr << "!!ERROR!!  Fun4AllSpillSRawEventOutputManager::UpdateDBStatus()." << endl;
+    return;
+  }
+}

--- a/packages/reco/ktracker/Fun4AllSpillSRawEventOutputManager.h
+++ b/packages/reco/ktracker/Fun4AllSpillSRawEventOutputManager.h
@@ -1,0 +1,61 @@
+#ifndef __FUN4ALL_SPILL_SRAW_EVENT_OUTPUT_MANAGER_H__
+#define __FUN4ALL_SPILL_SRAW_EVENT_OUTPUT_MANAGER_H__
+#include <fun4all/Fun4AllOutputManager.h>
+#include <string>
+#include <vector>
+class TFile;
+class TTree;
+class PHCompositeNode;
+class SRawEvent;
+class SQEvent;
+class SQSpillMap;
+class SQHitVector;
+class DbSvc;
+
+/// Fun4AllOutputManager to generate spill-level SRawEvent output files.
+class Fun4AllSpillSRawEventOutputManager: public Fun4AllOutputManager
+{
+  typedef enum {
+    UNDEF  = 0,
+    OPEN   = 1,
+    UPDATE = 2,
+    CLOSE  = 3
+  } Status_t;
+  std::string m_dir_base;
+  std::string m_tree_name;
+  std::string m_branch_name;
+  std::string m_file_name;
+  int m_run_id;
+  int m_spill_id;
+  TFile* m_file;
+  TTree* m_tree;
+  SRawEvent* m_sraw;
+  
+  SQEvent* m_evt;
+  SQSpillMap* m_sp_map;
+  SQHitVector* m_hit_vec;
+  SQHitVector* m_trig_hit_vec;
+
+  DbSvc* m_db;
+  std::string m_name_schema;
+  std::string m_name_table;
+  bool m_use_sqlite;
+
+ public:
+  Fun4AllSpillSRawEventOutputManager(const std::string &dir_base, const std::string &myname = "SPILLSRAWEVENTOUT");
+  virtual ~Fun4AllSpillSRawEventOutputManager();
+
+  void SetTreeName  (const std::string name) { m_tree_name   = name; }
+  void SetBranchName(const std::string name) { m_branch_name = name; }
+  void EnableDB(const std::string name_schema="user_e1039_maindaq", const std::string name_table="sraw_file_status", const bool refresh_db=false);
+  void EnableSQLiteDB(const bool use=true) { m_use_sqlite = use; }
+
+  virtual int Write(PHCompositeNode *startNode);
+
+ protected:
+  void CloseFile();
+  void OpenFile();
+  void UpdateDBStatus(const int status);
+};
+
+#endif /* __FUN4ALL_SPILL_SRAW_EVENT_OUTPUT_MANAGER_H__ */

--- a/packages/reco/ktracker/Fun4AllSpillSRawEventOutputManagerLinkDef.h
+++ b/packages/reco/ktracker/Fun4AllSpillSRawEventOutputManagerLinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class Fun4AllSpillSRawEventOutputManager-!;
+
+#endif /* __CINT__ */

--- a/packages/reco/ktracker/SQVertexing.cxx
+++ b/packages/reco/ktracker/SQVertexing.cxx
@@ -213,7 +213,7 @@ double SQVertexing::refitTrkToVtx(SQGenFit::GFTrack& track, double z, TVector3* 
   double z_offset_prev = 1.E9;
   double z_offset_curr = 0.;
   double chi2 = 0.;
-  const int n_iter_max = 10000;
+  const int n_iter_max = 100;
   int n_iter = 0;
   while(fabs(z_offset_curr - z_offset_prev) > 0.1)
   {
@@ -246,6 +246,8 @@ double SQVertexing::refitTrkToVtx(SRecTrack* track, double z, TVector3* pos, TVe
 
 double SQVertexing::calcZsclp(double p)
 {
+  if(p < 5.) p = 5.;
+  else if(p>120.) p = 120.;
   return 301.84 - 1.27137*p + 0.0218294*p*p - 0.000170711*p*p*p + 4.94683e-07*p*p*p*p - 271.;
 }
 

--- a/packages/reco/ktracker/SQVertexing.cxx
+++ b/packages/reco/ktracker/SQVertexing.cxx
@@ -102,6 +102,7 @@ int SQVertexing::process_event(PHCompositeNode* topNode)
   std::vector<int> trackIDs1;
   std::vector<int> trackIDs2;
   int nTracks = legacyContainer ? recEvent->getNTracks() : recTrackVec->size();
+  if(Verbosity() > 10) std::cout << "SQVertexing::process_event():  nTracks = " << nTracks << std::endl;
   for(int i = 0; i < nTracks; ++i)
   {
     SRecTrack* recTrack = legacyContainer ? &(recEvent->getTrack(i)) : dynamic_cast<SRecTrack*>(recTrackVec->at(i));
@@ -124,7 +125,8 @@ int SQVertexing::process_event(PHCompositeNode* topNode)
    
   }
   if(trackIDs1.empty() || trackIDs2.empty()) return Fun4AllReturnCodes::EVENT_OK;
-
+  if(Verbosity() > 10) std::cout << "  N of trackIDs1 & trackIDs1 = " << trackIDs1.size() << " & " << trackIDs2.size() << std::endl;
+  
   for(int i = 0; i < trackIDs1.size(); ++i)
   {
     for(int j = charge1 == charge2 ? i+1 : 0; j < trackIDs2.size(); ++j)
@@ -205,11 +207,14 @@ double SQVertexing::swimTrackToVertex(SQGenFit::GFTrack& track, double z, TVecto
 
 double SQVertexing::refitTrkToVtx(SQGenFit::GFTrack& track, double z, TVector3* pos, TVector3* mom)
 {
+  if(Verbosity() > 20) std::cout << "SQVertexing::refitTrkToVtx(): z = " << z << ", pos = (" << pos->X() << ", " << pos->Y() << ", " << pos->Z() << "), mom = (" << mom->X() << ", " << mom->Y() << ", " << mom->Z() << ")" << std::endl;
   gfield->setOffset(0.);
 
   double z_offset_prev = 1.E9;
   double z_offset_curr = 0.;
   double chi2 = 0.;
+  const int n_iter_max = 10000;
+  int n_iter = 0;
   while(fabs(z_offset_curr - z_offset_prev) > 0.1)
   {
     chi2 = swimTrackToVertex(track, z, pos, mom);
@@ -219,8 +224,14 @@ double SQVertexing::refitTrkToVtx(SQGenFit::GFTrack& track, double z, TVector3* 
     z_offset_curr = calcZsclp(mom->Mag());
   
     gfield->setOffset(-z_offset_curr);
+    if(Verbosity() > 20) std::cout << "  i_iter = " << n_iter << ": p = " << mom->Mag() << ", dz = " << z_offset_curr << " - " << z_offset_prev << " = " << z_offset_curr - z_offset_prev << std::endl;
+    if (++n_iter == n_iter_max) {
+      std::cout << "!WARNING!  SQVertexing::refitTrkToVtx():  Give up the iteration." << std::endl;
+      break;
+    }
   }
-
+  if(Verbosity() > 10) std::cout << "  n_iter = " << n_iter << std::endl;
+  
   //re-adjust FMag bend plane here
   gfield->setOffset(0.);
 
@@ -240,6 +251,8 @@ double SQVertexing::calcZsclp(double p)
 
 bool SQVertexing::processOneDimuon(SRecTrack* track1, SRecTrack* track2, SRecDimuon& dimuon)
 {
+  if(Verbosity() > 10) std::cout << "  SQVertexing::processOneDimuon(): " << std::endl;
+  
   //Pre-calculated variables
   dimuon.proj_target_pos = track1->getTargetPos();
   dimuon.proj_dump_pos   = track1->getDumpPos();

--- a/packages/reco/ktracker/SQVertexing.cxx
+++ b/packages/reco/ktracker/SQVertexing.cxx
@@ -247,7 +247,8 @@ double SQVertexing::refitTrkToVtx(SRecTrack* track, double z, TVector3* pos, TVe
 double SQVertexing::calcZsclp(double p)
 {
   if(p < 5.) p = 5.;
-  else if(p>120.) p = 120.;
+  else if(p > 120.) p = 120.;
+  
   return 301.84 - 1.27137*p + 0.0218294*p*p - 0.000170711*p*p*p + 4.94683e-07*p*p*p*p - 271.;
 }
 
@@ -305,14 +306,14 @@ double SQVertexing::findDimuonZVertex(SRecDimuon& dimuon, SQGenFit::GFTrack& tra
   //TODO: consider using addjustable bend-plane for vertex finding as well
   double stepsize[3] = {25., 5., 1.};
 
-  double z_min = 200.;
+  double z_min = 300.;
   double chi2_min = 1.E9;
   for(int i = 0; i < 3; ++i)
   {
     double z_start, z_end;
     if(i == 0)
     {
-      z_start = 200.;
+      z_start = z_min;
       z_end   = Z_UPSTREAM;
     }
     else

--- a/packages/reco/ktracker/UtilSRawEvent.cxx
+++ b/packages/reco/ktracker/UtilSRawEvent.cxx
@@ -25,16 +25,16 @@ bool UtilSRawEvent::SetEvent(SRawEvent* sraw, const SQEvent* evt, const bool do_
 
   /// Note that the bit order is different between SRawEvent and SQEvent!!
   int trig_bits = 0;
-  if (evt->get_trigger(SQEvent::MATRIX1)) trig_bits |= (0x1 << SRawEvent::MATRIX1);
-  if (evt->get_trigger(SQEvent::MATRIX2)) trig_bits |= (0x1 << SRawEvent::MATRIX2);
-  if (evt->get_trigger(SQEvent::MATRIX3)) trig_bits |= (0x1 << SRawEvent::MATRIX3);
-  if (evt->get_trigger(SQEvent::MATRIX4)) trig_bits |= (0x1 << SRawEvent::MATRIX4);
-  if (evt->get_trigger(SQEvent::MATRIX5)) trig_bits |= (0x1 << SRawEvent::MATRIX5);
-  if (evt->get_trigger(SQEvent::NIM1   )) trig_bits |= (0x1 << SRawEvent::NIM1   );
-  if (evt->get_trigger(SQEvent::NIM2   )) trig_bits |= (0x1 << SRawEvent::NIM2   );
-  if (evt->get_trigger(SQEvent::NIM3   )) trig_bits |= (0x1 << SRawEvent::NIM3   );
-  if (evt->get_trigger(SQEvent::NIM4   )) trig_bits |= (0x1 << SRawEvent::NIM4   );
-  if (evt->get_trigger(SQEvent::NIM5   )) trig_bits |= (0x1 << SRawEvent::NIM5   );
+  if (evt->get_trigger(SQEvent::MATRIX1)) trig_bits |= SRawEvent::MATRIX1;
+  if (evt->get_trigger(SQEvent::MATRIX2)) trig_bits |= SRawEvent::MATRIX2;
+  if (evt->get_trigger(SQEvent::MATRIX3)) trig_bits |= SRawEvent::MATRIX3;
+  if (evt->get_trigger(SQEvent::MATRIX4)) trig_bits |= SRawEvent::MATRIX4;
+  if (evt->get_trigger(SQEvent::MATRIX5)) trig_bits |= SRawEvent::MATRIX5;
+  if (evt->get_trigger(SQEvent::NIM1   )) trig_bits |= SRawEvent::NIM1   ;
+  if (evt->get_trigger(SQEvent::NIM2   )) trig_bits |= SRawEvent::NIM2   ;
+  if (evt->get_trigger(SQEvent::NIM3   )) trig_bits |= SRawEvent::NIM3   ;
+  if (evt->get_trigger(SQEvent::NIM4   )) trig_bits |= SRawEvent::NIM4   ;
+  if (evt->get_trigger(SQEvent::NIM5   )) trig_bits |= SRawEvent::NIM5   ;
   sraw->setTriggerBits(trig_bits);
 
   return true;

--- a/packages/reco/ktracker/UtilSRawEvent.cxx
+++ b/packages/reco/ktracker/UtilSRawEvent.cxx
@@ -23,11 +23,20 @@ bool UtilSRawEvent::SetEvent(SRawEvent* sraw, const SQEvent* evt, const bool do_
   int event_id = evt->get_event_id();
   sraw->setEventInfo(run_id, spill_id, event_id);
 
-  int triggers[10];
-  for(int i = SQEvent::NIM1; i <= SQEvent::MATRIX5; ++i) {
-    triggers[i] = evt->get_trigger(static_cast<SQEvent::TriggerMask>(i));
-  }
-  sraw->setTriggerBits(triggers);
+  /// Note that the bit order is different between SRawEvent and SQEvent!!
+  int trig_bits = 0;
+  if (evt->get_trigger(SQEvent::MATRIX1)) trig_bits |= (0x1 << SRawEvent::MATRIX1);
+  if (evt->get_trigger(SQEvent::MATRIX2)) trig_bits |= (0x1 << SRawEvent::MATRIX2);
+  if (evt->get_trigger(SQEvent::MATRIX3)) trig_bits |= (0x1 << SRawEvent::MATRIX3);
+  if (evt->get_trigger(SQEvent::MATRIX4)) trig_bits |= (0x1 << SRawEvent::MATRIX4);
+  if (evt->get_trigger(SQEvent::MATRIX5)) trig_bits |= (0x1 << SRawEvent::MATRIX5);
+  if (evt->get_trigger(SQEvent::NIM1   )) trig_bits |= (0x1 << SRawEvent::NIM1   );
+  if (evt->get_trigger(SQEvent::NIM2   )) trig_bits |= (0x1 << SRawEvent::NIM2   );
+  if (evt->get_trigger(SQEvent::NIM3   )) trig_bits |= (0x1 << SRawEvent::NIM3   );
+  if (evt->get_trigger(SQEvent::NIM4   )) trig_bits |= (0x1 << SRawEvent::NIM4   );
+  if (evt->get_trigger(SQEvent::NIM5   )) trig_bits |= (0x1 << SRawEvent::NIM5   );
+  sraw->setTriggerBits(trig_bits);
+
   return true;
 }
 


### PR DESCRIPTION
This pull request includes multiple updates eventually.

1. SQVertexing was found not converged on some events of the commissioning data.  To avoid it, we added lines to `SQVertexing::calcZsclp()` to enforce the valid momentum range, and also added the max number of iterations to `SQVertexing::refitTrkToVtx()`.  Verbose messages were added for debugging.

2. `Fun4AllSRawEventOutputManager` was renamed as `Fun4AllSpillSRawEventOutputManager` because it outputs spill-by-spill files.  A new manager, `Fun4AllSRawEventOutputManager`, was made, which outputs one file per process (=run).

3. A bug about the trigger bits in `UtilSRawEvent::SetEvent()` was fixed.  The order of FPGA and NIM bits in `SRawEvent` is different from that in `SQEvent`, but the function above had assumed that it is identical.