### PR TITLE
Removal of out-of-time hits by `CalibHodoInTime` and `CalibDriftDist`

### DIFF
--- a/interface_main/SQHitVector.h
+++ b/interface_main/SQHitVector.h
@@ -42,25 +42,25 @@ public:
   virtual void identify(std::ostream& os = std::cout) const {
     os << "SQHitVector base class" << std::endl;
   }
-  virtual void Reset() {}
-  virtual int  isValid() const {return 0;}
-  virtual SQHitVector* Clone() const {return NULL;}
+  virtual void Reset() = 0;
+  virtual int  isValid() const = 0;
+  virtual SQHitVector* Clone() const = 0;
 
-  virtual bool   empty()                   const {return true;}
-  virtual size_t  size()                   const {return 0;}
-  virtual void   clear()                         {}
+  virtual bool   empty() const = 0;
+  virtual size_t  size() const = 0;
+  virtual void   clear() = 0;
 
-  virtual const SQHit* at(const size_t idkey) const {return nullptr;}
-  virtual       SQHit* at(const size_t idkey) {return NULL;}
-  virtual       void   push_back(const SQHit *hit) {}
-  virtual       size_t erase(const size_t idkey) {return 0;}
-  virtual       Iter   erase(Iter pos) {return HitVector().end();}
+  virtual const SQHit* at(const size_t idkey) const = 0;
+  virtual       SQHit* at(const size_t idkey) = 0;
+  virtual       void   push_back(const SQHit *hit) = 0;
+  virtual       size_t erase(const size_t idkey) = 0;
+  virtual       Iter   erase(Iter pos) = 0;
 
-  virtual ConstIter begin()                   const {return HitVector().end();}
-  virtual ConstIter   end()                   const {return HitVector().end();}
+  virtual ConstIter begin() const = 0;
+  virtual ConstIter   end() const = 0;
 
-  virtual Iter begin()                   {return HitVector().end();}
-  virtual Iter   end()                   {return HitVector().end();}
+  virtual Iter begin() = 0;
+  virtual Iter   end() = 0;
 
 protected:
   SQHitVector() {}

--- a/packages/calibrator/CalibDriftDist.cc
+++ b/packages/calibrator/CalibDriftDist.cc
@@ -15,6 +15,7 @@ using namespace std;
 
 CalibDriftDist::CalibDriftDist(const std::string& name)
   : SubsysReco(name)
+  , m_skip_calib(false)
   , m_delete_out_time_hit(false)
   , m_manual_map_selection(false)
   , m_fn_xt("")
