### PR TITLE
Small changes in Single Muon generator, added single muon vertexing

### DIFF
--- a/generators/SingleMuonGen/SQSingleMuonGen.cxx
+++ b/generators/SingleMuonGen/SQSingleMuonGen.cxx
@@ -11,6 +11,7 @@
 #include <phool/PHCompositeNode.h>
 #include <phool/PHIODataNode.h>
 #include <phool/PHRandomSeed.h>
+#include <phool/recoConsts.h>
 
 #include <Geant4/G4ParticleTable.hh>
 #include <Geant4/G4ParticleDefinition.hh>
@@ -37,6 +38,8 @@ SQSingleMuonGen::SQSingleMuonGen(const std::string& name):
   _m_muon(0.105658),
   _m_pion(0.13957),
   _pt_dist(nullptr),
+  _vtx_x0(0.),
+  _vtx_y0(0.),
   _rndm(PHRandomSeed())
 {
   for(int i = 0; i < 6; ++i) _pz_dist[i] = nullptr;
@@ -66,6 +69,10 @@ int SQSingleMuonGen::InitRun(PHCompositeNode* topNode)
   _pz_dist[3] = new TF1("PzDistr4", "0.302*(x^-1.900)", _mom_min, _mom_max);
   _pz_dist[4] = new TF1("PzDistr5", "0.174*(x^-1.750)", _mom_min, _mom_max);
   _pz_dist[5] = new TF1("PzDistr6", "0.909*(x^-1.850)", _mom_min > 8. ? _mom_min : 8., _mom_max);
+
+  recoConsts* rc = recoConsts::instance();
+  _vtx_x0 = rc->get_DoubleFlag("X_BEAM");
+  _vtx_y0 = rc->get_DoubleFlag("Y_BEAM");
 
   return Fun4AllReturnCodes::EVENT_OK;
 }
@@ -204,10 +211,7 @@ bool SQSingleMuonGen::geometryCut()
 
 bool SQSingleMuonGen::generatePrimaryVtx()
 {
-  double x = 0.;
-  double y = 0.;
   double z = -300.;
-
-  _truth->motherVtx.SetXYZ(x, y, z);
+  _truth->motherVtx.SetXYZ(_vtx_x0, _vtx_y0, z);
   return true;
 }

--- a/generators/SingleMuonGen/SQSingleMuonGen.h
+++ b/generators/SingleMuonGen/SQSingleMuonGen.h
@@ -80,6 +80,10 @@ private:
   //! Distribution functions for p/pt distribution
   TF1* _pz_dist[6];
   TF1* _pt_dist;
+
+  //! Primary vertex location
+  double _vtx_x0;
+  double _vtx_y0;
 };
 
 #endif

--- a/packages/reco/SQGenFit/GFTrack.cxx
+++ b/packages/reco/SQGenFit/GFTrack.cxx
@@ -421,18 +421,19 @@ SRecTrack GFTrack::getSRecTrack()
     strack.insertChisq((*iter)->getTrackPoint()->getKalmanFitterInfo()->getSmoothedChi2());
   }
 
-  //Swim to various places and save info
-  strack.swimToVertex(nullptr, nullptr, false);
+  // Following code moved to SQVertexing
+  // //Swim to various places and save info
+  // strack.swimToVertex(nullptr, nullptr, false);
 
-  //Hypothesis test should be implemented here
-  //test Z_UPSTREAM
-  strack.setChisqUpstream(swimToVertex(Z_UPSTREAM));
+  // //Hypothesis test should be implemented here
+  // //test Z_UPSTREAM
+  // strack.setChisqUpstream(swimToVertex(Z_UPSTREAM));
 
-  //test Z_TARGET
-  strack.setChisqTarget(swimToVertex(Z_TARGET));
+  // //test Z_TARGET
+  // strack.setChisqTarget(swimToVertex(Z_TARGET));
 
-  //test Z_DUMP
-  strack.setChisqDump(swimToVertex(Z_DUMP));
+  // //test Z_DUMP
+  // strack.setChisqDump(swimToVertex(Z_DUMP));
 
   /*
   //Find POCA to beamline -- it seems to be funky and mostly found some place way upstream or downstream
@@ -454,11 +455,11 @@ SRecTrack GFTrack::getSRecTrack()
   }
   */
 
-  //test Z_VERTEX
-  TVector3 pos, mom;
-  strack.setChisqVertex(swimToVertex(strack.getVertexPos().Z(), &pos, &mom));
-  strack.setVertexPos(pos);
-  strack.setVertexMom(mom);
+  // //test Z_VERTEX
+  // TVector3 pos, mom;
+  // strack.setChisqVertex(swimToVertex(strack.getVertexPos().Z(), &pos, &mom));
+  // strack.setVertexPos(pos);
+  // strack.setVertexMom(mom);
 
   strack.setKalmanStatus(1);
   return strack;

--- a/packages/reco/SQGenFit/GFTrack.cxx
+++ b/packages/reco/SQGenFit/GFTrack.cxx
@@ -439,46 +439,6 @@ SRecTrack GFTrack::getSRecTrack()
     strack.insertChisq((*iter)->getTrackPoint()->getKalmanFitterInfo()->getSmoothedChi2());
   }
 
