### PR TITLE
Small updates on trigger utility and legacy generator

### DIFF
--- a/generators/E906LegacyGen/SQPileupGen.C
+++ b/generators/E906LegacyGen/SQPileupGen.C
@@ -26,7 +26,7 @@
 #include <g4main/PHG4TruthInfoContainer.h>
 #include <Geant4/G4ParticleTable.hh>
 #include <interface_main/SQMCEvent_v1.h>
-#include <interface_main/SQEvent_v1.h>
+#include <interface_main/SQEvent_v2.h>
 
 #include "SQPileupGen.h"
 #include <E906LegacyVtxGen/SQPrimaryVertexGen.h>
@@ -87,7 +87,7 @@ int SQPileupGen::InitRun(PHCompositeNode* topNode)
     PHNodeIterator iter(topNode);
     PHCompositeNode* dstNode = dynamic_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "DST"));
 
-    _evt = new SQEvent_v1();
+    _evt = new SQEvent_v2();
     dstNode->addNode(new PHIODataNode<PHObject>(_evt, "SQEvent", "PHObject"));
   }
 

--- a/generators/E906LegacyGen/SQPrimaryParticleGen.h
+++ b/generators/E906LegacyGen/SQPrimaryParticleGen.h
@@ -44,6 +44,12 @@ class SQPrimaryVertexGen;
  * The node stores the integrated luminosity etc.
  * You can divide the weighted event count by the integrated luminosity to obtain the cross section (per bin).
  * You can then multiply this cross section by an expected integrated luminosity (of spill, week, year, etc.) to obtain the expected count.
+ * 
+ * The generated process is accessible in analysis via SQMCEvent::get_process_id().
+ * The convention of IDs (or codes) is specific to this class, as defined as `ProcessCode_t`;
+ * @code
+ * if (mcevt->get_process_id() == SQPrimaryParticleGen::DrellYan) {...}
+ * @endcode
  */
 class SQPrimaryParticleGen: public PHG4ParticleGeneratorBase
 {
@@ -55,7 +61,7 @@ public:
     PsiPrime = -3,
     Pythia   = -4,
     Custom   = -5
-  } ProcessCode_t; ///< Negative, not to overlap the codes used in Pythia8.
+  } ProcessCode_t; ///< Negative, not to overlap with the codes used in Pythia8.
   
     SQPrimaryParticleGen(const std::string& name = "PrimaryGen");
     virtual ~SQPrimaryParticleGen();

--- a/generators/E906LegacyGen/SQPrimaryParticleGen.h
+++ b/generators/E906LegacyGen/SQPrimaryParticleGen.h
@@ -48,6 +48,15 @@ class SQPrimaryVertexGen;
 class SQPrimaryParticleGen: public PHG4ParticleGeneratorBase
 {
 public:
+  typedef enum {
+    Undef    =  0,
+    DrellYan = -1,
+    JPsi     = -2,
+    PsiPrime = -3,
+    Pythia   = -4,
+    Custom   = -5
+  } ProcessCode_t; ///< Negative, not to overlap the codes used in Pythia8.
+  
     SQPrimaryParticleGen(const std::string& name = "PrimaryGen");
     virtual ~SQPrimaryParticleGen();
 
@@ -74,11 +83,11 @@ public:
 
     //swith for the generators; Abi
     //@
-    void enablePythia(){_PythiaGen = true;}
-    void enableCustomDimuon(){_CustomDimuon = true;}
-    void enableDrellYanGen(){_DrellYanGen = true;}
-    void enableJPsiGen(){_JPsiGen = true;}
-    void enablePsipGen(){_PsipGen = true;}
+    void enablePythia      () { _proc_code = Pythia  ;}
+    void enableCustomDimuon() { _proc_code = Custom  ;}
+    void enableDrellYanGen () { _proc_code = DrellYan;}
+    void enableJPsiGen     () { _proc_code = JPsi    ;}
+    void enablePsipGen     () { _proc_code = PsiPrime;}
 
     void set_pdfset(const std::string name) { _pdfset = name; }
 
@@ -109,11 +118,7 @@ public:
     double CrossSectionPsip(const double xF);
 
  private:
-    bool _PythiaGen;
-    bool _CustomDimuon;
-    bool _DrellYanGen;
-    bool _JPsiGen;
-    bool _PsipGen;
+    ProcessCode_t _proc_code;
 
     SQPrimaryVertexGen* _vertexGen;
     PHG4InEvent *ineve;

--- a/packages/UtilAna/TrigRoads.cc
+++ b/packages/UtilAna/TrigRoads.cc
@@ -27,7 +27,27 @@ TrigRoad* TrigRoads::FindRoad(const int road_id)
   if (it != m_idx_map.end()) return &m_roads[it->second];
   return 0;
 }