@@ -36,7 +37,7 @@ CalibDriftDist::~CalibDriftDist()
 
 int CalibDriftDist::Init(PHCompositeNode* topNode)
 {
-  if (m_manual_map_selection) {
+  if (! m_skip_calib && m_manual_map_selection) {
     m_cal_xt = new CalibParamXT();
     m_cal_xt->SetMapID(m_fn_xt);
     m_cal_xt->ReadFromLocalFile(m_fn_xt);
@@ -51,40 +52,44 @@ int CalibDriftDist::InitRun(PHCompositeNode* topNode)
   m_vec_hit = findNode::getClass<SQHitVector>(topNode, "SQHitVector");
   if (!m_vec_hit) return Fun4AllReturnCodes::ABORTEVENT;
 
-  recoConsts* rc = recoConsts::instance();
+  if (m_skip_calib) {
+    if (Verbosity() > 0) cout << Name() << ": Skip the calibration." << endl;
+  } else {
+    recoConsts* rc = recoConsts::instance();
 
-  if (! m_manual_map_selection) {
-    int run_id = rc->get_IntFlag("RUNNUMBER");
-    m_cal_xt = new CalibParamXT();
-    m_cal_xt->SetMapIDbyDB(run_id); // (run_header->get_run_id());
-    m_cal_xt->ReadFromDB();
-  }
+    if (! m_manual_map_selection) {
+      int run_id = rc->get_IntFlag("RUNNUMBER");
+      m_cal_xt = new CalibParamXT();
+      m_cal_xt->SetMapIDbyDB(run_id); // (run_header->get_run_id());
+      m_cal_xt->ReadFromDB();
+    }
+    
+    SQParamDeco* param_deco = findNode::getClass<SQParamDeco>(topNode, "SQParamDeco");
+    if (param_deco) {
+      param_deco->set_variable(m_cal_xt->GetParamID(), m_cal_xt->GetMapID());
+    }
+    
+    rc->set_CharFlag(m_cal_xt->GetParamID(), m_cal_xt->GetMapID());
+    if (Verbosity() > 0) {
+      cout << Name() << ": " << m_cal_xt->GetParamID() << " = " << m_cal_xt->GetMapID() << "\n";
+    }
 
-  SQParamDeco* param_deco = findNode::getClass<SQParamDeco>(topNode, "SQParamDeco");
-  if (param_deco) {
-    param_deco->set_variable(m_cal_xt->GetParamID(), m_cal_xt->GetMapID());
-  }
-
-  rc->set_CharFlag(m_cal_xt->GetParamID(), m_cal_xt->GetMapID());
-  if (Verbosity() > 0) {
-    cout << Name() << ": " << m_cal_xt->GetParamID() << " = " << m_cal_xt->GetMapID() << "\n";
-  }
-
-  if (m_reso_d0 > 0) {
-    if (Verbosity() > 0) cout << "CalibDriftDist: Set the plane resolution.\n";
-    GeomSvc* geom = GeomSvc::instance();
-    for (int ii = 1; ii <= nChamberPlanes; ii++) {
-      Plane* plane = geom->getPlanePtr(ii);
-      string name = plane->detectorName;
-      double reso = -1;
-      if      (name.substr(0, 2) == "D0" ) reso = m_reso_d0;
-      else if (name.substr(0, 2) == "D1" ) reso = m_reso_d1;
-      else if (name.substr(0, 2) == "D2" ) reso = m_reso_d2;
-      else if (name.substr(0, 3) == "D3p") reso = m_reso_d3p;
-      else if (name.substr(0, 3) == "D3m") reso = m_reso_d3m;
-      if (reso > 0) {
-        plane->resolution = reso;
-        if (Verbosity() > 0) cout << "  " << setw(2) << ii << ":" << setw(5) << name << " = " << reso << endl;
+    if (m_reso_d0 > 0) {
+      if (Verbosity() > 0) cout << Name() << ": Set the plane resolution.\n";
+      GeomSvc* geom = GeomSvc::instance();
+      for (int ii = 1; ii <= nChamberPlanes; ii++) {
+        Plane* plane = geom->getPlanePtr(ii);
+        string name = plane->detectorName;
+        double reso = -1;
+        if      (name.substr(0, 2) == "D0" ) reso = m_reso_d0;
+        else if (name.substr(0, 2) == "D1" ) reso = m_reso_d1;
+        else if (name.substr(0, 2) == "D2" ) reso = m_reso_d2;
+        else if (name.substr(0, 3) == "D3p") reso = m_reso_d3p;
+        else if (name.substr(0, 3) == "D3m") reso = m_reso_d3m;
+        if (reso > 0) {
+          plane->resolution = reso;
+          if (Verbosity() > 0) cout << "  " << setw(2) << ii << ":" << setw(5) << name << " = " << reso << endl;
+        }
       }
     }
   }
@@ -98,7 +103,7 @@ int CalibDriftDist::process_event(PHCompositeNode* topNode)
   map<int, int> list_n_hit_out;
     
   GeomSvc* geom = GeomSvc::instance();
-  for (SQHitVector::Iter it = m_vec_hit->begin(); it != m_vec_hit->end();) {
+  for (SQHitVector::Iter it = m_vec_hit->begin(); it != m_vec_hit->end(); ) {
     SQHit* hit = *it;
     int det = hit->get_detector_id();
     if (!geom->isChamber(det) && !geom->isPropTube(det)) {
@@ -106,35 +111,37 @@ int CalibDriftDist::process_event(PHCompositeNode* topNode)
       continue;
     }
 
-    CalibParamXT::Set* xt = m_cal_xt->GetParam(det);
-    if (! det) {
-      cerr << "  WARNING:  Cannot find the in-time parameter for det=" << det << " in CalibDriftDist.\n";
-      it++;
-      continue;
-      //return Fun4AllReturnCodes::ABORTEVENT;
-    }
-    float tdc_time = hit->get_tdc_time();
-    bool is_in_time = (xt->T1 <= tdc_time && tdc_time <= xt->T0);
-    if (m_delete_out_time_hit && ! is_in_time) {
-      it = m_vec_hit->erase(it);
-    } else {
+    if (! m_skip_calib) {
+      CalibParamXT::Set* xt = m_cal_xt->GetParam(det);
+      if (! det) {
+        cerr << "  WARNING:  Cannot find the in-time parameter for det=" << det << " in CalibDriftDist.\n";
+        it++;
+        continue; // return Fun4AllReturnCodes::ABORTEVENT;
+      }
+      float tdc_time = hit->get_tdc_time();
       float drift_dist = xt->t2x.Eval(tdc_time);
       if (drift_dist < 0) drift_dist = 0;
       hit->set_drift_distance(drift_dist);
-      hit->set_in_time(is_in_time);
+      hit->set_in_time( xt->T1 <= tdc_time && tdc_time <= xt->T0 );
       /// No field for resolution in SQHit now.
-
+      
       int ele = hit->get_element_id();
       hit->set_pos(geom->getMeasurement(det, ele));
-      it++;
     }
-    if (Verbosity() > 1 && m_delete_out_time_hit) {
-      list_n_hit_in[det]++;
-      if (is_in_time) list_n_hit_out[det]++;
+    if (m_delete_out_time_hit) {
+      if (! hit->is_in_time()) {
+        it = m_vec_hit->erase(it);
+      } else {
+        it++;
+        if (Verbosity() > 1) list_n_hit_out[det]++;
+      }
+      if (Verbosity() > 1) list_n_hit_in[det]++;
+    } else {
+      it++;
     }
   }
   if (Verbosity() > 1 && m_delete_out_time_hit) {
-    cout << "CalibDriftDist: ";
+    cout << Name() << ": ";
     for (auto it = list_n_hit_in.begin(); it != list_n_hit_in.end(); it++) {
       cout << " " << it->first << ":" << it->second << "->" << list_n_hit_out[it->first];
     }

--- a/packages/calibrator/CalibDriftDist.h
+++ b/packages/calibrator/CalibDriftDist.h
@@ -10,6 +10,7 @@ class CalibParamXT;
  * Only when necessary, you can manually give a parameter set via `ReadParamFromFile()`.
  */
 class CalibDriftDist: public SubsysReco {
+  bool m_delete_out_time_hit;
   bool m_manual_map_selection;
   std::string m_fn_xt;
   SQHitVector* m_vec_hit;
@@ -32,6 +33,7 @@ class CalibDriftDist: public SubsysReco {
   /// Set the plane resolutions in cm.
   void SetResolution(const double reso_d0, const double reso_d1, const double reso_d2, const double reso_d3p, const double reso_d3m);
 
+  void DeleteOutTimeHit() { m_delete_out_time_hit = true; }
   void ReadParamFromFile(const char* fn_xt_curve);
   CalibParamXT* GetParamXT() { return m_cal_xt; }
 };

--- a/packages/calibrator/CalibDriftDist.h
+++ b/packages/calibrator/CalibDriftDist.h
@@ -8,8 +8,17 @@ class CalibParamXT;
 /**
  * This module automatically selects a proper set of calibration parameters based on the run number.
  * Only when necessary, you can manually give a parameter set via `ReadParamFromFile()`.
+ * 
+ * @code
+ *   auto cal_dd = new CalibDriftDist();
+ *   //cal_dd->Verbosity(10);
+ *   //cal_dd->SkipCalibration(); // Uncomment this when needed.
+ *   //cal_dd->DeleteOutTimeHit(); // Uncomment this when needed.
+ *   se->registerSubsystem(cal_dd);
+ * @endcode
  */
 class CalibDriftDist: public SubsysReco {
+  bool m_skip_calib;
   bool m_delete_out_time_hit;
   bool m_manual_map_selection;
   std::string m_fn_xt;
@@ -30,10 +39,12 @@ class CalibDriftDist: public SubsysReco {
   int process_event(PHCompositeNode *topNode);
   int End(PHCompositeNode *topNode);
 
+  /// Have this module skip the calibration.  Useful when you only delete out-of-time hits.
+  void SkipCalibration() { m_skip_calib = true; }
+  /// Have this module delete out-of-time hits.
+  void DeleteOutTimeHit() { m_delete_out_time_hit = true; }
   /// Set the plane resolutions in cm.
   void SetResolution(const double reso_d0, const double reso_d1, const double reso_d2, const double reso_d3p, const double reso_d3m);
-
-  void DeleteOutTimeHit() { m_delete_out_time_hit = true; }
   void ReadParamFromFile(const char* fn_xt_curve);
   CalibParamXT* GetParamXT() { return m_cal_xt; }
 };

--- a/packages/calibrator/CalibHodoInTime.cc
+++ b/packages/calibrator/CalibHodoInTime.cc
@@ -15,6 +15,8 @@ using namespace std;
 
 CalibHodoInTime::CalibHodoInTime(const std::string& name)
   : SubsysReco(name)
+  , m_skip_calib(false)
+  , m_delete_out_time_hit(false)
   , m_vec_hit   (0)
   , m_vec_trhit (0)
   , m_cal_taiwan(0)
@@ -42,68 +44,86 @@ int CalibHodoInTime::InitRun(PHCompositeNode* topNode)
   m_vec_trhit = findNode::getClass<SQHitVector>(topNode, "SQTriggerHitVector");
   if (!m_vec_hit || !m_vec_trhit) return Fun4AllReturnCodes::ABORTEVENT;
 
-  recoConsts* rc = recoConsts::instance();
-  int run_id = rc->get_IntFlag("RUNNUMBER");
-
-  m_cal_taiwan = new CalibParamInTimeTaiwan();
-  m_cal_taiwan->SetMapIDbyDB(run_id); // (run_header->get_run_id());
-  m_cal_taiwan->ReadFromDB();
-
-  m_cal_v1495 = new CalibParamInTimeV1495();
-  m_cal_v1495->SetMapIDbyDB(run_id); // (run_header->get_run_id());
-  m_cal_v1495->ReadFromDB();
-
-  SQParamDeco* param_deco = findNode::getClass<SQParamDeco>(topNode, "SQParamDeco");
-  if (param_deco)  {
-    param_deco->set_variable(m_cal_taiwan->GetParamID(), m_cal_taiwan->GetMapID());
-    param_deco->set_variable(m_cal_v1495 ->GetParamID(), m_cal_v1495 ->GetMapID());
+  if (m_skip_calib) {
+    if (Verbosity() > 0) cout << Name() << ": Skip the calibration." << endl;
+  } else {
+    recoConsts* rc = recoConsts::instance();
+    int run_id = rc->get_IntFlag("RUNNUMBER");
+    
+    m_cal_taiwan = new CalibParamInTimeTaiwan();
+    m_cal_taiwan->SetMapIDbyDB(run_id); // (run_header->get_run_id());
+    m_cal_taiwan->ReadFromDB();
+    
+    m_cal_v1495 = new CalibParamInTimeV1495();
+    m_cal_v1495->SetMapIDbyDB(run_id); // (run_header->get_run_id());
+    m_cal_v1495->ReadFromDB();
+    
+    SQParamDeco* param_deco = findNode::getClass<SQParamDeco>(topNode, "SQParamDeco");
+    if (param_deco)  {
+      param_deco->set_variable(m_cal_taiwan->GetParamID(), m_cal_taiwan->GetMapID());
+      param_deco->set_variable(m_cal_v1495 ->GetParamID(), m_cal_v1495 ->GetMapID());
+    }
+    
+    rc->set_CharFlag(m_cal_taiwan->GetParamID(), m_cal_taiwan->GetMapID());
+    rc->set_CharFlag(m_cal_v1495 ->GetParamID(), m_cal_v1495 ->GetMapID());
+  
+    if (Verbosity() > 0) {
+      cout << Name() << ": " << m_cal_taiwan->GetParamID() << " = " << m_cal_taiwan->GetMapID() << "\n"
+           << Name() << ": " << m_cal_v1495 ->GetParamID() << " = " << m_cal_v1495 ->GetMapID() << "\n";
+    }
   }
-
-  rc->set_CharFlag(m_cal_taiwan->GetParamID(), m_cal_taiwan->GetMapID());
-  rc->set_CharFlag(m_cal_v1495 ->GetParamID(), m_cal_v1495 ->GetMapID());
-
-  if (Verbosity() > 0) {
-    cout << Name() << ": " << m_cal_taiwan->GetParamID() << " = " << m_cal_taiwan->GetMapID() << "\n"
-         << Name() << ": " << m_cal_v1495 ->GetParamID() << " = " << m_cal_v1495 ->GetMapID() << "\n";
-  }
-
+  
   return Fun4AllReturnCodes::EVENT_OK;
 }
 
 int CalibHodoInTime::process_event(PHCompositeNode* topNode)
 {
   GeomSvc* geom = GeomSvc::instance();
-  for (SQHitVector::Iter it = m_vec_hit->begin(); it != m_vec_hit->end(); it++) {
+  for (SQHitVector::Iter it = m_vec_hit->begin(); it != m_vec_hit->end(); ) {
     SQHit* hit = *it;
     int det = hit->get_detector_id();
-    if (!geom->isHodo(det) && !geom->isDPHodo(det) && !geom->isInh(det)) continue;
-
-    int ele = hit->get_element_id();
-    double center, width;
-    if (! m_cal_taiwan->Find(det, ele, center, width)) {
-      if (Verbosity() > 1) cerr << "  WARNING:  Cannot find the in-time parameter for det=" << det << " ele=" << ele << ".\n";
-      //hit->set_in_time(false);
+    if (!geom->isHodo(det) && !geom->isDPHodo(det) && !geom->isInh(det)) {
+      it++;
       continue;
     }
-    hit->set_in_time( fabs(hit->get_tdc_time() - center) <= width / 2 );
-    hit->set_drift_distance(0);
+
+    if (! m_skip_calib) {
+      int ele = hit->get_element_id();
+      double center, width;
+      if (! m_cal_taiwan->Find(det, ele, center, width)) {
+        if (Verbosity() > 1) cerr << "  WARNING:  Cannot find the in-time parameter for det=" << det << " ele=" << ele << ".\n";
+        it++;
+        continue;
+      }
+      hit->set_in_time( fabs(hit->get_tdc_time() - center) <= width / 2 );
+      hit->set_drift_distance(0);
+    }
+    if (m_delete_out_time_hit && ! hit->is_in_time()) it = m_vec_hit->erase(it);
+    else                                              it++;
   }
 
-  for (SQHitVector::Iter it = m_vec_trhit->begin(); it != m_vec_trhit->end(); it++) {
+  for (SQHitVector::Iter it = m_vec_trhit->begin(); it != m_vec_trhit->end(); ) {
     SQHit* hit = *it;
     int det = hit->get_detector_id();
-    if (!geom->isHodo(det)) continue;
-
-    int ele = hit->get_element_id();
-    int lvl = hit->get_level();
-    double center, width;
-    if (! m_cal_v1495->Find(det, ele, lvl, center, width)) {
-      if (Verbosity() > 1) cerr << "  WARNING:  Cannot find the in-time parameter for trigger det=" << det << " ele=" << ele << " lvl=" << lvl << ".\n";
-      //hit->set_in_time(false);
+    if (!geom->isHodo(det)) {
+      it++;
       continue;
     }
-    hit->set_in_time( fabs(hit->get_tdc_time() - center) <= width / 2 );
-    hit->set_drift_distance(0);
+
+    if (! m_skip_calib) {
+      int ele = hit->get_element_id();
+      int lvl = hit->get_level();
+      double center, width;
+      if (! m_cal_v1495->Find(det, ele, lvl, center, width)) {
+        if (Verbosity() > 1) cerr << "  WARNING:  Cannot find the in-time parameter for trigger det=" << det << " ele=" << ele << " lvl=" << lvl << ".\n";
+        it++;
+        continue;
+      }
+      hit->set_in_time( fabs(hit->get_tdc_time() - center) <= width / 2 );
+      hit->set_drift_distance(0);
+    }
+    if (m_delete_out_time_hit && ! hit->is_in_time()) it = m_vec_trhit->erase(it);
+    else                                              it++;
   }
 
   return Fun4AllReturnCodes::EVENT_OK;

--- a/packages/calibrator/CalibHodoInTime.h
+++ b/packages/calibrator/CalibHodoInTime.h
@@ -7,9 +7,18 @@ class CalibParamInTimeV1495;
 
 /// SubsysReco module to calibrate the in-time window of the hodoscope.
 /**
- * It does _not_ take care of the DP hodoscope at present.
+ * The calibration parameter (i.e. center and width of window) is taken from DB, based on run number.
+ * 
+ * @code
+ *   auto cal_hodo = new CalibHodoInTime();
+ *   //cal_hodo->SkipCalibration(); // Uncomment this when needed.
+ *   //cal_hodo->DeleteOutTimeHit(); // Uncomment this when needed.
+ *   se->registerSubsystem(cal_hodo);
+ * @endcode
  */
 class CalibHodoInTime: public SubsysReco {
+  bool m_skip_calib;
+  bool m_delete_out_time_hit;
   SQHitVector* m_vec_hit;
   SQHitVector* m_vec_trhit;
   CalibParamInTimeTaiwan* m_cal_taiwan;
@@ -22,6 +31,11 @@ class CalibHodoInTime: public SubsysReco {
   int InitRun(PHCompositeNode *topNode);
   int process_event(PHCompositeNode *topNode);
   int End(PHCompositeNode *topNode);
+
+  /// Have this module skip the calibration.  Useful when you only delete out-of-time hits.
+  void SkipCalibration() { m_skip_calib = true; }
+  /// Have this module delete out-of-time hits.
+  void DeleteOutTimeHit() { m_delete_out_time_hit = true; }
 };
 
 #endif // __CALIB_HODO_IN_TIME_H__


### PR DESCRIPTION
This update is to add options to `CalibHodoInTime` and `CalibDriftDist` about hit removal.  They will be able to delete out-of-time hits when `DeleteOutTimeHit()` is called.  They will be able to also skip the calibration when `SkipCalibration()` is called, so that they can only delete out-of-time hits using the existing in-time flag of SQHits.

The default behaviors of  `CalibHodoInTime` and `CalibDriftDist` haven't changed.  

`SQHitVector.h` was modified to suppress the compilation warning about `return HitVector().end()`.