-  // Following code moved to SQVertexing
-  // //Swim to various places and save info
-  // strack.swimToVertex(nullptr, nullptr, false);
-
-  // //Hypothesis test should be implemented here
-  // //test Z_UPSTREAM
-  // strack.setChisqUpstream(swimToVertex(Z_UPSTREAM));
-
-  // //test Z_TARGET
-  // strack.setChisqTarget(swimToVertex(Z_TARGET));
-
-  // //test Z_DUMP
-  // strack.setChisqDump(swimToVertex(Z_DUMP));
-
-  /*
-  //Find POCA to beamline -- it seems to be funky and mostly found some place way upstream or downstream
-  // most likely because the cross product of the track direction and beam line direction is way too small 
-  // z axis to provide reasonable calculation of the POCA location. It's disabled for now.
-  TVector3 ep1(0., 0., -499.);
-  TVector3 ep2(0., 0., 0.);
-  try
-  {
-    extrapolateToLine(ep1, ep2);
-    TVectorD beamR(1); beamR(0) = 0.;
-    TMatrixDSym beamC(1); beamC(0, 0) = 1000.;
-    strack.setChisqVertex(updatePropState(beamR, beamC));
-  }
-  catch(genfit::Exception& e)
-  {
-    std::cerr << "Hypothesis test failed at beamline: " << e.what() << std::endl;
-    print(0);
-  }
-  */
-
-  // //test Z_VERTEX
-  // TVector3 pos, mom;
-  // strack.setChisqVertex(swimToVertex(strack.getVertexPos().Z(), &pos, &mom));
-  // strack.setVertexPos(pos);
-  // strack.setVertexMom(mom);
-
   strack.setKalmanStatus(1);
   return strack;
 }

--- a/packages/reco/SQGenFit/GFTrack.cxx
+++ b/packages/reco/SQGenFit/GFTrack.cxx
@@ -24,6 +24,8 @@ namespace
   //static flag to indicate the initialized has been done
   static bool inited = false;
 
+  static int MAX_ERROR;
+
   static double Z_TARGET;
   static double Z_DUMP;
   static double Z_UPSTREAM;
@@ -49,6 +51,8 @@ namespace
       Y_BEAM    = rc->get_DoubleFlag("Y_BEAM");
       SIGX_BEAM = rc->get_DoubleFlag("SIGX_BEAM");
       SIGY_BEAM = rc->get_DoubleFlag("SIGY_BEAM");
+
+      MAX_ERROR = 5;
     }
   }
 };
@@ -56,12 +60,12 @@ namespace
 namespace SQGenFit
 {
 
-GFTrack::GFTrack(): _track(nullptr), _trkrep(nullptr), _propState(nullptr), _virtMeas(nullptr), _trkcand(nullptr), _pdg(0)
+GFTrack::GFTrack(): _track(nullptr), _trkrep(nullptr), _propState(nullptr), _virtMeas(nullptr), _trkcand(nullptr), _pdg(0), _errorNo(0)
 {
   initGlobalVariables();
 }
 
-GFTrack::GFTrack(SRecTrack& recTrack):  _track(nullptr), _trkrep(nullptr), _propState(nullptr), _virtMeas(nullptr), _trkcand(nullptr), _pdg(0)
+GFTrack::GFTrack(SRecTrack& recTrack):  _track(nullptr), _trkrep(nullptr), _propState(nullptr), _virtMeas(nullptr), _trkcand(nullptr), _pdg(0), _errorNo(0)
 {
   initGlobalVariables();
 
@@ -100,7 +104,7 @@ GFTrack::GFTrack(SRecTrack& recTrack):  _track(nullptr), _trkrep(nullptr), _prop
   }
 }
 
