### PR TITLE
EMCal bug fix

### DIFF
--- a/simulation/g4detectors/PHG4EMCalDetector.cc
+++ b/simulation/g4detectors/PHG4EMCalDetector.cc
@@ -78,9 +78,9 @@ void PHG4EMCalDetector::Construct(G4LogicalVolume* logicWorld)
   }
 
   // Overal envelop volume for the entire detector
-  double xLength_enve = m_tower_size_x*m_ntowers_x*cm;
-  double yLength_enve = m_tower_size_y*m_ntowers_y*cm;
-  double zLength_enve = m_tower_size_z*cm;
+  double xLength_enve = m_tower_size_x*m_ntowers_x;
+  double yLength_enve = m_tower_size_y*m_ntowers_y;
+  double zLength_enve = m_tower_size_z;
   G4VSolid* emcal_enve_solid = new G4Box(name+"_enve_solid", xLength_enve/2., yLength_enve/2., zLength_enve/2.);
 
   G4Material* mat_Air = G4Material::GetMaterial("G4_AIR");

--- a/simulation/g4detectors/SQDigitizer.cc
+++ b/simulation/g4detectors/SQDigitizer.cc
@@ -266,6 +266,7 @@ void SQDigitizer::digitizeEMCal(const std::string& detName)
       digiHit.set_tdc_time(0.);
       digiHit.set_drift_distance(0.);
       digiHit.set_pos(0.);
+      digiHit.set_edep(0.);
 
       digiHit.set_truth_x(g4hit.get_x(0));
       digiHit.set_truth_y(g4hit.get_y(0));


### PR DESCRIPTION
PR to fix two issues in the current EMCal simulation. 

- First one is on the EMCal geometry, since the unit is already specified in the constructor, adding another unit would cause the geometry to be wrong by one order of magnitude.
- Second is on the energy deposit of EMCal hit. Without setting to zero, it would be randomly initialized, causing some undefined behaviors.

The fixes have been tested multiple times for the EMCal simulations for dark sector. Made this PR for synchronization with the master branch. PR should not affect anything except EMCal.