### PR TITLE
Update RUS I/O  and CalibHitElementPos

### DIFF
--- a/packages/RUS/Fun4AllRUSInputManager.cc
+++ b/packages/RUS/Fun4AllRUSInputManager.cc
@@ -83,10 +83,6 @@ Fun4AllRUSInputManager::Fun4AllRUSInputManager(const std::string& name, const st
     PHIODataNode<PHObject>* trknode = new PHIODataNode<PHObject>(trk_vec, "SQTruthTrackVector", "PHObject");
     eventNode->addNode(trknode);
 
-    SQHitVector* hit_vec_mc = new SQHitVector_v1();
-    PHIODataNode<PHObject>* mcHitNode = new PHIODataNode<PHObject>(hit_vec_mc, "SQMCHitVector", "PHObject");
-    eventNode->addNode(mcHitNode);
-
     syncobject = new SyncObjectv2();
 }
 

--- a/packages/RUS/Fun4AllRUSInputManager.cc
+++ b/packages/RUS/Fun4AllRUSInputManager.cc
@@ -1,4 +1,5 @@
  #include "Fun4AllRUSInputManager.h"
+ #include <interface_main/SQMCHit_v1.h>
  #include <interface_main/SQHit_v1.h>
  #include <interface_main/SQTrack_v1.h>
  #include <interface_main/SQHitVector_v1.h>
@@ -33,6 +34,7 @@ Fun4AllRUSInputManager::Fun4AllRUSInputManager(const std::string& name, const st
    Fun4AllInputManager(name, ""),
    segment(-999),
    isopen(0),
+   is_mc(false),
    events_total(0),
    events_thisfile(0),
    topNodeName(topnodename),
@@ -41,41 +43,51 @@ Fun4AllRUSInputManager::Fun4AllRUSInputManager(const std::string& name, const st
    spill_map(nullptr),
    event_header(nullptr),
    hit_vec(nullptr),
+   trk_vec(nullptr),
    _fin(nullptr),
    _tin(nullptr)
 {
-   Fun4AllServer* se = Fun4AllServer::instance();
-   topNode = se->topNode(topNodeName.c_str());
-   PHNodeIterator iter(topNode);
+    Fun4AllServer* se = Fun4AllServer::instance();
+    topNode = se->topNode(topNodeName.c_str());
+    PHNodeIterator iter(topNode);
 
     PHCompositeNode* runNode = static_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "RUN"));
-  if (!runNode) {
-    runNode = new PHCompositeNode("RUN");
-    topNode->addNode(runNode);
-  }
+    if (!runNode) {
+        runNode = new PHCompositeNode("RUN");
+        topNode->addNode(runNode);
+    }
 
-  PHCompositeNode* eventNode = static_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "DST"));
-  if (!eventNode) {
-    eventNode = new PHCompositeNode("DST");
-    topNode->addNode(eventNode);
-  }
+    PHCompositeNode* eventNode = static_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "DST"));
+    if (!eventNode) {
+        eventNode = new PHCompositeNode("DST");
+        topNode->addNode(eventNode);
+    }
 
-     run_header = new SQRun_v1();
-     PHIODataNode<PHObject>* runHeaderNode = new PHIODataNode<PHObject>(run_header, "SQRun", "PHObject");
-     runNode->addNode(runHeaderNode);
+    run_header = new SQRun_v1();
+    PHIODataNode<PHObject>* runHeaderNode = new PHIODataNode<PHObject>(run_header, "SQRun", "PHObject");
+    runNode->addNode(runHeaderNode);
 
-     spill_map = new SQSpillMap_v1();
-     PHIODataNode<PHObject>* spillNode = new PHIODataNode<PHObject>(spill_map, "SQSpillMap", "PHObject");
-     runNode->addNode(spillNode);
+    spill_map = new SQSpillMap_v1();
+    PHIODataNode<PHObject>* spillNode = new PHIODataNode<PHObject>(spill_map, "SQSpillMap", "PHObject");
+    runNode->addNode(spillNode);
 
-     event_header = new SQEvent_v1();
-     PHIODataNode<PHObject>* eventHeaderNode = new PHIODataNode<PHObject>(event_header, "SQEvent", "PHObject");
-     eventNode->addNode(eventHeaderNode);
+    event_header = new SQEvent_v1();
+    PHIODataNode<PHObject>* eventHeaderNode = new PHIODataNode<PHObject>(event_header, "SQEvent", "PHObject");
+    eventNode->addNode(eventHeaderNode);
 
-     hit_vec = new SQHitVector_v1();
-     PHIODataNode<PHObject>* hitNode = new PHIODataNode<PHObject>(hit_vec, "SQHitVector", "PHObject");
-     eventNode->addNode(hitNode);
-   syncobject = new SyncObjectv2();
+    hit_vec = new SQHitVector_v1();
+    PHIODataNode<PHObject>* hitNode = new PHIODataNode<PHObject>(hit_vec, "SQHitVector", "PHObject");
+    eventNode->addNode(hitNode);
+
+    trk_vec = new SQTrackVector_v1();
+    PHIODataNode<PHObject>* trknode = new PHIODataNode<PHObject>(trk_vec, "SQTruthTrackVector", "PHObject");
+    eventNode->addNode(trknode);
+
+    SQHitVector* hit_vec_mc = new SQHitVector_v1();
+    PHIODataNode<PHObject>* mcHitNode = new PHIODataNode<PHObject>(hit_vec_mc, "SQMCHitVector", "PHObject");
+    eventNode->addNode(mcHitNode);
+
+    syncobject = new SyncObjectv2();
 }
 
 Fun4AllRUSInputManager::~Fun4AllRUSInputManager()
@@ -87,43 +99,98 @@ Fun4AllRUSInputManager::~Fun4AllRUSInputManager()
    delete syncobject;
  }
 