-GFTrack::GFTrack(Tracklet& tracklet): _track(nullptr), _trkrep(nullptr), _propState(nullptr), _virtMeas(nullptr), _trkcand(nullptr), _pdg(0)
+GFTrack::GFTrack(Tracklet& tracklet): _track(nullptr), _trkrep(nullptr), _propState(nullptr), _virtMeas(nullptr), _trkcand(nullptr), _pdg(0), _errorNo(0)
 {
   initGlobalVariables();
   setTracklet(tracklet, 590., false);
@@ -109,6 +113,11 @@ GFTrack::GFTrack(Tracklet& tracklet): _track(nullptr), _trkrep(nullptr), _propSt
 GFTrack::~GFTrack()
 {
   if(_track != nullptr) delete _track;
+}
+
+void GFTrack::setMaxErrorCount(unsigned int m)
+{
+  MAX_ERROR = m;
 }
 
 void GFTrack::setVerbosity(unsigned int v)
@@ -323,13 +332,22 @@ double GFTrack::swimToVertex(double z, TVector3* pos, TVector3* mom, TMatrixDSym
   }
   catch(genfit::Exception& e)
   {
-    std::cerr << __FILE__ << " " << __LINE__ << ": hypo test failed vertex @Z=" << z << ": " << e.what() << std::endl;
-    return -1.;
+    if(_errorNo < MAX_ERROR) std::cerr << "SQGenFit::GFTrack::swimToVertex: hypo test failed vertex @Z=" << z << ": " << e.what() << std::endl;
+    chi2 = -1.;
   }
   catch(double len)
   {
-    std::cerr << __FILE__ << " " << __LINE__ << ": hypo test failed vertex @Z=" << z << ": " << len << std::endl;
-    return -1.;
+    if(_errorNo < MAX_ERROR) std::cerr << "SQGenFit::GFTrack::swimToVertex: hypo test failed vertex @Z=" << z << ": " << len << std::endl;
+    chi2 = -2.;
+  }
+
+  if(chi2 < 0.)
+  {
+    ++_errorNo;
+    if(_errorNo == MAX_ERROR)
+    {
+      std::cerr << "SQGenFit::GFTrack::swimToVertex: ... too many extraplolation errors, future errors from this track will be suppressed... " << std::endl;
+    }
   }
 
   return chi2;

--- a/packages/reco/SQGenFit/GFTrack.h
+++ b/packages/reco/SQGenFit/GFTrack.h
@@ -27,6 +27,7 @@ public:
   ~GFTrack();
 
   void setVerbosity(unsigned int v);
+  void setMaxErrorCount(unsigned int m);
   void setTracklet(Tracklet& tracklet, double z_reference = 590., bool wildseedcov = false);
   void addMeasurements(std::vector<GFMeasurement*>& measurements);
   void addMeasurement(GFMeasurement* measurement);
@@ -76,6 +77,9 @@ private:
   //Store the original track candidate information from track finding
   Tracklet* _trkcand;
   int _pdg;
+
+  //Local error count to suppress eccessive error messages
+  unsigned int _errorNo;
 
 };
 }

--- a/packages/reco/ktracker/SQVertexing.cxx
+++ b/packages/reco/ktracker/SQVertexing.cxx
@@ -294,6 +294,26 @@ bool SQVertexing::processOneMuon(SRecTrack* track)
     track->setChisqVertex(swimTrackToVertex(gtrk, track->getVertexPos().Z(), &pos, &mom));
   track->setVertexFast(mom, pos);
 
+  /*
+  //Find POCA to beamline -- it seems to be funky and mostly found some place way upstream or downstream
+  // most likely because the cross product of the track direction and beam line direction is way too small 
+  // z axis to provide reasonable calculation of the POCA location. It's disabled for now.
+  TVector3 ep1(0., 0., -499.);
+  TVector3 ep2(0., 0., 0.);
+  try
+  {
+    extrapolateToLine(ep1, ep2);
+    TVectorD beamR(1); beamR(0) = 0.;
+    TMatrixDSym beamC(1); beamC(0, 0) = 1000.;
+    strack.setChisqVertex(updatePropState(beamR, beamC));
+  }
+  catch(genfit::Exception& e)
+  {
+    std::cerr << "Hypothesis test failed at beamline: " << e.what() << std::endl;
+    print(0);
+  }
+  */
+
   return true;
 }
 

--- a/packages/reco/ktracker/SQVertexing.cxx
+++ b/packages/reco/ktracker/SQVertexing.cxx
@@ -106,7 +106,6 @@ int SQVertexing::InitRun(PHCompositeNode* topNode)
 int SQVertexing::process_event(PHCompositeNode* topNode)
 {
   if(legacyContainer_out) recEvent->clearDimuons();
-  std::cout << __FILE__ << "  " << __LINE__ << "                    New Event  " << std::endl;
 
   std::vector<int> trackIDs1;
   std::vector<int> trackIDs2;

--- a/packages/reco/ktracker/SQVertexing.h
+++ b/packages/reco/ktracker/SQVertexing.h
@@ -46,6 +46,7 @@ private:
   double findDimuonZVertex(SRecDimuon& dimuon, SQGenFit::GFTrack& track1, SQGenFit::GFTrack& track2);
   double calcZsclp(double p);
   bool   processOneDimuon(SRecTrack* track1, SRecTrack* track2, SRecDimuon& dimuon);
+  bool   processOneMuon(SRecTrack* track);
 
   bool legacyContainer_in, legacyContainer_out;
   bool enableSingleRetracking;


### PR DESCRIPTION
This PR consists of three changes. 

The first commit changes the single muon generator to read X_BEAM and Y_BEAM reco consts when generating the primary vertex. In the past the primary vertex X and Y positions are hard-coded to be 0.

The second and third commit moves the single muon vertexing code from SQGenFit::GFTrack::getSRecTrack to SQVertexing::processOneMuon. In the past the single muon vertexing is done in SQGenFit::GFTrack::getSRecTrack which is called by SQReco. After we update the X_BEAM and Y_BEAM information and re-run the production with only SQVertexing the single muon info will not be updated.

The last commit added an error count data member is SQGenFit::GFTrack to supress the excessive error message in the extrapolation. Now the code will suppress future error messages after 5 errors in the same track.