### PR TITLE
Initialization of GFTrack

### DIFF
--- a/packages/reco/SQGenFit/GFTrack.cxx
+++ b/packages/reco/SQGenFit/GFTrack.cxx
@@ -63,6 +63,7 @@ GFTrack::GFTrack(): _track(nullptr), _trkrep(nullptr), _propState(nullptr), _vir
 
 GFTrack::GFTrack(SRecTrack& recTrack):  _track(nullptr), _trkrep(nullptr), _propState(nullptr), _virtMeas(nullptr), _trkcand(nullptr), _pdg(0)
 {
+  initGlobalVariables();
   _pdg = recTrack.getCharge() > 0 ? -13 : 13;
   _trkrep = new genfit::RKTrackRep(_pdg);
     
@@ -100,6 +101,7 @@ GFTrack::GFTrack(SRecTrack& recTrack):  _track(nullptr), _trkrep(nullptr), _prop
 
 GFTrack::GFTrack(Tracklet& tracklet): _track(nullptr), _trkrep(nullptr), _propState(nullptr), _virtMeas(nullptr), _trkcand(nullptr), _pdg(0)
 {
+  initGlobalVariables();
   setTracklet(tracklet, 590., false);
 }
 

--- a/packages/reco/interface/SRecEvent.cxx
+++ b/packages/reco/interface/SRecEvent.cxx
@@ -590,6 +590,46 @@ void SRecTrack::print(std::ostream& os) const
   os << "Chi square at vertex: " << fChisqVertex << std::endl;
 }
 