+
 void Fun4AllRUSInputManager::VectToE1039() {
-	event_header->set_run_id(runID);
-	SQSpill* spill = spill_map->get(spillID);
-	if(!spill) {
-		spill = new SQSpill_v2();
-		spill->set_spill_id(spillID);
-		spill->set_run_id(runID);
-		spill_map->insert(spill);
-		run_header->set_n_spill(spill_map->size());
-	}
-	event_header->set_spill_id(spillID);
-	event_header->set_event_id(eventID);
-	event_header->set_data_quality(0);
-	for(int i = -16; i <= 16; ++i) {event_header->set_qie_rf_intensity(i, rfIntensity[i+16]);} // need to be added
-	// Apply the FPGA triggers to the event header
-	event_header->set_trigger(SQEvent::MATRIX1, fpgaTrigger[0]);
-	event_header->set_trigger(SQEvent::MATRIX2, fpgaTrigger[1]);
-	event_header->set_trigger(SQEvent::MATRIX3, fpgaTrigger[2]);
-	event_header->set_trigger(SQEvent::MATRIX4, fpgaTrigger[3]);
-	event_header->set_trigger(SQEvent::MATRIX5, fpgaTrigger[4]);
-	// Apply the NIM triggers to the event header
-	event_header->set_trigger(SQEvent::NIM1, nimTrigger[0]);
-	event_header->set_trigger(SQEvent::NIM2, nimTrigger[1]);
-	event_header->set_trigger(SQEvent::NIM3, nimTrigger[2]);
-	event_header->set_trigger(SQEvent::NIM4, nimTrigger[3]);
-	event_header->set_trigger(SQEvent::NIM5, nimTrigger[4]);
-	event_header->set_qie_turn_id(turnID);
-	event_header->set_qie_rf_id(rfID);
-	for (size_t i = 0; i < elementID->size(); ++i) {
-		SQHit* hit = new SQHit_v1();
-		hit->set_hit_id(hitID->at(i));
-		hit->set_detector_id(detectorID->at(i));
-		hit->set_element_id(elementID->at(i));
-		hit->set_tdc_time(tdcTime->at(i));
-		hit->set_drift_distance(driftDistance->at(i));
-		hit_vec->push_back(hit);
-	}
+    event_header->set_run_id(runID);
+
+    SQSpill* spill = spill_map->get(spillID);
+    if (!spill) {
+        spill = new SQSpill_v2();
+        spill->set_spill_id(spillID);
+        spill->set_run_id(runID);
+        spill_map->insert(spill);
+        run_header->set_n_spill(spill_map->size());
+    }
+
+    event_header->set_spill_id(spillID);
+    event_header->set_event_id(eventID);
+    event_header->set_data_quality(0);
+
+    for (int i = -16; i <= 16; ++i) {
+        event_header->set_qie_rf_intensity(i, rfIntensity[i+16]); // need to be added
+    }
+
+    // Apply the FPGA triggers to the event header
+    event_header->set_trigger(SQEvent::MATRIX1, fpgaTrigger[0]);
+    event_header->set_trigger(SQEvent::MATRIX2, fpgaTrigger[1]);
+    event_header->set_trigger(SQEvent::MATRIX3, fpgaTrigger[2]);
+    event_header->set_trigger(SQEvent::MATRIX4, fpgaTrigger[3]);
+    event_header->set_trigger(SQEvent::MATRIX5, fpgaTrigger[4]);
+
+    // Apply the NIM triggers to the event header
+    event_header->set_trigger(SQEvent::NIM1, nimTrigger[0]);
+    event_header->set_trigger(SQEvent::NIM2, nimTrigger[1]);
+    event_header->set_trigger(SQEvent::NIM3, nimTrigger[2]);
+    event_header->set_trigger(SQEvent::NIM4, nimTrigger[3]);
+    event_header->set_trigger(SQEvent::NIM5, nimTrigger[4]);
+
+    event_header->set_qie_turn_id(turnID);
+    event_header->set_qie_rf_id(rfID);
+
+    // Hits
+    for (size_t i = 0; i < elementID->size(); ++i) {
+        SQHit* hit = nullptr;
+
+        if (is_mc) {  
+            hit = new SQMCHit_v1();
+            hit->set_track_id(hitTrackID->at(i));
+        } else {
+            hit = new SQHit_v1();
+        }
+
+        hit->set_hit_id(hitID->at(i));
+        hit->set_detector_id(detectorID->at(i));
+        hit->set_element_id(elementID->at(i));
+        hit->set_tdc_time(tdcTime->at(i));
+        hit->set_drift_distance(driftDistance->at(i));
+
+        hit_vec->push_back(hit);
+    }
+
+
+    // MC true Tracks
+    if (is_mc){
+        const double MUON_MASS = 0.105658; // GeV
+        for (size_t i = 0; i < gTrackID->size(); ++i) {
+            SQTrack* trk = new SQTrack_v1();
+
+            trk->set_charge(gCharge->at(i));
+            trk->set_track_id(gTrackID->at(i));
+            trk->set_pos_vtx(TVector3(gvx->at(i), gvy->at(i), gvz->at(i)));
+
+            {
+                TLorentzVector p4;
+                p4.SetXYZM(gpx->at(i), gpy->at(i), gpz->at(i), MUON_MASS);
+                trk->set_mom_vtx(p4);
+            }
+
+            trk->set_pos_st1(TVector3(gx_st1->at(i), gy_st1->at(i), gz_st1->at(i)));
+            {
+                TLorentzVector p4;
+                p4.SetXYZM(gpx_st1->at(i), gpy_st1->at(i), gpz_st1->at(i), MUON_MASS);
+                trk->set_mom_st1(p4);
+            }
+
+            trk->set_pos_st3(TVector3(gx_st3->at(i), gy_st3->at(i), gz_st3->at(i)));
+            {
+                TLorentzVector p4;
+                p4.SetXYZM(gpx_st3->at(i), gpy_st3->at(i), gpz_st3->at(i), MUON_MASS);
+                trk->set_mom_st3(p4);
+            }
+
+            trk_vec->push_back(trk);
+        }
+    }
 }
 
 int Fun4AllRUSInputManager::fileopen(const std::string &filenam) {
@@ -162,10 +229,35 @@ int Fun4AllRUSInputManager::fileopen(const std::string &filenam) {
 	_tin->SetBranchAddress("rfIntensity", rfIntensity);
 
 	_tin->SetBranchAddress("hitID", &hitID);    
+	_tin->SetBranchAddress("hitTrackID", &hitTrackID);    
 	_tin->SetBranchAddress("detectorID", &detectorID);    
 	_tin->SetBranchAddress("elementID", &elementID);    
 	_tin->SetBranchAddress("driftDistance", &driftDistance);    
 	_tin->SetBranchAddress("tdcTime", &tdcTime);    
+
+	_tin->SetBranchAddress("gCharge", &gCharge);
+	_tin->SetBranchAddress("gTrackID", &gTrackID);
+	_tin->SetBranchAddress("gvx", &gvx);
+	_tin->SetBranchAddress("gvy", &gvy);
+	_tin->SetBranchAddress("gvz", &gvz);
+	_tin->SetBranchAddress("gpx", &gpx);
+	_tin->SetBranchAddress("gpy", &gpy);
+	_tin->SetBranchAddress("gpz", &gpz);
+
+	_tin->SetBranchAddress("gx_st1", &gx_st1);
+	_tin->SetBranchAddress("gy_st1", &gy_st1);
+	_tin->SetBranchAddress("gz_st1", &gz_st1);
+	_tin->SetBranchAddress("gpx_st1", &gpx_st1);
+	_tin->SetBranchAddress("gpy_st1", &gpy_st1);
+	_tin->SetBranchAddress("gpz_st1", &gpz_st1);
+
+	_tin->SetBranchAddress("gx_st3", &gx_st3);
+	_tin->SetBranchAddress("gy_st3", &gy_st3);
+	_tin->SetBranchAddress("gz_st3", &gz_st3);
+	_tin->SetBranchAddress("gpx_st3", &gpx_st3);
+	_tin->SetBranchAddress("gpy_st3", &gpy_st3);
+	_tin->SetBranchAddress("gpz_st3", &gpz_st3);
+
 
 	segment = 0;
 	isopen = 1;

--- a/packages/RUS/Fun4AllRUSInputManager.h
+++ b/packages/RUS/Fun4AllRUSInputManager.h
@@ -13,6 +13,7 @@ class TTree;
 class SQRun;
 class SQSpillMap;
 class SQEvent;
+class SQTrackVector;
 class SQHitVector;
 
 class Fun4AllRUSInputManager : public Fun4AllInputManager {
@@ -36,7 +37,11 @@ public:
 
     const std::string& get_tree_name() const { return _tree_name; }
     void set_tree_name(const std::string& treeName) { _tree_name = treeName; }
+    void set_mc(bool val) { is_mc = val; }
+    bool get_mc() const { return is_mc; }
 protected:
+
+    bool is_mc;
     int OpenNextFile();
     void VectToE1039();
     int segment;
@@ -62,15 +67,28 @@ protected:
     int nimTrigger[5] = {0};
 
     std::vector<int>* hitID = nullptr;
+    std::vector<int>* hitTrackID = nullptr;
     std::vector<int>* detectorID = nullptr;
     std::vector<int>* elementID = nullptr;
     std::vector<double>* driftDistance = nullptr;
     std::vector<double>* tdcTime = nullptr;
 
+
+	std::vector<int> *gCharge = nullptr, *gTrackID = nullptr;
+	std::vector<double>
+  	*gvx = nullptr, *gvy = nullptr, *gvz = nullptr,
+ 	*gpx = nullptr, *gpy = nullptr, *gpz = nullptr,
+  	*gx_st1 = nullptr, *gy_st1 = nullptr, *gz_st1 = nullptr,
+  	*gpx_st1 = nullptr, *gpy_st1 = nullptr, *gpz_st1 = nullptr,
+  	*gx_st3 = nullptr, *gy_st3 = nullptr, *gz_st3 = nullptr,
+  	*gpx_st3 = nullptr, *gpy_st3 = nullptr, *gpz_st3 = nullptr;
+
     SQRun*       run_header;
     SQSpillMap*  spill_map;
     SQEvent*     event_header;
     SQHitVector* hit_vec;
+    SQHitVector* hit_vec_mc;
+    SQTrackVector* trk_vec;
 };
 
 #endif /* __Fun4AllRUSInputManager_H_ */

--- a/packages/RUS/Fun4AllRUSInputManager.h
+++ b/packages/RUS/Fun4AllRUSInputManager.h
@@ -87,7 +87,6 @@ protected:
     SQSpillMap*  spill_map;
     SQEvent*     event_header;
     SQHitVector* hit_vec;
-    SQHitVector* hit_vec_mc;
     SQTrackVector* trk_vec;
 };
 

--- a/packages/RUS/Fun4AllRUSOutputManager.cc
+++ b/packages/RUS/Fun4AllRUSOutputManager.cc
@@ -25,8 +25,8 @@ Fun4AllRUSOutputManager::Fun4AllRUSOutputManager(const std::string &myname)
     : Fun4AllOutputManager(myname),
     m_file(0),
     m_tree(0),
-    true_mode(true),
-    exp_mode(false),
+    mc_truth_mode(false),
+    write_sq_event_info(true),
     m_tree_name("tree"),
     m_file_name("output.root"),
     m_evt(0),
@@ -71,7 +71,7 @@ int Fun4AllRUSOutputManager::OpenFile(PHCompositeNode* startNode) {
     m_tree->Branch("runID", &runID, "runID/I");
     m_tree->Branch("eventID", &eventID, "eventID/I");
 
-    if (sqevent_flag){
+    if (write_sq_event_info){
         m_tree->Branch("spillID", &spillID, "spillID/I");
         m_tree->Branch("rfID", &rfID, "rfID/I");
         m_tree->Branch("turnID", &turnID, "turnID/I");
@@ -86,8 +86,7 @@ int Fun4AllRUSOutputManager::OpenFile(PHCompositeNode* startNode) {
     m_tree->Branch("tdcTime", &tdcTime);
     m_tree->Branch("driftDistance", &driftDistance);
 
-
-    if (true_mode) {
+    if (mc_truth_mode) {
         m_tree->Branch("gProcessID", &gProcessID); //Hit level
         m_tree->Branch("gCharge", &gCharge);
         m_tree->Branch("gTrackID", &gTrackID);
@@ -116,17 +115,10 @@ int Fun4AllRUSOutputManager::OpenFile(PHCompositeNode* startNode) {
 
     m_evt = findNode::getClass<SQEvent>(startNode, "SQEvent");
     m_hit_vec = findNode::getClass<SQHitVector>(startNode, "SQHitVector");
+    if (mc_truth_mode) m_vec_trk = findNode::getClass<SQTrackVector>(startNode, "SQTruthTrackVector");
 
-    if (true_mode) {
-        m_vec_trk = findNode::getClass<SQTrackVector>(startNode, "SQTruthTrackVector");
-        if (!m_vec_trk) {
-            return Fun4AllReturnCodes::ABORTEVENT;
-        }
-    }
-
-    if (!m_evt || !m_hit_vec) {
+    if (!m_evt || !m_hit_vec || (mc_truth_mode && !m_vec_trk))
         return Fun4AllReturnCodes::ABORTEVENT;
-    }
 
     return Fun4AllReturnCodes::EVENT_OK;
 }
@@ -135,7 +127,7 @@ int Fun4AllRUSOutputManager::Write(PHCompositeNode* startNode) {
         OpenFile(startNode);
     }
 
-    if (sqevent_flag){
+    if (write_sq_event_info){
         runID = m_evt->get_run_id();
         spillID = m_evt->get_spill_id();
         eventID = m_evt->get_event_id();
@@ -157,7 +149,7 @@ int Fun4AllRUSOutputManager::Write(PHCompositeNode* startNode) {
             rfIntensity[i+ 16] = m_evt->get_qie_rf_intensity(i);
         }
     }
-    if (m_hit_vec && exp_mode==true) {
+    if (mc_truth_mode==false) {
         ResetHitBranches();
         for (int ihit = 0; ihit < m_hit_vec->size(); ++ihit) {
             SQHit* hit = m_hit_vec->at(ihit);
@@ -169,7 +161,7 @@ int Fun4AllRUSOutputManager::Write(PHCompositeNode* startNode) {
             driftDistance.push_back(hit->get_drift_distance());
         }
     }
-    if(true_mode == true){
+    if(mc_truth_mode == true){
         ResetTrueTrackBranches();
         ResetHitBranches();
         for (unsigned int ii = 0; ii < m_vec_trk->size(); ii++) {
@@ -190,7 +182,6 @@ int Fun4AllRUSOutputManager::Write(PHCompositeNode* startNode) {
             gpx_st1.push_back(trk->get_mom_st1().Px());
             gpy_st1.push_back(trk->get_mom_st1().Py());
             gpz_st1.push_back(trk->get_mom_st1().Pz());
-
             gx_st3.push_back(trk->get_pos_st3().X());
             gy_st3.push_back(trk->get_pos_st3().Y());
             gz_st3.push_back(trk->get_pos_st3().Z());
@@ -198,31 +189,25 @@ int Fun4AllRUSOutputManager::Write(PHCompositeNode* startNode) {
             gpy_st3.push_back(trk->get_mom_st3().Py());
             gpz_st3.push_back(trk->get_mom_st3().Pz());
 
-            //This assignment will later need to be done using a DST node, for example, a Geant4 geometry data node to set the limits.
             double z = trk->get_pos_vtx().Z();
             if (z <= -296. && z >= -304.) source_flag = 1; // target
             else if (z >= 0. && z < 500) source_flag = 2;   // dump
             else if (z > -296. && z < 0.) source_flag = 3;  // gap
             else if (z < -304) source_flag = 0;              // upstream
 
-            if (m_hit_vec) {
-                for (int ihit = 0; ihit < m_hit_vec->size(); ++ihit) {
-                    SQHit* hit = m_hit_vec->at(ihit);
-                    if(hit->get_track_id() != trk->get_track_id()) continue;
-                    int process_id_ = (trk->get_charge() > 0) ? process_id : process_id + 10;
-                    unsigned int encodedValue = EncodeProcess(process_id_, source_flag);
-                    //cout << "charge: "<< trk->get_charge() <<endl;
-                    //cout << "encodedValue: "<< encodedValue<< endl;
-                    //cout << "DecodeSourceFlag: "<< DecodeSourceFlag(encodedValue) << endl;
-                    //cout << "DecodeProcessID: "<< DecodeProcessID(encodedValue) << endl;
-                    gProcessID.push_back(encodedValue);
-                    hitID.push_back(hit->get_hit_id());
-                    hitTrackID.push_back(hit->get_track_id());
-                    detectorID.push_back(hit->get_detector_id());
-                    elementID.push_back(hit->get_element_id());
-                    tdcTime.push_back(hit->get_tdc_time());
-                    driftDistance.push_back(hit->get_drift_distance());
-                }   
+            for (int ihit = 0; ihit < m_hit_vec->size(); ++ihit) {
+                SQHit* hit = m_hit_vec->at(ihit);
+
+                if(hit->get_track_id() != trk->get_track_id()) continue;
+                int process_id_ = (trk->get_charge() > 0) ? process_id : process_id + 10;
+                unsigned int encodedValue = EncodeProcess(process_id_, source_flag);
+                gProcessID.push_back(encodedValue);
+                hitID.push_back(hit->get_hit_id());
+                hitTrackID.push_back(hit->get_track_id());
+                detectorID.push_back(hit->get_detector_id());
+                elementID.push_back(hit->get_element_id());
+                tdcTime.push_back(hit->get_tdc_time());
+                driftDistance.push_back(hit->get_drift_distance());
             }
         }
     }

--- a/packages/RUS/Fun4AllRUSOutputManager.cc
+++ b/packages/RUS/Fun4AllRUSOutputManager.cc
@@ -23,12 +23,14 @@ using namespace std;
 
 Fun4AllRUSOutputManager::Fun4AllRUSOutputManager(const std::string &myname)
     : Fun4AllOutputManager(myname),
-    m_file(0),
-    m_tree(0),
+    process_id(14),
+    source_flag(1),
     mc_truth_mode(false),
     write_sq_event_info(true),
     m_tree_name("tree"),
     m_file_name("output.root"),
+    m_file(0),
+    m_tree(0),
     m_evt(0),
     m_vec_trk(0),
     m_sp_map(0),
@@ -36,9 +38,12 @@ Fun4AllRUSOutputManager::Fun4AllRUSOutputManager(const std::string &myname)
     m_compression_level(5),
     m_basket_size(64000),
     m_auto_flush(2500),
-    process_id(14),
-    source_flag(1),
-    m_hit_vec(0)
+    m_hit_vec(0),
+    runID(0),
+    spillID(0),
+    eventID(0),
+    turnID(0),
+    rfID(0)
 {
     ;
 }
@@ -149,7 +154,7 @@ int Fun4AllRUSOutputManager::Write(PHCompositeNode* startNode) {
             rfIntensity[i+ 16] = m_evt->get_qie_rf_intensity(i);
         }
     }
-    if (mc_truth_mode==false) {
+    if (!mc_truth_mode) {
         ResetHitBranches();
         for (int ihit = 0; ihit < m_hit_vec->size(); ++ihit) {
             SQHit* hit = m_hit_vec->at(ihit);
@@ -161,7 +166,7 @@ int Fun4AllRUSOutputManager::Write(PHCompositeNode* startNode) {
             driftDistance.push_back(hit->get_drift_distance());
         }
     }
-    if(mc_truth_mode == true){
+    if(mc_truth_mode){
         ResetTrueTrackBranches();
         ResetHitBranches();
         for (unsigned int ii = 0; ii < m_vec_trk->size(); ii++) {

--- a/packages/RUS/Fun4AllRUSOutputManager.h
+++ b/packages/RUS/Fun4AllRUSOutputManager.h
@@ -20,13 +20,8 @@ class Fun4AllRUSOutputManager : public Fun4AllOutputManager {
         Fun4AllRUSOutputManager(const std::string &myname = "UNIVERSALOUT");
         virtual ~Fun4AllRUSOutputManager();
 
-        int process_id;
-        int source_flag;
-        bool mc_truth_mode;
-
         void SetTreeName(const std::string& name) { m_tree_name = name; }
         void SetFileName(const std::string& name) { m_file_name = name; }
-        virtual int Write(PHCompositeNode* startNode);
         void ResetHitBranches();
         void ResetTrueTrackBranches();
         void SetBasketSize(int size) { m_basket_size = size; }
@@ -35,19 +30,22 @@ class Fun4AllRUSOutputManager : public Fun4AllOutputManager {
         unsigned int EncodeProcess(int processID, int sourceFlag);
         void SetProcessId(int proc_id) { process_id = proc_id; }
         void SetMCTrueMode(bool enable) { mc_truth_mode = enable; }
-
-        bool write_sq_event_info;
         void EnableEventInfo(bool enable) { write_sq_event_info = enable; }
+
+        virtual int Write(PHCompositeNode* startNode);
 
     protected:
         int OpenFile(PHCompositeNode* startNode);
         void CloseFile();
 
     private:
+		int process_id;
+    	int source_flag;
+    	bool mc_truth_mode;
+    	bool write_sq_event_info;
         std::string m_tree_name;
         std::string m_file_name;
         std::string m_dir_base;
-        bool m_dimuon_mode;
 
         TFile* m_file;
         TTree* m_tree;

--- a/packages/RUS/Fun4AllRUSOutputManager.h
+++ b/packages/RUS/Fun4AllRUSOutputManager.h
@@ -22,9 +22,7 @@ class Fun4AllRUSOutputManager : public Fun4AllOutputManager {
 
         int process_id;
         int source_flag;
-        bool true_mode;
-        bool exp_mode;
-        bool sqevent_flag;
+        bool mc_truth_mode;
 
         void SetTreeName(const std::string& name) { m_tree_name = name; }
         void SetFileName(const std::string& name) { m_file_name = name; }
@@ -36,21 +34,10 @@ class Fun4AllRUSOutputManager : public Fun4AllOutputManager {
         void SetCompressionLevel(int level) { m_compression_level = level; }
         unsigned int EncodeProcess(int processID, int sourceFlag);
         void SetProcessId(int proc_id) { process_id = proc_id; }
-        void DisableSQEvent(bool enable) { sqevent_flag = enable; }
+        void SetMCTrueMode(bool enable) { mc_truth_mode = enable; }
 
-        void SetMCTrueTrackMode(bool enable) {
-            true_mode = enable;
-            if (enable) {
-                exp_mode = false;
-            }
-        }
-
-        void SetExpMode(bool enable) {
-            exp_mode = enable;
-            if (enable) {
-                true_mode = false;
-            }
-        }
+        bool write_sq_event_info;
+        void EnableEventInfo(bool enable) { write_sq_event_info = enable; }
 
     protected:
         int OpenFile(PHCompositeNode* startNode);

--- a/packages/calibrator/CalibHitElementPos.cc
+++ b/packages/calibrator/CalibHitElementPos.cc
@@ -1,55 +1,70 @@
 #include <iomanip>
- #include <interface_main/SQHitVector.h>
- #include <fun4all/Fun4AllReturnCodes.h>
- #include <phool/PHNodeIterator.h>
- #include <phool/PHIODataNode.h>
- #include <phool/getClass.h>
- #include <geom_svc/GeomSvc.h>
- #include "CalibHitElementPos.h"
- using namespace std;
-  
- CalibHitElementPos::CalibHitElementPos(const std::string& name)
-   : SubsysReco(name)
-   , m_cal_hit   (true)
-   , m_vec_hit   (0)
- {
-   ;
- }
-  
- CalibHitElementPos::~CalibHitElementPos()
- {
-   ;
- }
-  
- int CalibHitElementPos::Init(PHCompositeNode* topNode)
- {
-   return Fun4AllReturnCodes::EVENT_OK;
- }
-  
- int CalibHitElementPos::InitRun(PHCompositeNode* topNode)
- {
-   m_vec_hit   = findNode::getClass<SQHitVector>(topNode, "SQHitVector");
-   if (!m_vec_hit) return Fun4AllReturnCodes::ABORTEVENT;
-   return Fun4AllReturnCodes::EVENT_OK;
- }
-  
- int CalibHitElementPos::process_event(PHCompositeNode* topNode)
- {
-   if (Verbosity() > 10) cout << "CalibHitElementPos::process_event()"<< endl;
-   GeomSvc* geom = GeomSvc::instance();
-   if (m_cal_hit) {
-     for (SQHitVector::Iter it = m_vec_hit->begin(); it != m_vec_hit->end(); it++) {
-       SQHit* hit = *it;
-       if (Verbosity() > 10) cout << "  hit " << hit->get_detector_id() << " " << hit->get_element_id() << endl;
-       if (hit->get_detector_id() <= 0 || hit->get_detector_id() >= 1000) continue; // temporary solution to avoid a seg fault on strange hits.
-       hit->set_pos(geom->getMeasurement(hit->get_detector_id(), hit->get_element_id()));
-     }
-   }
+#include <interface_main/SQHitVector.h>
+#include <fun4all/Fun4AllReturnCodes.h>
+#include <phool/PHNodeIterator.h>
+#include <phool/PHIODataNode.h>
+#include <phool/getClass.h>
+#include <geom_svc/GeomSvc.h>
+#include "CalibHitElementPos.h"
+using namespace std;
 
-   return Fun4AllReturnCodes::EVENT_OK;
- }
-  
- int CalibHitElementPos::End(PHCompositeNode* topNode)
- {
-   return Fun4AllReturnCodes::EVENT_OK;
- }
+CalibHitElementPos::CalibHitElementPos(const std::string& name)
+  : SubsysReco(name)
+  , m_cal_hit   (true)
+  , m_cal_tr_hit(true)
+  , m_vec_hit   (0)
+  , m_vec_trhit (0)
+{
+  ;
+}
+
+CalibHitElementPos::~CalibHitElementPos()
+{
+  ;
+}
+
+int CalibHitElementPos::Init(PHCompositeNode* topNode)
+{
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int CalibHitElementPos::InitRun(PHCompositeNode* topNode)
+{
+  if (m_cal_hit) {
+    m_vec_hit = findNode::getClass<SQHitVector>(topNode, "SQHitVector");
+    if (!m_vec_hit) return Fun4AllReturnCodes::ABORTEVENT;
+  }
+  if (m_cal_tr_hit) {
+    m_vec_trhit = findNode::getClass<SQHitVector>(topNode, "SQTriggerHitVector");
+    if (!m_vec_trhit) return Fun4AllReturnCodes::ABORTEVENT;
+  }
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int CalibHitElementPos::process_event(PHCompositeNode* topNode)
+{
+  if (Verbosity() > 10) cout << "CalibHitElementPos::process_event()"<< endl;
+  GeomSvc* geom = GeomSvc::instance();
+  if (m_cal_hit) {
+    for (SQHitVector::Iter it = m_vec_hit->begin(); it != m_vec_hit->end(); it++) {
+      SQHit* hit = *it;
+      if (Verbosity() > 10) cout << "  hit " << hit->get_detector_id() << " " << hit->get_element_id() << endl;
+      if (hit->get_detector_id() <= 0 || hit->get_detector_id() >= 1000) continue; // temporary solution to avoid a seg fault on strange hits.
+      hit->set_pos(geom->getMeasurement(hit->get_detector_id(), hit->get_element_id()));
+    }
+  }
+  if (m_cal_tr_hit) {
+    for (SQHitVector::Iter it = m_vec_trhit->begin(); it != m_vec_trhit->end(); it++) {
+      SQHit* hit = *it;
+      if (Verbosity() > 10) cout << "  trig hit " << hit->get_detector_id() << " " << hit->get_element_id() << endl;
+      if (hit->get_detector_id() <= 0 || hit->get_detector_id() >= 1000) continue; // temporary solution to avoid a seg fault on strange hits.
+      hit->set_pos(geom->getMeasurement(hit->get_detector_id(), hit->get_element_id()));
+    }
+  }
+  return Fun4AllReturnCodes::EVENT_OK;
+}
+
+int CalibHitElementPos::End(PHCompositeNode* topNode)
+{
+  return Fun4AllReturnCodes::EVENT_OK;
+}

--- a/packages/calibrator/CalibHitElementPos.cc
+++ b/packages/calibrator/CalibHitElementPos.cc
@@ -1,65 +1,55 @@
 #include <iomanip>
-#include <interface_main/SQHitVector.h>
-#include <fun4all/Fun4AllReturnCodes.h>
-#include <phool/PHNodeIterator.h>
-#include <phool/PHIODataNode.h>
-#include <phool/getClass.h>
-#include <geom_svc/GeomSvc.h>
-#include "CalibHitElementPos.h"
-using namespace std;
+ #include <interface_main/SQHitVector.h>
+ #include <fun4all/Fun4AllReturnCodes.h>
+ #include <phool/PHNodeIterator.h>
+ #include <phool/PHIODataNode.h>
+ #include <phool/getClass.h>
+ #include <geom_svc/GeomSvc.h>
+ #include "CalibHitElementPos.h"
+ using namespace std;
+  
+ CalibHitElementPos::CalibHitElementPos(const std::string& name)
+   : SubsysReco(name)
+   , m_cal_hit   (true)
+   , m_vec_hit   (0)
+ {
+   ;
+ }
+  
+ CalibHitElementPos::~CalibHitElementPos()
+ {
+   ;
+ }
+  
+ int CalibHitElementPos::Init(PHCompositeNode* topNode)
+ {
+   return Fun4AllReturnCodes::EVENT_OK;
+ }
+  
+ int CalibHitElementPos::InitRun(PHCompositeNode* topNode)
+ {
+   m_vec_hit   = findNode::getClass<SQHitVector>(topNode, "SQHitVector");
+   if (!m_vec_hit) return Fun4AllReturnCodes::ABORTEVENT;
+   return Fun4AllReturnCodes::EVENT_OK;
+ }
+  
+ int CalibHitElementPos::process_event(PHCompositeNode* topNode)
+ {
+   if (Verbosity() > 10) cout << "CalibHitElementPos::process_event()"<< endl;
+   GeomSvc* geom = GeomSvc::instance();
+   if (m_cal_hit) {
+     for (SQHitVector::Iter it = m_vec_hit->begin(); it != m_vec_hit->end(); it++) {
+       SQHit* hit = *it;
+       if (Verbosity() > 10) cout << "  hit " << hit->get_detector_id() << " " << hit->get_element_id() << endl;
+       if (hit->get_detector_id() <= 0 || hit->get_detector_id() >= 1000) continue; // temporary solution to avoid a seg fault on strange hits.
+       hit->set_pos(geom->getMeasurement(hit->get_detector_id(), hit->get_element_id()));
+     }
+   }
 
-CalibHitElementPos::CalibHitElementPos(const std::string& name)
-  : SubsysReco(name)
-  , m_cal_hit   (true)
-  , m_cal_tr_hit(true)
-  , m_vec_hit   (0)
-  , m_vec_trhit (0)
-{
-  ;
-}
-
-CalibHitElementPos::~CalibHitElementPos()
-{
-  ;
-}
-
-int CalibHitElementPos::Init(PHCompositeNode* topNode)
-{
-  return Fun4AllReturnCodes::EVENT_OK;
-}
-
-int CalibHitElementPos::InitRun(PHCompositeNode* topNode)
-{
-  m_vec_hit   = findNode::getClass<SQHitVector>(topNode, "SQHitVector");
-  m_vec_trhit = findNode::getClass<SQHitVector>(topNode, "SQTriggerHitVector");
-  if (!m_vec_hit || !m_vec_trhit) return Fun4AllReturnCodes::ABORTEVENT;
-  return Fun4AllReturnCodes::EVENT_OK;
-}
-
-int CalibHitElementPos::process_event(PHCompositeNode* topNode)
-{
-  if (Verbosity() > 10) cout << "CalibHitElementPos::process_event()"<< endl;
-  GeomSvc* geom = GeomSvc::instance();
-  if (m_cal_hit) {
-    for (SQHitVector::Iter it = m_vec_hit->begin(); it != m_vec_hit->end(); it++) {
-      SQHit* hit = *it;
-      if (Verbosity() > 10) cout << "  hit " << hit->get_detector_id() << " " << hit->get_element_id() << endl;
-      if (hit->get_detector_id() <= 0 || hit->get_detector_id() >= 1000) continue; // temporary solution to avoid a seg fault on strange hits.
-      hit->set_pos(geom->getMeasurement(hit->get_detector_id(), hit->get_element_id()));
-    }
-  }
-  if (m_cal_tr_hit) {
-    for (SQHitVector::Iter it = m_vec_trhit->begin(); it != m_vec_trhit->end(); it++) {
-      SQHit* hit = *it;
-      if (Verbosity() > 10) cout << "  trig hit " << hit->get_detector_id() << " " << hit->get_element_id() << endl;
-      if (hit->get_detector_id() <= 0 || hit->get_detector_id() >= 1000) continue; // temporary solution to avoid a seg fault on strange hits.
-      hit->set_pos(geom->getMeasurement(hit->get_detector_id(), hit->get_element_id()));
-    }
-  }
-  return Fun4AllReturnCodes::EVENT_OK;
-}
-
-int CalibHitElementPos::End(PHCompositeNode* topNode)
-{
-  return Fun4AllReturnCodes::EVENT_OK;
-}
+   return Fun4AllReturnCodes::EVENT_OK;
+ }
+  
+ int CalibHitElementPos::End(PHCompositeNode* topNode)
+ {
+   return Fun4AllReturnCodes::EVENT_OK;
+ }

--- a/packages/calibrator/CalibHitElementPos.h
+++ b/packages/calibrator/CalibHitElementPos.h
@@ -1,23 +1,25 @@
- #ifndef __CALIB_HIT_ELEMENT_POS_H__
- #define __CALIB_HIT_ELEMENT_POS_H__
- #include <fun4all/SubsysReco.h>
- class SQHitVector;
-  
- class CalibHitElementPos: public SubsysReco {
-   bool m_cal_hit;
-   bool m_cal_tr_hit;
-   SQHitVector* m_vec_hit;
-  
-  public:
-   CalibHitElementPos(const std::string &name = "CalibHitElementPos");
-   virtual ~CalibHitElementPos();
-   int Init(PHCompositeNode *topNode);
-   int InitRun(PHCompositeNode *topNode);
-   int process_event(PHCompositeNode *topNode);
-   int End(PHCompositeNode *topNode);
-  
-   void CalibHit       (const bool cal) { m_cal_hit    = cal; }
-   void CalibTriggerHit(const bool cal) { m_cal_tr_hit = cal; }
- };
-  
- #endif // __CALIB_HIT_ELEMENT_POS_H__
+#ifndef __CALIB_HIT_ELEMENT_POS_H__
+#define __CALIB_HIT_ELEMENT_POS_H__
+#include <fun4all/SubsysReco.h>
+class SQHitVector;
+
+/// SubsysReco module to set the position of SQHit using GeomSvc.
+class CalibHitElementPos: public SubsysReco {
+  bool m_cal_hit;
+  bool m_cal_tr_hit;
+  SQHitVector* m_vec_hit;
+  SQHitVector* m_vec_trhit;
+
+ public:
+  CalibHitElementPos(const std::string &name = "CalibHitElementPos");
+  virtual ~CalibHitElementPos();
+  int Init(PHCompositeNode *topNode);
+  int InitRun(PHCompositeNode *topNode);
+  int process_event(PHCompositeNode *topNode);
+  int End(PHCompositeNode *topNode);
+
+  void CalibHit       (const bool cal) { m_cal_hit    = cal; }
+  void CalibTriggerHit(const bool cal) { m_cal_tr_hit = cal; }
+};
+
+#endif // __CALIB_HIT_ELEMENT_POS_H__

--- a/packages/calibrator/CalibHitElementPos.h
+++ b/packages/calibrator/CalibHitElementPos.h
@@ -1,25 +1,23 @@
-#ifndef __CALIB_HIT_ELEMENT_POS_H__
-#define __CALIB_HIT_ELEMENT_POS_H__
-#include <fun4all/SubsysReco.h>
-class SQHitVector;
-
-/// SubsysReco module to set the position of SQHit using GeomSvc.
-class CalibHitElementPos: public SubsysReco {
-  bool m_cal_hit;
-  bool m_cal_tr_hit;
-  SQHitVector* m_vec_hit;
-  SQHitVector* m_vec_trhit;
-
- public:
-  CalibHitElementPos(const std::string &name = "CalibHitElementPos");
-  virtual ~CalibHitElementPos();
-  int Init(PHCompositeNode *topNode);
-  int InitRun(PHCompositeNode *topNode);
-  int process_event(PHCompositeNode *topNode);
-  int End(PHCompositeNode *topNode);
-
-  void CalibHit       (const bool cal) { m_cal_hit    = cal; }
-  void CalibTriggerHit(const bool cal) { m_cal_tr_hit = cal; }
-};
-
-#endif // __CALIB_HIT_ELEMENT_POS_H__
+ #ifndef __CALIB_HIT_ELEMENT_POS_H__
+ #define __CALIB_HIT_ELEMENT_POS_H__
+ #include <fun4all/SubsysReco.h>
+ class SQHitVector;
+  
+ class CalibHitElementPos: public SubsysReco {
+   bool m_cal_hit;
+   bool m_cal_tr_hit;
+   SQHitVector* m_vec_hit;
+  
+  public:
+   CalibHitElementPos(const std::string &name = "CalibHitElementPos");
+   virtual ~CalibHitElementPos();
+   int Init(PHCompositeNode *topNode);
+   int InitRun(PHCompositeNode *topNode);
+   int process_event(PHCompositeNode *topNode);
+   int End(PHCompositeNode *topNode);
+  
+   void CalibHit       (const bool cal) { m_cal_hit    = cal; }
+   void CalibTriggerHit(const bool cal) { m_cal_tr_hit = cal; }
+ };
+  
+ #endif // __CALIB_HIT_ELEMENT_POS_H__


### PR DESCRIPTION
###
RUS I/O updates: true-track handling, event-info flag, and CalibHitElementPos cleanup

### Summary
This PR syncs `devel_RUS` with my latest local changes and focuses on three things:
1) **Remove stale member** from calibrator to match the new RUS I/O changes.  
2) **Add MC true-track info** in the input manager with `SQMCHit_v1`.  
3) **Cleaning up RUS output manager via a new boolean.

---

### Changes
- **Calibrator**
  - `packages/calibrator/CalibHitElementPos.cc|.h`
    - Removed `m_cal_tr_hit` to be compatible with the RUS input side.

- **RUS Input Manager**
  - `packages/RUS/Fun4AllRUSInputManager.cc`
    - Adds *true track info* variables.
    - Uses `SQMCHit_v1` for hits when MC/true-track mode is enabled:
      - `hit = new SQMCHit_v1();` to carry **true track id** per hit.
      - Falls back to `SQHit_v1` when not in MC mode.

- **RUS Output Manager**
  - `packages/RUS/Fun4AllRUSOutputManager.cc|.h`
    - Added `bool write_sq_event_info` (default **true**) to control writing of spill/trigger/RF arrays to the tree.
      - When `mc_truth_mode == false`, writes per-hit branches only.
      - When `mc_truth_mode == true`, also writes truth-track branches and encodes `(process_id, source_flag)` via `EncodeProcess(...)`.
---

I tested it with the Fun4All macro in my local branch. The reconstruction worked correctly as expected, and the track information was also retained at the hit level.