+  
+int TrigRoads::FindRoadIndex(const int road_id) const
+{
+  auto it = m_idx_map.find(road_id);
+  if (it != m_idx_map.end()) return it->second;
+  return -1;
+}
 
+const TrigRoad* TrigRoads::GetRoad(const int idx) const
+{
+  if (idx < 0 || idx > (int)m_roads.size()) return 0;
+  return &m_roads[idx];
+}
+
+const TrigRoad* TrigRoads::FindRoad(const int road_id) const
+{
+  auto it = m_idx_map.find(road_id);
+  if (it != m_idx_map.end()) return &m_roads[it->second];
+  return 0;
+}
+  
 int TrigRoads::LoadConfig(const std::string file_name)
 {
   //cout << "TrigRoads::LoadConfig(" << file_name << ")\n";

--- a/packages/UtilAna/TrigRoads.h
+++ b/packages/UtilAna/TrigRoads.h
@@ -21,6 +21,9 @@ class TrigRoads {
   unsigned int GetNumRoads() const { return m_roads.size(); }
   TrigRoad* GetRoad(const int idx);
   TrigRoad* FindRoad(const int road_id);
+  int FindRoadIndex(const int road_id) const;
+  const TrigRoad* GetRoad(const int idx) const;
+  const TrigRoad* FindRoad(const int road_id) const;
 
   int Charge() const { return m_pol; }
   int TopBot() const { return m_top_bot; }

--- a/packages/UtilAna/UtilTrigger.cc
+++ b/packages/UtilAna/UtilTrigger.cc
@@ -1,6 +1,8 @@
 #include <cmath>
 #include <geom_svc/GeomSvc.h>
 #include <interface_main/SQHitVector.h>
+#include "UtilSQHit.h"
+#include "TrigRoadset.h"
 using namespace std;
 namespace UtilTrigger {
 
@@ -28,6 +30,26 @@ void Road2Hodo(const int road, int& h1, int& h2, int& h3, int& h4, int& tb)
   h3 = 1 + (rr/16      ) %16;
   h4 = 1 + (rr         ) %16;
   tb = road>0 ? +1 : -1;
+}
+
+/// Flip the given road ID in the left-right direction.
+int FlipRoadLeftRight(const int road)
+{
+  int h1, h2, h3, h4, tb;
+  Road2Hodo(road, h1, h2, h3, h4, tb);
+  h1 = 24 - h1; // 1 <-> 23, 2 <-> 22,,,
+  h2 = 17 - h2; // 1 <-> 16, 2 <-> 15,,,
+  h3 = 17 - h3;
+  h4 = 17 - h4;
+  return Hodo2Road(h1, h2, h3, h4, tb);
+}
+
+/// Flip the given road ID in the top-bottom direction.
+int FlipRoadTopBottom(const int road)
+{
+  int h1, h2, h3, h4, tb;
+  Road2Hodo(road, h1, h2, h3, h4, tb);
+  return Hodo2Road(h1, h2, h3, h4, -tb);
 }
 
 /// Find a unique road in the given list of SQHits.
@@ -62,4 +84,56 @@ int ExtractRoadID(const SQHitVector* vec)
   return Hodo2Road(list_ele_id[1], list_ele_id[2], list_ele_id[3], list_ele_id[4], tb);
 }
 
+/// Find all fired roads enabled in `rs`, by taking all hit combinations from `vec`.
+void FindFiredRoads(const SQHitVector* vec, const TrigRoadset* rs, const bool in_time, std::vector<int>* pos_top, std::vector<int>* pos_bot, std::vector<int>* neg_top, std::vector<int>* neg_bot)
+{
+  pos_top->clear();
+  neg_top->clear();
+  shared_ptr<SQHitVector> hv_h1t(UtilSQHit::FindFirstHits(vec, "H1T", in_time));
+  shared_ptr<SQHitVector> hv_h2t(UtilSQHit::FindFirstHits(vec, "H2T", in_time));
+  shared_ptr<SQHitVector> hv_h3t(UtilSQHit::FindFirstHits(vec, "H3T", in_time));
+  shared_ptr<SQHitVector> hv_h4t(UtilSQHit::FindFirstHits(vec, "H4T", in_time));
+  for (auto it1 = hv_h1t->begin(); it1 != hv_h1t->end(); it1++) {
+  for (auto it2 = hv_h2t->begin(); it2 != hv_h2t->end(); it2++) {
+  for (auto it3 = hv_h3t->begin(); it3 != hv_h3t->end(); it3++) {
+  for (auto it4 = hv_h4t->begin(); it4 != hv_h4t->end(); it4++) {
+    int road = Hodo2Road(
+      (*it1)->get_element_id(), 
+      (*it2)->get_element_id(), 
+      (*it3)->get_element_id(), 
+      (*it4)->get_element_id(), +1);
+    if (rs->PosTop()->FindRoad(road)) pos_top->push_back(road);
+    if (rs->NegTop()->FindRoad(road)) neg_top->push_back(road);
+  }
+  }
+  }
+  }
+  pos_top->erase(std::unique(pos_top->begin(), pos_top->end()), pos_top->end());
+  neg_top->erase(std::unique(neg_top->begin(), neg_top->end()), neg_top->end());
+  
+  pos_bot->clear();
+  neg_bot->clear();
+  shared_ptr<SQHitVector> hv_h1b(UtilSQHit::FindHits(vec, "H1B", in_time));
+  shared_ptr<SQHitVector> hv_h2b(UtilSQHit::FindHits(vec, "H2B", in_time));
+  shared_ptr<SQHitVector> hv_h3b(UtilSQHit::FindHits(vec, "H3B", in_time));
+  shared_ptr<SQHitVector> hv_h4b(UtilSQHit::FindHits(vec, "H4B", in_time));
+  for (auto it1 = hv_h1b->begin(); it1 != hv_h1b->end(); it1++) {
+  for (auto it2 = hv_h2b->begin(); it2 != hv_h2b->end(); it2++) {
+  for (auto it3 = hv_h3b->begin(); it3 != hv_h3b->end(); it3++) {
+  for (auto it4 = hv_h4b->begin(); it4 != hv_h4b->end(); it4++) {
+    int road = UtilTrigger::Hodo2Road(
+      (*it1)->get_element_id(), 
+      (*it2)->get_element_id(), 
+      (*it3)->get_element_id(), 
+      (*it4)->get_element_id(), -1);
+    if (rs->PosBot()->FindRoad(road)) pos_bot->push_back(road);
+    if (rs->NegBot()->FindRoad(road)) neg_bot->push_back(road);
+  }
+  }
+  }
+  }
+  pos_bot->erase(std::unique(pos_bot->begin(), pos_bot->end()), pos_bot->end());
+  neg_bot->erase(std::unique(neg_bot->begin(), neg_bot->end()), neg_bot->end());
+}
+  
 }; // End of "namespace UtilTrigger"

