### PR TITLE
Minor bug fixes and re-org in various reconstruction code

### DIFF
--- a/packages/reco/SQGenFit/GFTrack.cxx
+++ b/packages/reco/SQGenFit/GFTrack.cxx
@@ -63,6 +63,8 @@ GFTrack::GFTrack(): _track(nullptr), _trkrep(nullptr), _propState(nullptr), _vir
 
 GFTrack::GFTrack(SRecTrack& recTrack):  _track(nullptr), _trkrep(nullptr), _propState(nullptr), _virtMeas(nullptr), _trkcand(nullptr), _pdg(0)
 {
+  initGlobalVariables();
+
   _pdg = recTrack.getCharge() > 0 ? -13 : 13;
   _trkrep = new genfit::RKTrackRep(_pdg);
     
@@ -100,6 +102,7 @@ GFTrack::GFTrack(SRecTrack& recTrack):  _track(nullptr), _trkrep(nullptr), _prop
 
 GFTrack::GFTrack(Tracklet& tracklet): _track(nullptr), _trkrep(nullptr), _propState(nullptr), _virtMeas(nullptr), _trkcand(nullptr), _pdg(0)
 {
+  initGlobalVariables();
   setTracklet(tracklet, 590., false);
 }
 

--- a/packages/reco/ktracker/KalmanFastTracking.h
+++ b/packages/reco/ktracker/KalmanFastTracking.h
@@ -25,6 +25,7 @@ Created: 05-24-2013
 #include "KalmanTrack.h"
 #include "KalmanFitter.h"
 #include "FastTracklet.h"
+#include "SQTrackletFitter.h"
 
 class TGeoManager;
 
@@ -194,12 +195,8 @@ protected:
     //Sagitta ratio in station 1, index 0, 1, 2 are for X/U/V
     int s_detectorID[3];
 
-    //Current tracklets being processed
-    Tracklet tracklet_curr;
-
-    //Least chi square fitter and functor
-    ROOT::Math::Minimizer* minimizer[2];
-    ROOT::Math::Functor fcn;
+    //Simple tracklet fitter
+    SQTrackletFitter* trackletFitter;
 
     //Kalman fitter
     KalmanFitter* kmfitter;

--- a/packages/reco/ktracker/SQTrackletFitter.cxx
+++ b/packages/reco/ktracker/SQTrackletFitter.cxx
@@ -1,0 +1,72 @@
+#include "SQTrackletFitter.h"
+
+#include <phool/recoConsts.h>
+
+SQTrackletFitter::SQTrackletFitter(bool KMAG_ON)
+{
+  nParameters = KMAG_ON ? 5 : 4;
+
+  recoConsts* rc = recoConsts::instance();
+  tx_max = rc->get_DoubleFlag("TX_MAX");
+  ty_max = rc->get_DoubleFlag("TY_MAX");
+  x0_max = rc->get_DoubleFlag("X0_MAX");
+  y0_max = rc->get_DoubleFlag("Y0_MAX");
+  invP_min = rc->get_DoubleFlag("INVP_MIN");
+  invP_max = rc->get_DoubleFlag("INVP_MAX");
+
+  minimizer = ROOT::Math::Factory::CreateMinimizer("Minuit2", "Combined");
+  fcn = ROOT::Math::Functor(&tracklet_fit, &Tracklet::Eval, nParameters);
+
+  minimizer->SetMaxFunctionCalls(1000000);
+  minimizer->SetMaxIterations(100);
+  minimizer->SetTolerance(1E-2);
+  minimizer->SetFunction(fcn);
+  minimizer->SetPrintLevel(0);
+}
+
+SQTrackletFitter::~SQTrackletFitter()
+{
+  delete minimizer;
+}
+
+int SQTrackletFitter::fit(Tracklet& tracklet)
+{
+  tracklet_fit = tracklet;
+
+  minimizer->SetLimitedVariable(0, "tx", tracklet.tx, 0.001, -tx_max, tx_max);
+  minimizer->SetLimitedVariable(1, "ty", tracklet.ty, 0.001, -ty_max, ty_max);
+  minimizer->SetLimitedVariable(2, "x0", tracklet.x0, 0.1, -x0_max, x0_max);
+  minimizer->SetLimitedVariable(3, "y0", tracklet.y0, 0.1, -y0_max, y0_max);
+  if(nParameters == 5)
+  {
+    minimizer->SetLimitedVariable(4, "invP", tracklet.invP, 0.001*tracklet.invP, invP_min, invP_max);
+  }
+
+  minimizer->Minimize();
+
+  //update the track parameters
+  tracklet.tx = minimizer->X()[0];
+  tracklet.ty = minimizer->X()[1];
+  tracklet.x0 = minimizer->X()[2];
+  tracklet.y0 = minimizer->X()[3];
+
+  tracklet.err_tx = minimizer->Errors()[0];
+  tracklet.err_ty = minimizer->Errors()[1];
+  tracklet.err_x0 = minimizer->Errors()[2];
+  tracklet.err_y0 = minimizer->Errors()[3];
+
+  /// Avoid too-small error, which causes NaN in Tracklet::operator+().
+  if (tracklet.err_tx < 1e-6) tracklet.err_tx = 1e-6;
+  if (tracklet.err_ty < 1e-6) tracklet.err_ty = 1e-6;
+  if (tracklet.err_x0 < 1e-4) tracklet.err_x0 = 1e-4;
+  if (tracklet.err_y0 < 1e-4) tracklet.err_y0 = 1e-4;
+
+  if(nParameters == 5)
+  {
+    tracklet.invP = minimizer->X()[4];
+    tracklet.err_invP = minimizer->Errors()[4];
+  }
+
+  tracklet.chisq = minimizer->MinValue();
+  return minimizer->Status();
+}

--- a/packages/reco/ktracker/SQTrackletFitter.h
+++ b/packages/reco/ktracker/SQTrackletFitter.h
@@ -1,0 +1,43 @@
+#ifndef _SQTRACKLETFITTER_H
+#define _SQTRACKLETFITTER_H
+
+#include <Math/Factory.h>
+#include <Math/Minimizer.h>
+#include <Math/Functor.h>
+
+#include "FastTracklet.h"
+
+class SQTrackletFitter
+{
+public:
+  SQTrackletFitter(bool KMAG_ON = true);
+  ~SQTrackletFitter();
+
+  /// core function - fit the tracklet and return the fit status
+  int fit(Tracklet& tracklet);
+
+  /// retrieve the fit parameter value and error
+  double getParameter(int idx) { return minimizer->X()[idx]; }
+  double getParaError(int idx) { return minimizer->Errors()[idx]; }
+
+  /// retrieve the chi2
+  double getChi2() { return minimizer->MinValue();}
+
+private:
+  /// The tracklet object
+  Tracklet tracklet_fit;
+
+  /// The fit parameter range
+  double tx_max;
+  double ty_max;
+  double x0_max;
+  double y0_max;
+  double invP_min, invP_max;
+
+  /// Least chi2 fitter and functor
+  unsigned int nParameters;
+  ROOT::Math::Minimizer* minimizer;
+  ROOT::Math::Functor fcn;
+};
+
+#endif

--- a/packages/reco/ktracker/SQVertexing.cxx
+++ b/packages/reco/ktracker/SQVertexing.cxx
@@ -15,6 +15,8 @@
 #include <interface_main/SQTrackVector_v1.h>
 #include <interface_main/SQDimuonVector_v1.h>
 #include <GenFit/FieldManager.h>
+#include <GenFit/MaterialEffects.h>
+#include <GenFit/TGeoMaterialInterface.h>
 
 #include "SRecEvent.h"
 #include "GFTrack.h"
@@ -371,6 +373,8 @@ int SQVertexing::InitField(PHCompositeNode* topNode)
 
     std::cout << "SQVertexing::InitGeom - creating new GenFit field map" << std::endl;
     gfield = new SQGenFit::GFField(phfield);
+
+    genfit::FieldManager::getInstance()->init(gfield);
   }
   else
   {
@@ -387,6 +391,8 @@ int SQVertexing::InitGeom(PHCompositeNode* topNode)
     std::cout << "SQVertexing::InitGeom - create geom from " << geom_file_name << std::endl;
 
     int ret = PHGeomUtility::ImportGeomFile(topNode, geom_file_name);
+    genfit::MaterialEffects::getInstance()->init(new genfit::TGeoMaterialInterface());
+
     if(ret != Fun4AllReturnCodes::EVENT_OK) return ret;
   }
   else


### PR DESCRIPTION
This PR includes three small changes.

1. Take the tracklet fitter out of KalmanFastTracking and put it in its own class, so that other packages can use it. This is needed for the alignment code package;
2. Fixed a bug in GFTrack that sometimes the global constants are not properly initialized
3. Fixed a bug in SQVertexing. Now the Genfit unitlities are initialized if SQReco is not created.