+void SRecTrack::printGF(std::ostream& os) const
+{
+  os << "SRecTrack::PrintGF():\n"
+     << "  DetPlaneVecO";
+  for (unsigned int iv = 0; iv < fGFDetPlaneVec[0].size(); iv++) {
+    const TVector3* vec = &fGFDetPlaneVec[0][iv];
+    os << " " << iv << ":(" << vec->X() << " " << vec->Y() << " " << vec->Z() << ")" ;
+  }
+  os << "\n  DetPlaneVecU";
+  for (unsigned int iv = 0; iv < fGFDetPlaneVec[1].size(); iv++) {
+    const TVector3* vec = &fGFDetPlaneVec[1][iv];
+    os << " " << iv << ":(" << vec->X() << " " << vec->Y() << " " << vec->Z() << ")" ;
+  }
+  os << "\n  DetPlaneVecV";
+  for (unsigned int iv = 0; iv < fGFDetPlaneVec[2].size(); iv++) {
+    const TVector3* vec = &fGFDetPlaneVec[2][iv];
+    os << " " << iv << ":(" << vec->X() << " " << vec->Y() << " " << vec->Z() << ")" ;
+  }
+  os << "\n  AuxInfo";
+  for (unsigned int iv = 0; iv < fGFAuxInfo.size(); iv++) {
+    os << " [" << iv << "]";
+    for (int ir = 0; ir < fGFAuxInfo[iv].GetNrows(); ir++) os << " " << fGFAuxInfo[iv](ir);
+  }
+  os << "\n  StateVec";
+  for (unsigned int iv = 0; iv < fGFStateVec.size(); iv++) {
+    os << " [" << iv << "]";
+    for (int ir = 0; ir < fGFStateVec[iv].GetNrows(); ir++) os << " " << fGFStateVec[iv](ir);
+  }
+  os << "\n  Cov";
+  for (unsigned int iv = 0; iv < fGFCov.size(); iv++) {
+    os << " [" << iv << "]";
+    for (int ir = 0; ir < fGFCov[iv].GetNrows(); ir++) {
+      os << " (";
+      for (int ic = 0; ic < fGFCov[iv].GetNcols(); ic++) os << " " << fGFCov[iv][ir][ic];
+      os << ")";
+    }
+  }
+  os << std::endl;
+}
+
 void SRecDimuon::calcVariables(int choice)
 {
     TLorentzVector pos, neg;

--- a/packages/reco/interface/SRecEvent.h
+++ b/packages/reco/interface/SRecEvent.h
@@ -238,6 +238,7 @@ public:
 
     ///Debugging output
     void print(std::ostream& os = std::cout) const;
+    void printGF(std::ostream& os = std::cout) const;
 
 private:
     ///Total Chisq

--- a/packages/reco/ktracker/SQVertexing.cxx
+++ b/packages/reco/ktracker/SQVertexing.cxx
@@ -214,7 +214,7 @@ double SQVertexing::swimTrackToVertex(SQGenFit::GFTrack& track, double z, TVecto
 
 double SQVertexing::refitTrkToVtx(SQGenFit::GFTrack& track, double z, TVector3* pos, TVector3* mom)
 {
-  if(Verbosity() > 20) std::cout << "SQVertexing::refitTrkToVtx(): z = " << z << ", pos = (" << pos->X() << ", " << pos->Y() << ", " << pos->Z() << "), mom = (" << mom->X() << ", " << mom->Y() << ", " << mom->Z() << ")" << std::endl;
+  if(Verbosity() > 10) std::cout << "SQVertexing::refitTrkToVtx(): z = " << z << std::endl;
   gfield->setOffset(0.);
 
   double z_offset_prev = 1.E9;
@@ -237,7 +237,9 @@ double SQVertexing::refitTrkToVtx(SQGenFit::GFTrack& track, double z, TVector3* 
       break;
     }
   }
-  if(Verbosity() > 10) std::cout << "  n_iter = " << n_iter << std::endl;
+  if(Verbosity() > 10) {
+    std::cout << "  n_iter = " << n_iter << ",  pos = (" << pos->X() << ", " << pos->Y() << ", " << pos->Z() << "),  mom = (" << mom->X() << ", " << mom->Y() << ", " << mom->Z() << ")" << std::endl;
+  }
   
   //re-adjust FMag bend plane here
   gfield->setOffset(0.);
@@ -262,6 +264,10 @@ double SQVertexing::calcZsclp(double p)
 bool SQVertexing::processOneDimuon(SRecTrack* track1, SRecTrack* track2, SRecDimuon& dimuon)
 {
   if(Verbosity() > 10) std::cout << "  SQVertexing::processOneDimuon(): " << std::endl;
+  if(Verbosity() > 20) {
+    track1->printGF();
+    track2->printGF();
+  }
   
   //Pre-calculated variables
   dimuon.proj_target_pos = track1->getTargetPos();

--- a/packages/reco/ktracker/SQVertexing.cxx
+++ b/packages/reco/ktracker/SQVertexing.cxx
@@ -15,6 +15,8 @@
 #include <interface_main/SQTrackVector_v1.h>
 #include <interface_main/SQDimuonVector_v1.h>
 #include <GenFit/FieldManager.h>
+#include <GenFit/MaterialEffects.h>
+#include <GenFit/TGeoMaterialInterface.h>
 
 #include "SRecEvent.h"
 #include "GFTrack.h"
@@ -371,6 +373,8 @@ int SQVertexing::InitField(PHCompositeNode* topNode)
 
     std::cout << "SQVertexing::InitGeom - creating new GenFit field map" << std::endl;
     gfield = new SQGenFit::GFField(phfield);
+    genfit::FieldManager::getInstance()->init(gfield);
+    genfit::MaterialEffects::getInstance()->init(new genfit::TGeoMaterialInterface());
   }
   else
   {


### PR DESCRIPTION
This is to fix a problem that SQVertexing outputs a different/strange vertexing result when it is used alone (i.e. without SQReco).  One clear failure was seen on the matrix inversion made in "GFTrack::updatePropState()".  It was because the beam covariance matrix was zero, and the root cause was that GFTrack was initialized only in the default constructor.  The default constructor is called only in SQReco, thus this problem was not apparent. 