--- a/packages/UtilAna/UtilTrigger.cc
+++ b/packages/UtilAna/UtilTrigger.cc
@@ -85,6 +85,19 @@ int ExtractRoadID(const SQHitVector* vec)
 }
 
 /// Find all fired roads enabled in `rs`, by taking all hit combinations from `vec`.
+/**
+ * @code
+ * SQHitVector* vec = ...;
+ * const TrigRoadset* rs = ...;
+ * const bool in_time = true;
+ * std::vector<int> fired_roads_PT;
+ * std::vector<int> fired_roads_PB;
+ * std::vector<int> fired_roads_NT;
+ * std::vector<int> fired_roads_NB;
+ * UtilTrigger::FindFiredRoads(vec, rs, in_time, fired_roads_PT, fired_roads_PB, fired_roads_NT, fired_roads_NB);
+ * if (fired_roads_PT.size() > 0) { ... }
+ * @endcode
+ */
 void FindFiredRoads(const SQHitVector* vec, const TrigRoadset* rs, const bool in_time, std::vector<int>* pos_top, std::vector<int>* pos_bot, std::vector<int>* neg_top, std::vector<int>* neg_bot)
 {
   pos_top->clear();

--- a/packages/UtilAna/UtilTrigger.h
+++ b/packages/UtilAna/UtilTrigger.h
@@ -4,9 +4,14 @@
 class SQHitVector;
 
 namespace UtilTrigger {
+  class TrigRoadset;
   int  Hodo2Road(const int h1, const int h2, const int h3, const int h4, const int tb);
   void Road2Hodo(const int road, int& h1, int& h2, int& h3, int& h4, int& tb);
+  int FlipRoadLeftRight(const int road);
+  int FlipRoadTopBottom(const int road);
   int  ExtractRoadID(const SQHitVector* vec);
+  void FindFiredRoads(const SQHitVector* vec, const TrigRoadset* rs, const bool in_time, std::vector<int>* pos_top, std::vector<int>* pos_bot, std::vector<int>* neg_top, std::vector<int>* neg_bot);
+
 }; // namespace UtilTrigger
 
 #endif /* _UTIL_TRIGGER__H_ */

--- a/packages/reco/kfitter/KalmanFilter.cxx
+++ b/packages/reco/kfitter/KalmanFilter.cxx
@@ -44,7 +44,8 @@ KalmanFilter::KalmanFilter(bool limitedStep)
 
 bool KalmanFilter::initExtrapolator(const PHField *field,  const TGeoManager *geom)
 {
-	_extrapolator.init(field, geom);
+  _extrapolator.init(field, geom);
+  return true;
 }
 
 bool KalmanFilter::fit_node(Node& _node)

--- a/packages/reco/ktracker/SQVertexing.cxx
+++ b/packages/reco/ktracker/SQVertexing.cxx
@@ -380,7 +380,7 @@ int SQVertexing::InitField(PHCompositeNode* topNode)
   }
   catch(const std::exception& e)
   {
-    std::cout << "SQVertexing::InitGeom - Caught an exception " << std::endl;
+    std::cout << "SQVertexing::InitField - Caught an exception " << std::endl;
     gfield = nullptr;
   }
   
