### PR TITLE
Changes of SQReco and SQVertexing for re-tracking/vertexing plus code improvements

### DIFF
--- a/framework/phool/recoConsts.cc
+++ b/framework/phool/recoConsts.cc
@@ -62,10 +62,10 @@ void recoConsts::set_defaults()
   set_BoolFlag("OnlineAlignment", false);
   set_BoolFlag("IdealGeom", false);
 
-  set_CharFlag("AlignmentMille", "$E1039_RESOURCE/alignment/run6/align_mille.txt");
-  set_CharFlag("AlignmentHodo", "$E1039_RESOURCE/alignment/run6/alignment_hodo.txt");
-  set_CharFlag("AlignmentProp", "$E1039_RESOURCE/alignment/run6/alignment_prop.txt");
-  set_CharFlag("Calibration", "$E1039_RESOURCE/alignment/run6/calibration.txt");
+  set_CharFlag("AlignmentMille", "");
+  set_CharFlag("AlignmentHodo" , "");
+  set_CharFlag("AlignmentProp" , "");
+  set_CharFlag("Calibration"   , "");
 
   set_CharFlag("DB_SERVER", "DB1");
   set_CharFlag("DB_USER"  , "seaguest");
@@ -171,10 +171,15 @@ void recoConsts::set_defaults()
 void recoConsts::init(int runNo, bool verbose)
 {
   set_IntFlag("RUNNUMBER", runNo);
-  if (runNo < 10) { // E906 data.  We will need dataset-dependent settings.
+  if (runNo < 10) {
+    if (verbose) std::cout << "recoConsts::init(): run " << runNo << " | E906 data.  Roadset 78." << std::endl;
     set_DoubleFlag("FMAGSTR", -1.044);
     set_DoubleFlag("KMAGSTR", -1.025);
     set_CharFlag  ("TRIGGER_L1", "78");
+    set_CharFlag("AlignmentMille", "$E1039_RESOURCE/alignment/run6/align_mille.txt");
+    set_CharFlag("AlignmentHodo" , "$E1039_RESOURCE/alignment/run6/alignment_hodo.txt");
+    set_CharFlag("AlignmentProp" , "$E1039_RESOURCE/alignment/run6/alignment_prop.txt");
+    set_CharFlag("Calibration"   , "$E1039_RESOURCE/alignment/run6/calibration.txt");
     set_DoubleFlag("RejectWinDC0" , 0.12);
     set_DoubleFlag("RejectWinDC1" , 0.25);
     set_DoubleFlag("RejectWinDC2" , 0.15);
@@ -185,6 +190,25 @@ void recoConsts::init(int runNo, bool verbose)
     set_IntFlag("MaxHitsDC2" , 170);
     set_IntFlag("MaxHitsDC3p", 140);
     set_IntFlag("MaxHitsDC3m", 140);
+  } else if (runNo < 6180) {
+    if (verbose) std::cout << "recoConsts::init(): run " << runNo << " | E1039 commissioning data in 2024." << std::endl;
+    set_DoubleFlag("FMAGSTR", -1.044);
+    set_DoubleFlag("KMAGSTR", -1.025);
+    set_CharFlag  ("HIT_MASK_MODE", "X");
+    set_CharFlag  ("AlignmentMille", "$E1039_RESOURCE/alignment/run0/align_mille_v10_a.txt");
+    set_CharFlag  ("AlignmentHodo" , "");
+    set_CharFlag  ("AlignmentProp" , "");
+    set_CharFlag  ("Calibration"   , "");
+    set_IntFlag   ("MaxHitsDC0" , 350);
+    set_IntFlag   ("MaxHitsDC1" , 350);
+    set_IntFlag   ("MaxHitsDC2" , 170);
+    set_IntFlag   ("MaxHitsDC3p", 140);
+    set_IntFlag   ("MaxHitsDC3m", 140);
+    set_DoubleFlag("RejectWinDC0" , 0.3);
+    set_DoubleFlag("RejectWinDC1" , 0.5);
+    set_DoubleFlag("RejectWinDC2" , 0.35);
+    set_DoubleFlag("RejectWinDC3p", 0.24);
+    set_DoubleFlag("RejectWinDC3m", 0.24);
   }
   return;
 }

--- a/framework/phool/recoConsts.h
+++ b/framework/phool/recoConsts.h
@@ -22,8 +22,8 @@ public:
   //! set the default value for all the constants needed - user is supposed to add a default value here to introduce new constants
   void set_defaults();
 
-  //! initialize the constants by the runNo - not implemented yet
-  void init(int runNo = 0, bool verbose = false);
+  //! initialize the constants by the runNo
+  void init(int runNo = 0, bool verbose = true);
 
   //! initialize the constants by pre-defined parameter set name - not implemented yet
   void init(const std::string& setname, bool verbose = false);

--- a/packages/geom_svc/GeomSvc.cxx
+++ b/packages/geom_svc/GeomSvc.cxx
@@ -956,73 +956,77 @@ void GeomSvc::loadAlignment(const std::string& alignmentFile_chamber, const std:
     }
     _align_chamber.close();
 
-    //load alignment numbers for hodos
-    fstream _align_hodo;
-    _align_hodo.open(alignmentFile_hodo.c_str(), ios::in);
-
-    if(_align_hodo)
-    {
+    if (! alignmentFile_hodo.empty()) {
+      //load alignment numbers for hodos
+      fstream _align_hodo;
+      _align_hodo.open(alignmentFile_hodo.c_str(), ios::in);
+      
+      if(_align_hodo)
+      {
         for(int i = nChamberPlanes+1; i <= nChamberPlanes+nHodoPlanes; i++)
         {
-            _align_hodo.getline(buf, 100);
-            istringstream stringBuf(buf);
-
-            stringBuf >> planes[i].deltaW;
-            planes[i].deltaX = planes[i].deltaW*planes[i].costheta;
-            planes[i].deltaY = planes[i].deltaW*planes[i].sintheta;
-            planes[i].update();
+          _align_hodo.getline(buf, 100);
+          istringstream stringBuf(buf);
+          
+          stringBuf >> planes[i].deltaW;
+          planes[i].deltaX = planes[i].deltaW*planes[i].costheta;
+          planes[i].deltaY = planes[i].deltaW*planes[i].sintheta;
+          planes[i].update();
         }
         cout << "GeomSvc: loaded hodoscope alignment parameters from " << alignmentFile_hodo << endl;
-    }
-    else
-    {
+      }
+      else
+      {
         cout << "GeomSvc: failed to load hodoscope alignment parameters from " << alignmentFile_hodo << endl;
+      }
+      _align_hodo.close();
     }
-    _align_hodo.close();
 
-    //load alignment numbers for prop. tubes
-    fstream _align_prop;
-    _align_prop.open(alignmentFile_prop.c_str(), ios::in);
-
-    if(_align_prop)
-    {
+    if (! alignmentFile_prop.empty()) {    
+      //load alignment numbers for prop. tubes
+      fstream _align_prop;
+      _align_prop.open(alignmentFile_prop.c_str(), ios::in);
+      
+      if(_align_prop)
+      {
         for(int i = nChamberPlanes+nHodoPlanes+1; i <= nChamberPlanes+nHodoPlanes+nPropPlanes; i += 2)
         {
-            planes[i].deltaW = 0.;
-            planes[i+1].deltaW = 0.;
-            for(int j = 0; j < 9; j++)
-            {
-                _align_prop.getline(buf, 100);
-                istringstream stringBuf(buf);
-
-                stringBuf >> planes[i].deltaW_module[j];
-                planes[i+1].deltaW_module[j] = planes[i].deltaW_module[j];
-
-                planes[i].deltaW += planes[i].deltaW_module[j];
-                planes[i+1].deltaW += planes[i+1].deltaW_module[j];
-            }
-
-            planes[i].deltaW /= 9.;
-            planes[i].deltaX = planes[i].deltaW*planes[i].costheta;
-            planes[i].deltaY = planes[i].deltaW*planes[i].sintheta;
-
-            planes[i+1].deltaW /= 9.;
-            planes[i+1].deltaX = planes[i+1].deltaW*planes[i+1].costheta;
-            planes[i+1].deltaY = planes[i+1].deltaW*planes[i+1].sintheta;
+          planes[i].deltaW = 0.;
+          planes[i+1].deltaW = 0.;
+          for(int j = 0; j < 9; j++)
+          {
+            _align_prop.getline(buf, 100);
+            istringstream stringBuf(buf);
+            
+            stringBuf >> planes[i].deltaW_module[j];
+            planes[i+1].deltaW_module[j] = planes[i].deltaW_module[j];
+            
+            planes[i].deltaW += planes[i].deltaW_module[j];
+            planes[i+1].deltaW += planes[i+1].deltaW_module[j];
+          }
+          
+          planes[i].deltaW /= 9.;
+          planes[i].deltaX = planes[i].deltaW*planes[i].costheta;
+          planes[i].deltaY = planes[i].deltaW*planes[i].sintheta;
+          
+          planes[i+1].deltaW /= 9.;
+          planes[i+1].deltaX = planes[i+1].deltaW*planes[i+1].costheta;
+          planes[i+1].deltaY = planes[i+1].deltaW*planes[i+1].sintheta;
         }
         cout << "GeomSvc: loaded prop. tube alignment parameters from " << alignmentFile_prop << endl;
-    }
-    else
-    {
+      }
+      else
+      {
         cout << "GeomSvc: failed to load prop. tube alignment parameters from " << alignmentFile_prop << endl;
+      }
     }
-
 }
 
 void GeomSvc::loadMilleAlignment(const std::string& alignmentFile_mille)
 {
     using namespace std;
-
+    if (alignmentFile_mille.empty()) return;
+    
     //load alignment numbers for chambers
     fstream _align_mille;
     _align_mille.open(alignmentFile_mille.c_str(), ios::in);
@@ -1061,7 +1065,8 @@ void GeomSvc::loadMilleAlignment(const std::string& alignmentFile_mille)
 void GeomSvc::loadCalibration(const std::string& calibrationFile)
 {
     using namespace std;
-
+    if (calibrationFile.empty()) return;
+    
     fstream _cali_file;
     _cali_file.open(calibrationFile.c_str(), ios::in);
 

--- a/packages/reco/ktracker/SQVertexing.cxx
+++ b/packages/reco/ktracker/SQVertexing.cxx
@@ -106,6 +106,7 @@ int SQVertexing::InitRun(PHCompositeNode* topNode)
 int SQVertexing::process_event(PHCompositeNode* topNode)
 {
   if(legacyContainer_out) recEvent->clearDimuons();
+  else                    recDimuonVec->clear();
 
   std::vector<int> trackIDs1;
   std::vector<int> trackIDs2;
@@ -194,9 +195,15 @@ int SQVertexing::MakeNodes(PHCompositeNode* topNode)
       return Fun4AllReturnCodes::ABORTEVENT;
     }
 
-    recDimuonVec = new SQDimuonVector_v1();
     TString dimuonVecName = TString::Format("SQRecDimuonVector_%s%s", (charge1 == 1 ? "P" : "M"), (charge2 == 1 ? "P" : "M"));
-    dstNode->addNode(new PHIODataNode<PHObject>(recDimuonVec, dimuonVecName.Data(), "PHObject"));
+    recDimuonVec = findNode::getClass<SQDimuonVector>(dstNode, dimuonVecName.Data());
+    if (!recDimuonVec) {
+      recDimuonVec = new SQDimuonVector_v1();
+      dstNode->addNode(new PHIODataNode<PHObject>(recDimuonVec, dimuonVecName.Data(), "PHObject"));
+    }
+    //recDimuonVec = new SQDimuonVector_v1();
+    //TString dimuonVecName = TString::Format("SQRecDimuonVector_%s%s", (charge1 == 1 ? "P" : "M"), (charge2 == 1 ? "P" : "M"));
+    //dstNode->addNode(new PHIODataNode<PHObject>(recDimuonVec, dimuonVecName.Data(), "PHObject"));
   }
   return Fun4AllReturnCodes::EVENT_OK;
 }


### PR DESCRIPTION
This update is mainly to modify `SQReco` and `SQVertexing` so that they reuse the output nodes (i.e. `SQRecTrackVector` and `SQRecDimuonVector`) when the nodes exist.  This feature is needed by the hit embedding (`e1039-analysis/HitEmbedding`) because it runs the reconstruction twice (before and after embedding hits).  In `SQReco::MakeNodes()` the output node is created only if it is not found.  The output node is cleared at the beginning of `SQReco::process_event()`.  The same steps are done in `SQVertexing`.

I replaced `LogDebug()` in `SQReco.cxx` with bare `cout`.  Now debug messages are printed out properly depending on the verbosity.

I added a set of default parameters for the commissioning run to `recoConsts.cc`.  We can use it just by calling `recoConsts::init(int runNo)` in Fun4All macros.  This way should be better than writing the parameters in every Fun4All macro.

I modified `GeomSvc` so that it doesn't show the error message  if the name of alignment/calibration file is empty (i.e. "").  It is not error but normal that `AlignmentHodo` etc. are empty for the commissioning data.

I have confirmed that the modified version runs fine on gpvm and grid for the hit embedding.