### PR TITLE
Add flexibility in SQVertexing IO options

### DIFF
--- a/packages/reco/ktracker/SQVertexing.cxx
+++ b/packages/reco/ktracker/SQVertexing.cxx
@@ -58,7 +58,6 @@ namespace
 
 SQVertexing::SQVertexing(const std::string& name, int sign1, int sign2):
   SubsysReco(name),
-  legacyContainer(false),
   legacyContainer_in(false),
   legacyContainer_out(false),
   enableSingleRetracking(false),

--- a/packages/reco/ktracker/SQVertexing.h
+++ b/packages/reco/ktracker/SQVertexing.h
@@ -26,7 +26,7 @@ public:
   int process_event(PHCompositeNode* topNode);
   int End(PHCompositeNode* topNode);
 
-  void set_legacy_rec_container(const bool enable = true)  { legacyContainer = enable; legacyContainer_in = enable; legacyContainer_out = enable; }
+  void set_legacy_rec_container(const bool enable = true)  { legacyContainer_in  = enable; legacyContainer_out = enable; }
   void set_legacy_in_container(const bool enable = true)   { legacyContainer_in  = enable; }
   void set_legacy_out_container(const bool enable = true)  { legacyContainer_out = enable; }
   void set_single_retracking(const bool enable = true)     { enableSingleRetracking = true; }
@@ -46,7 +46,6 @@ private:
   double calcZsclp(double p);
   bool   processOneDimuon(SRecTrack* track1, SRecTrack* track2, SRecDimuon& dimuon);
 
-  bool legacyContainer;
   bool legacyContainer_in, legacyContainer_out;
   bool enableSingleRetracking;
 

--- a/packages/reco/ktracker/SQVertexing.h
+++ b/packages/reco/ktracker/SQVertexing.h
@@ -26,7 +26,9 @@ public:
   int process_event(PHCompositeNode* topNode);
   int End(PHCompositeNode* topNode);
 
-  void set_legacy_rec_container(const bool enable = true)  { legacyContainer = enable; }
+  void set_legacy_rec_container(const bool enable = true)  { legacyContainer = enable; legacyContainer_in = enable; legacyContainer_out = enable; }
+  void set_legacy_in_container(const bool enable = true)   { legacyContainer_in  = enable; }
+  void set_legacy_out_container(const bool enable = true)  { legacyContainer_out = enable; }
   void set_single_retracking(const bool enable = true)     { enableSingleRetracking = true; }
 
   void set_geom_file_name(const std::string& geomFileName) { geom_file_name = geomFileName; }
@@ -45,6 +47,7 @@ private:
   bool   processOneDimuon(SRecTrack* track1, SRecTrack* track2, SRecDimuon& dimuon);
 
   bool legacyContainer;
+  bool legacyContainer_in, legacyContainer_out;
   bool enableSingleRetracking;
 
   int charge1, charge2;


### PR DESCRIPTION
This PR made two changes:

1. It added additional Boolean flags (and associated set functions) to allow user to control whether to use legacy-style input/output containers separately. ```SQVertexing::set_legacy_in_container()``` will switch between using ```SQTrackVector``` and old ```std::vector<SRecTrack>``` embedded inside the ```SRecEvent``` as input. Similarly,  ```SQVertexing::set_legacy_out_container()``` will switch between using ```SQDimuonVector``` and old ```std::vector<SRecDimuon>```  embedded inside the ```SRecEvent``` as output. Setting ```SQVertexing::set_legacy_container()``` will turn on/off both input and output switch simultaneously. 
2. Added some code at the end of ```SQVertexing::processOneDimuon()``` to change the sign of the Px of the "positive" muon if we are processing like-sign dimuons.