### PR TITLE
Single Muon Generator

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -80,6 +80,7 @@ else # 'all' or 'resume'
     simulation/g4detectors
     simulation/g4eval
     generators/E906LegacyGen
+    generators/SingleMuonGen
     packages/calibrator
     packages/evt_filter
     packages/dptrigger

--- a/generators/SingleMuonGen/CMakeLists.txt
+++ b/generators/SingleMuonGen/CMakeLists.txt
@@ -1,0 +1,73 @@
+# Setup the project
+cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
+project(SingleMuonGen CXX C)
+
+# source code
+include_directories("${PROJECT_SOURCE_DIR}/")
+file(GLOB sources ${PROJECT_SOURCE_DIR}/*.cxx)
+file(GLOB headers ${PROJECT_SOURCE_DIR}/*.h)
+
+# ROOT
+find_program(ROOTCONF "root-config")
+if(ROOTCONF)
+  message("-- Detecting ROOT:    found at ${ROOTCONF}")
+else()
+  message(FATAL_ERROR "-- Detecting ROOT:    not found")
+endif()
+execute_process(COMMAND root-config --prefix OUTPUT_VARIABLE ROOT_PREFIX  OUTPUT_STRIP_TRAILING_WHITESPACE)
+execute_process(COMMAND root-config --cflags OUTPUT_VARIABLE ROOT_CFLAGS  OUTPUT_STRIP_TRAILING_WHITESPACE)
+execute_process(COMMAND root-config --libs   OUTPUT_VARIABLE ROOT_LINK    OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+# Geant4
+find_program(G4CONF "geant4-config")
+if(G4CONF)
+  message("-- Detecting Geant4:  found at ${G4CONF}")
+else()
+  message(FATAL_ERROR "-- Detecting Geant4:  not found")
+endif()
+#find_package(Geant4 REQUIRED vis_all)
+execute_process(COMMAND geant4-config --prefix OUTPUT_VARIABLE GEANT4_PREFIX OUTPUT_STRIP_TRAILING_WHITESPACE)
+execute_process(COMMAND geant4-config --cflags OUTPUT_VARIABLE GEANT4_CFLAGS OUTPUT_STRIP_TRAILING_WHITESPACE)
+execute_process(COMMAND geant4-config --libs   OUTPUT_VARIABLE GEANT4_LINK   OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+# Warning suppression
+string(REGEX REPLACE "-W[a-z-]*" "" GEANT4_CFLAGS ${GEANT4_CFLAGS})
+string(REPLACE "-pedantic" "" GEANT4_CFLAGS ${GEANT4_CFLAGS})
+
+# ROOT dict generation
+file(GLOB dicts "")
+file(GLOB LinkDefhs ${PROJECT_SOURCE_DIR}/*LinkDef.h)
+foreach(LinkDefh ${LinkDefhs})
+	string(REPLACE "LinkDef.h" ".h" Dicth ${LinkDefh})
+	string(REPLACE "LinkDef.h" "_Dict.C" DictC ${LinkDefh})
+	string(REPLACE "${PROJECT_SOURCE_DIR}/" "" DictC ${DictC})
+	list(APPEND dicts ${DictC})
+	add_custom_command(OUTPUT ${DictC} COMMAND rootcint ARGS -f ${DictC} -noIncludePaths -inlineInputHeader -c -p -I${PROJECT_SOURCE_DIR} -I${GEANT4_PREFIX}/include/Geant4 ${Dicth} ${LinkDefh})
+endforeach(LinkDefh)
+
+# source code
+include_directories("${PROJECT_SOURCE_DIR}/")
+file(GLOB sources ${PROJECT_SOURCE_DIR}/*.cxx)
+file(GLOB headers ${PROJECT_SOURCE_DIR}/*.h)
+
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${GEANT4_CFLAGS} ${ROOT_CFLAGS} -std=c++17")
+set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -lphool")
+add_library(singlemuongen SHARED ${sources} ${dicts})
+target_link_libraries(singlemuongen -lfun4all -lphool -lSubsysReco -lg4testbench -lphg4hit ${ROOT_LINK})
+
+message(STATUS ${PROJECT_SOURCE_DIR} " will be installed to " ${CMAKE_INSTALL_PREFIX})
+
+install(TARGETS singlemuongen DESTINATION ${CMAKE_INSTALL_PREFIX}/lib)
+
+file(GLOB dist_headers ${PROJECT_SOURCE_DIR}/*.h)
+file(GLOB non_dist_headers ${PROJECT_SOURCE_DIR}/*LinkDef.h)
+list(REMOVE_ITEM dist_headers ${non_dist_headers})
+install(FILES ${dist_headers} DESTINATION ${CMAKE_INSTALL_PREFIX}/include/${CMAKE_PROJECT_NAME}/)
+
+# Install the pcm files in case of ROOT 6.
+execute_process(COMMAND root-config --version OUTPUT_VARIABLE ROOT_VER)
+string(SUBSTRING ${ROOT_VER} 0 1 ROOT_VER)
+if (ROOT_VER GREATER 5)
+   add_custom_target(install_pcm ALL COMMAND mkdir -p ${CMAKE_INSTALL_PREFIX}/lib COMMAND cp -up *_rdict.pcm ${CMAKE_INSTALL_PREFIX}/lib)
+   add_dependencies(install_pcm singlemuongen)
+endif()

--- a/generators/SingleMuonGen/SQSingleMuonGen.cxx
+++ b/generators/SingleMuonGen/SQSingleMuonGen.cxx
@@ -1,0 +1,221 @@
+#include "SQSingleMuonGen.h"
+
+#include <g4main/PHG4Particlev2.h>
+#include <g4main/PHG4InEvent.h>
+#include <g4main/PHG4VtxPointv1.h>
+#include <g4main/PHG4TruthInfoContainer.h>
+
+#include <fun4all/Fun4AllReturnCodes.h>
+#include <phool/getClass.h>
+
+#include <phool/PHCompositeNode.h>
+#include <phool/PHIODataNode.h>
+#include <phool/PHRandomSeed.h>
+
+#include <Geant4/G4ParticleTable.hh>
+#include <Geant4/G4ParticleDefinition.hh>
+
+#include <TMath.h>
+#include <TGenPhaseSpace.h>
+
+#include <cstdlib>
+#include <cmath>
+#include <cassert>
+
+SQSingleMuonGen::SQSingleMuonGen(const std::string& name): 
+  PHG4ParticleGeneratorBase(name),
+  _ineve(nullptr),
+  _truth(nullptr),
+  _target_only(true),
+  _enable_geom_cut(true),
+  _enable_real_mom_dist(true),
+  _ctau(2.6E-8*29979245800.),
+  _mom_min(1.),
+  _mom_max(100.),
+  _pt_max(4.),
+  _charge_ratio(0.5),
+  _m_muon(0.1057),
+  _m_pion(0.13957),
+  _rndm(PHRandomSeed())
+{
+}
+
+int SQSingleMuonGen::InitRun(PHCompositeNode* topNode) 
+{
+  PHNodeIterator iter(topNode);
+  PHCompositeNode* dstNode = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "DST"));
+
+  _truth = new SQSingleMuonTruthInfo();
+  PHIODataNode<PHObject>* truthNode = new PHIODataNode<PHObject>(_truth, "TruthInfo", "PHObject");
+  dstNode->addNode(truthNode);
+
+  _ineve = findNode::getClass<PHG4InEvent>(topNode, "PHG4INEVENT");
+  if(!_ineve) 
+  {  
+    _ineve = new PHG4InEvent();
+    PHIODataNode<PHObject>* eveNode = new PHIODataNode<PHObject>(_ineve, "PHG4INEVENT", "PHObject");
+    dstNode->addNode(eveNode);
+  }
+
+  _pt_dist    = new TF1("PtDistr", "1*(x^-2)", 0.00001, _pt_max);
+  _pz_dist[0] = new TF1("PzDistr1", "0.161*(x^-2.396)", _mom_min, _mom_max);
+  _pz_dist[1] = new TF1("PzDistr2", "0.527*(x^-1.996)", _mom_min, _mom_max);
+  _pz_dist[2] = new TF1("PzDistr3", "0.489*(x^-2.200)", _mom_min, _mom_max);
+  _pz_dist[3] = new TF1("PzDistr4", "0.302*(x^-1.900)", _mom_min, _mom_max);
+  _pz_dist[4] = new TF1("PzDistr5", "0.174*(x^-1.750)", _mom_min, _mom_max);
+  _pz_dist[5] = new TF1("PzDistr6", "0.909*(x^-1.850)", _mom_min > 8. ? _mom_min : 8., _mom_max);
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+SQSingleMuonGen::~SQSingleMuonGen()
+{
+  for(int i = 0; i < 6; ++i) delete _pz_dist[i];
+  delete _pt_dist;
+}
+
+int SQSingleMuonGen::process_event(PHCompositeNode* topNode) 
+{
+  int nTries = 0;
+  bool accepted = false;
+  while(!accepted)
+  {
+    //Generate mother particle first
+    generatePrimaryVtx();
+    generateMotherParticle();
+
+    //Decay the mother particle, and get the muon's vtx and mom
+    decayMotherParticle();
+
+    accepted = _enable_geom_cut ? geometryCut() : true;
+
+    ++nTries;
+  }
+
+  if(Verbosity() > 10) std::cout << "Generated single muon within acceptance after " << nTries << " tries." << std::endl;
+
+  int pdgcode = _truth->motherPid > 0 ? 13 : -13;
+  std::string pdgname = get_pdgname(pdgcode);
+
+  //Generate a muon and set common features
+  int vtxID = _ineve->AddVtx(_truth->muVtx.X(), _truth->muVtx.Y(), _truth->muVtx.Z(), 0.);
+  PHG4Particle* particle = new PHG4Particlev2();
+  particle->set_track_id(0);
+  particle->set_vtx_id(vtxID);
+  particle->set_parent_id(0);
+  particle->set_pid(pdgcode);
+  particle->set_name(pdgname);
+
+  double m  = 0.105658;
+  double e  = TMath::Sqrt(_truth->muMom.Mag2() + m*m);
+  particle->set_px(_truth->muMom.X());
+  particle->set_py(_truth->muMom.Y());
+  particle->set_pz(_truth->muMom.Z());
+  particle->set_e(e);
+  _ineve->AddParticle(vtxID, particle);  //ownership of particle is transferred to _ineve and released in its Reset action
+
+  if(Verbosity() > Fun4AllBase::VERBOSITY_A_LOT)
+  {
+    _ineve->identify();
+  }
+
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+void SQSingleMuonGen::generateMotherParticle()
+{
+  int pid = _rndm.Rndm() < _charge_ratio ? 211 : -211;
+  std::string name = get_pdgname(pid);
+
+  TLorentzVector p;
+  if(_enable_real_mom_dist)
+  {
+    double pt = _pt_dist->GetRandom();
+    double pz = 0.;
+    if(pt < 0.1)
+    {
+      pz = _pz_dist[0]->GetRandom();
+    }
+    else if(pt < 0.2)
+    {
+      pz = _pz_dist[1]->GetRandom();
+    }
+    else if(pt < 0.3)
+    {
+      pz = _pz_dist[2]->GetRandom();
+    }
+    else if(pt < 0.4)
+    {
+      pz = _pz_dist[3]->GetRandom();
+    }
+    else if(pt < 0.5)
+    {
+      pz = _pz_dist[4]->GetRandom();
+    }
+    else
+    {
+      pz = _pz_dist[5]->GetRandom();
+    }
+
+    double phi = _rndm.Rndm()*TMath::TwoPi();
+    double px = pt*TMath::Cos(phi);
+    double py = pt*TMath::Sin(phi);
+
+    p.SetXYZM(px, py, pz, _m_pion);
+  }
+  else
+  {
+    double pz = _mom_min + (_mom_max - _mom_min)*_rndm.Rndm();
+    double pt = _rndm.Rndm()*_pt_max;
+    double phi = _rndm.Rndm()*TMath::TwoPi();
+    double px = pt*TMath::Cos(phi);
+    double py = pt*TMath::Sin(phi);
+
+    p.SetXYZM(px, py, pz, _m_pion);
+  }
+
+  _truth->motherPid = pid;
+  _truth->motherMom = p.Vect();
+}
+
+void SQSingleMuonGen::decayMotherParticle()
+{
+  TGenPhaseSpace evtgen;
+  double m[2] = {_m_muon, 0.};
+
+  TLorentzVector W;
+  W.SetVectM(_truth->motherMom, _m_pion);
+  evtgen.SetDecay(W, 2, m);
+  evtgen.Generate();
+
+  TLorentzVector* p = evtgen.GetDecay(0);
+  _truth->muMom = p->Vect();
+
+  // Get the decay vector
+  double ctau1  = _ctau*W.Gamma();
+  _truth->decayLength = _rndm.Exp(ctau1);
+  _truth->muVtx = _truth->decayLength*_truth->muMom.Unit() + _truth->motherVtx;
+  
+  _truth->identify();
+}
+
+bool SQSingleMuonGen::geometryCut()
+{
+  if(fabs(_truth->muMom.Px()/_truth->muMom.Pz()) > 0.15) return false;
+  if(fabs(_truth->muMom.Py()/_truth->muMom.Pz()) > 0.15) return false;
+  if(_truth->muMom.Mag() < 10.) return false;
+
+  if(_truth->decayLength > 300.) return false;
+  return true;
+}
+
+bool SQSingleMuonGen::generatePrimaryVtx()
+{
+  double x = 0.;
+  double y = 0.;
+  double z = -300.;
+
+  _truth->motherVtx.SetXYZ(x, y, z);
+
+  return true;
+}

--- a/generators/SingleMuonGen/SQSingleMuonGen.cxx
+++ b/generators/SingleMuonGen/SQSingleMuonGen.cxx
@@ -34,7 +34,7 @@ SQSingleMuonGen::SQSingleMuonGen(const std::string& name):
   _mom_max(100.),
   _pt_max(4.),
   _charge_ratio(0.5),
-  _m_muon(0.1057),
+  _m_muon(0.105658),
   _m_pion(0.13957),
   _rndm(PHRandomSeed())
 {
@@ -57,7 +57,8 @@ int SQSingleMuonGen::InitRun(PHCompositeNode* topNode)
     dstNode->addNode(eveNode);
   }
 
-  _pt_dist    = new TF1("PtDistr", "1*(x^-2)", 0.00001, _pt_max);
+  //_pt_dist    = new TF1("PtDistr", "1*(x^-2)", 0.00001, _pt_max);
+  _pt_dist    = new TF1("PtDistr", "TMath::Landau(x, 0.416742, 0.174227)", 0., _pt_max);
   _pz_dist[0] = new TF1("PzDistr1", "0.161*(x^-2.396)", _mom_min, _mom_max);
   _pz_dist[1] = new TF1("PzDistr2", "0.527*(x^-1.996)", _mom_min, _mom_max);
   _pz_dist[2] = new TF1("PzDistr3", "0.489*(x^-2.200)", _mom_min, _mom_max);
@@ -106,8 +107,7 @@ int SQSingleMuonGen::process_event(PHCompositeNode* topNode)
   particle->set_pid(pdgcode);
   particle->set_name(pdgname);
 
-  double m  = 0.105658;
-  double e  = TMath::Sqrt(_truth->muMom.Mag2() + m*m);
+  double e  = TMath::Sqrt(_truth->muMom.Mag2() + _m_muon*_m_muon);
   particle->set_px(_truth->muMom.X());
   particle->set_py(_truth->muMom.Y());
   particle->set_pz(_truth->muMom.Z());

--- a/generators/SingleMuonGen/SQSingleMuonGen.h
+++ b/generators/SingleMuonGen/SQSingleMuonGen.h
@@ -1,0 +1,85 @@
+#ifndef SQSingleMuonGen_H__
+#define SQSingleMuonGen_H__
+
+#include <g4main/PHG4ParticleGeneratorBase.h>
+#include <string>
+
+#include <TVector3.h>
+#include <TRandom2.h>
+#include <TF1.h>
+
+#include "SQSingleMuonTruthInfo.h"
+
+class PHG4InEvent;
+class PHG4Particle;
+class PHG4VtxPoint;
+class PHCompositeNode;
+
+class SQSingleMuonGen: public PHG4ParticleGeneratorBase 
+{
+public:
+
+  SQSingleMuonGen(const std::string& name = "SINGLEGEN");
+  virtual ~SQSingleMuonGen();
+
+  int InitRun(PHCompositeNode *topNode);
+  int process_event(PHCompositeNode *topNode);
+
+  const void set_target_only(bool en = true)   { _target_only = en; }
+  const void enable_geom_cut(bool en = true)   { _enable_geom_cut = en; }
+  const void set_mother_decay_length(double l) { _ctau = l; }
+  const void set_charge_ratio(double v)        { _charge_ratio = v; }
+  const void set_pt_max(double v)              { _pt_max = v; }
+  const void set_mom_range(double min, double max)  { _mom_min = min; _mom_max = max; }
+  const void enable_real_mom_dist(bool en = true)   { _enable_real_mom_dist = en; }
+
+private:
+  //! generate a set of vertex positions based on the acceptance requirement
+  bool generatePrimaryVtx();
+
+  //! Function to generate and decay a pion
+  void generateMotherParticle();
+  void decayMotherParticle();
+
+  //! Check if the muon satisfy the geometry cuts
+  bool geometryCut();
+
+  //! interface to the G4 process
+  PHG4InEvent* _ineve;
+
+  //! Container of the mother particle to be saved on DST
+  SQSingleMuonTruthInfo* _truth;
+
+  //! Minimum and maximum mother particle momentum
+  double _mom_min;
+  double _mom_max;
+  double _pt_max;
+
+  //! target only flag
+  bool _target_only;
+
+  //! enable geometry cut
+  bool _enable_geom_cut;
+
+  //! enable realistic pion momentum distribution
+  bool _enable_real_mom_dist;
+
+  //! Mother particle decay length
+  double _ctau;
+
+  //! pi+/pi- ratio
+  double _charge_ratio;
+
+  //! Random generator
+  TRandom2 _rndm;
+
+  //! Hardcoded mass for muon and pion
+  const double _m_muon;
+  const double _m_pion;
+
+  //! Distribution functions for p/pt distribution
+  TF1* _pz_dist[6];
+  TF1* _pt_dist;
+};
+
+#endif

--- a/generators/SingleMuonGen/SQSingleMuonGen.h
+++ b/generators/SingleMuonGen/SQSingleMuonGen.h
@@ -28,7 +28,7 @@ public:
   const void set_target_only(bool en = true)   { _target_only = en; }
   const void enable_geom_cut(bool en = true)   { _enable_geom_cut = en; }
   const void set_mother_decay_length(double l) { _ctau = l; }
-  const void set_charge_ratio(double v)        { _charge_ratio = v; }
+  const void set_charge_ratio(double v)        { _charge_ratio = v/(v+1.); }
   const void set_pt_max(double v)              { _pt_max = v; }
   const void set_mom_range(double min, double max)  { _mom_min = min; _mom_max = max; }
   const void enable_real_mom_dist(bool en = true)   { _enable_real_mom_dist = en; }

--- a/generators/SingleMuonGen/SQSingleMuonGenLinkDef.h
+++ b/generators/SingleMuonGen/SQSingleMuonGenLinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class SQSingleMuonGen-!;
+
+#endif /* __CINT__ */

--- a/generators/SingleMuonGen/SQSingleMuonTruthInfo.cxx
+++ b/generators/SingleMuonGen/SQSingleMuonTruthInfo.cxx
@@ -1,0 +1,37 @@
+#include "SQSingleMuonTruthInfo.h"
+
+SQSingleMuonTruthInfo::SQSingleMuonTruthInfo():
+  motherPid(0),
+  motherMom(0., 0., 0.),
+  motherVtx(0., 0., 0.),
+  decayLength(-1.),
+  muMom(0., 0., 0.),
+  muVtx(0., 0., 0.)
+{}
+
+SQSingleMuonTruthInfo::~SQSingleMuonTruthInfo()
+{
+}
+
+void SQSingleMuonTruthInfo::identify(std::ostream& os) const
+{
+  os << "Mother particle momentum/vertex: " << std::endl;
+  os << " PID: " << motherPid << std::endl;
+  os << " Mom: "; motherMom.Print();
+  os << " Mom: "; motherVtx.Print();
+
+  os << "Decay particle momentum/vertex: " << std::endl;
+  os << " Mom: "; muMom.Print();
+  os << " Mom: "; muVtx.Print();
+  os << " Decay length: " << decayLength << std::endl;
+}
+
+void SQSingleMuonTruthInfo::Reset()
+{
+  motherMom.SetXYZ(0., 0., 0.);
+  motherVtx.SetXYZ(0., 0., 0.);
+  motherPid = 0;
+  muMom.SetXYZ(0., 0., 0.);
+  muVtx.SetXYZ(0., 0., 0.);
+  decayLength = -1.;
+}

--- a/generators/SingleMuonGen/SQSingleMuonTruthInfo.h
+++ b/generators/SingleMuonGen/SQSingleMuonTruthInfo.h
@@ -1,0 +1,34 @@
+#ifndef _SQSingleMuonTruthInfo_H
+#define _SQSingleMuonTruthInfo_H
+
+#include <phool/PHObject.h>
+
+#include <iostream>
+#include <TLorentzVector.h>
+
+class SQSingleMuonTruthInfo: public PHObject 
+{
+public:
+  SQSingleMuonTruthInfo();
+  virtual ~SQSingleMuonTruthInfo();
+
+  void identify(std::ostream& os = std::cout) const;
+  void Reset();
+  int  isValid() const { return 1; };
+  SQSingleMuonTruthInfo* Clone() const { return (new SQSingleMuonTruthInfo(*this)); }
+
+public:
+  int motherPid;
+  TVector3 motherMom;
+  TVector3 motherVtx;
+
+  double decayLength;
+  TVector3 muMom;
+  TVector3 muVtx;
+
+private:
+  ClassDef(SQSingleMuonTruthInfo, 1)
+
+};
+
+#endif

--- a/generators/SingleMuonGen/SQSingleMuonTruthInfoLinkDef.h
+++ b/generators/SingleMuonGen/SQSingleMuonTruthInfoLinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class SQSingleMuonTruthInfo+;
+
+#endif /* __CINT__ */


### PR DESCRIPTION
A quick version of a single muon generator. The pion momentum and pT distributions are digitized from this paper https://arxiv.org/pdf/1404.5882. The pion is sequentially decayed to muons. A new Truth Information (SQSingleMuonTruthInfo) node is added to contain the generator level information.