@@ -391,13 +391,13 @@ int SQVertexing::InitField(PHCompositeNode* topNode)
     std::unique_ptr<PHFieldConfig> default_field_cfg(new PHFieldConfig_v3(rc->get_CharFlag("fMagFile"), rc->get_CharFlag("kMagFile"), rc->get_DoubleFlag("FMAGSTR"), rc->get_DoubleFlag("KMAGSTR"), 5.));
     PHField* phfield = PHFieldUtility::GetFieldMapNode(default_field_cfg.get(), topNode, 0);
 
-    std::cout << "SQVertexing::InitGeom - creating new GenFit field map" << std::endl;
+    std::cout << "SQVertexing::InitField - creating new GenFit field map" << std::endl;
     gfield = new SQGenFit::GFField(phfield);
     genfit::FieldManager::getInstance()->init(gfield);
   }
   else
   {
-    std::cout << "SQVertexing::InitGeom - reading existing GenFit field map" << std::endl;
+    std::cout << "SQVertexing::InitField - reading existing GenFit field map" << std::endl;
   }
 
   return Fun4AllReturnCodes::EVENT_OK;

--- a/simulation/g4dst/TruthNodeMaker.cc
+++ b/simulation/g4dst/TruthNodeMaker.cc
@@ -6,7 +6,7 @@
 #include <g4main/PHG4Hit.h>
 #include <g4main/PHG4Particle.h>
 #include <g4main/PHG4VtxPoint.h>
-#include <interface_main/SQEvent_v1.h>
+#include <interface_main/SQEvent_v2.h>
 #include <interface_main/SQMCEvent_v1.h>
 #include <interface_main/SQTrack_v1.h>
 #include <interface_main/SQDimuon_v1.h>
@@ -334,7 +334,7 @@ int TruthNodeMaker::MakeNodes(PHCompositeNode* topNode)
 
   m_evt = findNode::getClass<SQEvent>(topNode, "SQEvent");
   if (! m_evt) {
-    m_evt = new SQEvent_v1();
+    m_evt = new SQEvent_v2();
     node_dst->addNode(new PHIODataNode<PHObject>(m_evt, "SQEvent", "PHObject"));
   }
 


### PR DESCRIPTION
This update is to make multiple small changes.  I have confirmed that the updated code can be built fine and `SQPrimaryParticleGen` sets the process ID of `SQMCEvent` properly.

I added functions to `UtilTrigger`, which should be useful in many analyses.  One big function is to extract a list of all fired enabled roads from all (or only in-time) hodoscope hits.

I gave IDs (codes) to the processes generated by `SQPrimaryParticleGen`.  The IDs are defined as `ProcessCode_t`, where they are negative not to overlap with the codes used in Pythia8.  The ID is accessible in analysis via `SQMCEvent::get_process_id()`.  Inside `SQPrimaryParticleGen` the generated process is selected via `_proc_code` instead of `_PythiaGen` etc. and thus only one process can be enabled now.

I replaced `SQEvent_v1` with `SQEvent_v2` in simulation-related classes.  `SQEvent_v2` is slightly smaller since it doesn't contain real-data-only variables.

I fixed typos in debug messages of `SQVertexing`.