### PR TITLE
Add boolean flag to control MC true branch address setup

### DIFF
--- a/packages/RUS/Fun4AllRUSInputManager.cc
+++ b/packages/RUS/Fun4AllRUSInputManager.cc
@@ -190,75 +190,75 @@ void Fun4AllRUSInputManager::VectToE1039() {
 }
 
 int Fun4AllRUSInputManager::fileopen(const std::string &filenam) {
-	if (isopen) {
-		std::cout << "Closing currently open file "
-			<< filename
-			<< " and opening " << filenam << std::endl;
-		fileclose();
-	}   
-	filename = filenam;
+    if (isopen) {
+        std::cout << "Closing currently open file "
+            << filename
+            << " and opening " << filenam << std::endl;
+        fileclose();
+    }   
+    filename = filenam;
 
 
-	if (verbosity > 0) {
-		std::cout << ThisName << ": opening file " << filename.c_str() << std::endl;
-	}   
+    if (verbosity > 0) {
+        std::cout << ThisName << ": opening file " << filename.c_str() << std::endl;
+    }   
 
-	events_thisfile = 0;
+    events_thisfile = 0;
 
-	_fin = TFile::Open(filenam.c_str(), "READ"); // Open the file dynamically
-	if (!_fin || _fin->IsZombie()) {
-		std::cerr << "!!ERROR!! Failed to open file " << filenam << std::endl;
-	}
+    _fin = TFile::Open(filenam.c_str(), "READ"); // Open the file dynamically
+    if (!_fin || _fin->IsZombie()) {
+        std::cerr << "!!ERROR!! Failed to open file " << filenam << std::endl;
+    }
 
-	_tin = (TTree*) _fin->Get(_tree_name.c_str());
-	if (!_tin) {
-		std::cerr << "!!ERROR!! Tree " << _tree_name << " not found in file " << filenam << std::endl;
-		return -1; 
-	}
-	_tin->SetBranchAddress("eventID", &eventID);    
-	_tin->SetBranchAddress("runID", &runID);    
-	_tin->SetBranchAddress("spillID", &spillID);    
-	_tin->SetBranchAddress("rfID", &rfID);    
-	_tin->SetBranchAddress("turnID", &turnID);    
-	_tin->SetBranchAddress("fpgaTrigger", fpgaTrigger);
-	_tin->SetBranchAddress("nimTrigger", nimTrigger);
-	_tin->SetBranchAddress("rfIntensity", rfIntensity);
+    _tin = (TTree*) _fin->Get(_tree_name.c_str());
+    if (!_tin) {
+        std::cerr << "!!ERROR!! Tree " << _tree_name << " not found in file " << filenam << std::endl;
+        return -1; 
+    }
+    _tin->SetBranchAddress("eventID", &eventID);    
+    _tin->SetBranchAddress("runID", &runID);    
+    _tin->SetBranchAddress("spillID", &spillID);    
+    _tin->SetBranchAddress("rfID", &rfID);    
+    _tin->SetBranchAddress("turnID", &turnID);    
+    _tin->SetBranchAddress("fpgaTrigger", fpgaTrigger);
+    _tin->SetBranchAddress("nimTrigger", nimTrigger);
+    _tin->SetBranchAddress("rfIntensity", rfIntensity);
+    _tin->SetBranchAddress("hitID", &hitID);    
+    _tin->SetBranchAddress("hitTrackID", &hitTrackID);    
+    _tin->SetBranchAddress("detectorID", &detectorID);    
+    _tin->SetBranchAddress("elementID", &elementID);    
+    _tin->SetBranchAddress("driftDistance", &driftDistance);    
+    _tin->SetBranchAddress("tdcTime", &tdcTime);    
 
-	_tin->SetBranchAddress("hitID", &hitID);    
-	_tin->SetBranchAddress("hitTrackID", &hitTrackID);    
-	_tin->SetBranchAddress("detectorID", &detectorID);    
-	_tin->SetBranchAddress("elementID", &elementID);    
-	_tin->SetBranchAddress("driftDistance", &driftDistance);    
-	_tin->SetBranchAddress("tdcTime", &tdcTime);    
+    if (is_mc) {
+        _tin->SetBranchAddress("gCharge", &gCharge);
+        _tin->SetBranchAddress("gTrackID", &gTrackID);
+        _tin->SetBranchAddress("gvx", &gvx);
+        _tin->SetBranchAddress("gvy", &gvy);
+        _tin->SetBranchAddress("gvz", &gvz);
+        _tin->SetBranchAddress("gpx", &gpx);
+        _tin->SetBranchAddress("gpy", &gpy);
+        _tin->SetBranchAddress("gpz", &gpz);
 
-	_tin->SetBranchAddress("gCharge", &gCharge);
-	_tin->SetBranchAddress("gTrackID", &gTrackID);
-	_tin->SetBranchAddress("gvx", &gvx);
-	_tin->SetBranchAddress("gvy", &gvy);
-	_tin->SetBranchAddress("gvz", &gvz);
-	_tin->SetBranchAddress("gpx", &gpx);
-	_tin->SetBranchAddress("gpy", &gpy);
-	_tin->SetBranchAddress("gpz", &gpz);
+        _tin->SetBranchAddress("gx_st1", &gx_st1);
+        _tin->SetBranchAddress("gy_st1", &gy_st1);
+        _tin->SetBranchAddress("gz_st1", &gz_st1);
+        _tin->SetBranchAddress("gpx_st1", &gpx_st1);
+        _tin->SetBranchAddress("gpy_st1", &gpy_st1);
+        _tin->SetBranchAddress("gpz_st1", &gpz_st1);
 
-	_tin->SetBranchAddress("gx_st1", &gx_st1);
-	_tin->SetBranchAddress("gy_st1", &gy_st1);
-	_tin->SetBranchAddress("gz_st1", &gz_st1);
-	_tin->SetBranchAddress("gpx_st1", &gpx_st1);
-	_tin->SetBranchAddress("gpy_st1", &gpy_st1);
-	_tin->SetBranchAddress("gpz_st1", &gpz_st1);
+        _tin->SetBranchAddress("gx_st3", &gx_st3);
+        _tin->SetBranchAddress("gy_st3", &gy_st3);
+        _tin->SetBranchAddress("gz_st3", &gz_st3);
+        _tin->SetBranchAddress("gpx_st3", &gpx_st3);
+        _tin->SetBranchAddress("gpy_st3", &gpy_st3);
+        _tin->SetBranchAddress("gpz_st3", &gpz_st3);
+    }
 
-	_tin->SetBranchAddress("gx_st3", &gx_st3);
-	_tin->SetBranchAddress("gy_st3", &gy_st3);
-	_tin->SetBranchAddress("gz_st3", &gz_st3);
-	_tin->SetBranchAddress("gpx_st3", &gpx_st3);
-	_tin->SetBranchAddress("gpy_st3", &gpy_st3);
-	_tin->SetBranchAddress("gpz_st3", &gpz_st3);
-
-
-	segment = 0;
-	isopen = 1;
-	AddToFileOpened(filenam); // Add file to the list of opened files
-	return 0;
+    segment = 0;
+    isopen = 1;
+    AddToFileOpened(filenam); // Add file to the list of opened files
+    return 0;
 }
 
 int Fun4AllRUSInputManager::run(const int nevents) {

--- a/packages/RUS/Fun4AllRUSInputManager.cc
+++ b/packages/RUS/Fun4AllRUSInputManager.cc
@@ -1,88 +1,53 @@
- #include "Fun4AllRUSInputManager.h"
- #include <interface_main/SQMCHit_v1.h>
- #include <interface_main/SQHit_v1.h>
- #include <interface_main/SQTrack_v1.h>
- #include <interface_main/SQHitVector_v1.h>
- #include <interface_main/SQTrackVector_v1.h>
- #include <interface_main/SQEvent_v1.h>
- #include <interface_main/SQRun_v1.h>
- #include <interface_main/SQSpill_v2.h>
- #include <interface_main/SQSpillMap_v1.h>
- #include <interface_main/SQStringMap.h>
- #include <interface_main/SQScaler_v1.h>
- #include <interface_main/SQSlowCont_v1.h>
- #include <fun4all/Fun4AllServer.h>
- #include <fun4all/Fun4AllSyncManager.h>
- #include <fun4all/Fun4AllReturnCodes.h>
- #include <fun4all/Fun4AllUtils.h>
- #include <fun4all/PHTFileServer.h>
- #include <ffaobjects/RunHeader.h>
- #include <ffaobjects/SyncObjectv2.h>
- #include <phool/getClass.h>
- #include <phool/PHCompositeNode.h>
- #include <phool/PHDataNode.h>
- #include <phool/recoConsts.h>
- #include <cstdlib>
- #include <memory>
- #include <TFile.h>
- #include <TTree.h>
+#include "Fun4AllRUSInputManager.h"
+#include <interface_main/SQMCHit_v1.h>
+#include <interface_main/SQHit_v1.h>
+#include <interface_main/SQTrack_v1.h>
+#include <interface_main/SQHitVector_v1.h>
+#include <interface_main/SQTrackVector_v1.h>
+#include <interface_main/SQEvent_v1.h>
+#include <interface_main/SQRun_v1.h>
+#include <interface_main/SQSpill_v2.h>
+#include <interface_main/SQSpillMap_v1.h>
+#include <interface_main/SQStringMap.h>
+#include <interface_main/SQScaler_v1.h>
+#include <interface_main/SQSlowCont_v1.h>
+#include <fun4all/Fun4AllServer.h>
+#include <fun4all/Fun4AllSyncManager.h>
+#include <fun4all/Fun4AllReturnCodes.h>
+#include <fun4all/Fun4AllUtils.h>
+#include <fun4all/PHTFileServer.h>
+#include <ffaobjects/RunHeader.h>
+#include <ffaobjects/SyncObjectv2.h>
+#include <phool/getClass.h>
+#include <phool/PHCompositeNode.h>
+#include <phool/PHDataNode.h>
+#include <phool/recoConsts.h>
+#include <cstdlib>
+#include <memory>
+#include <TFile.h>
+#include <TTree.h>
 
 using namespace std;
 
-//Constructor
-Fun4AllRUSInputManager::Fun4AllRUSInputManager(const std::string& name, const std::string& topnodename):
-   Fun4AllInputManager(name, ""),
-   segment(-999),
-   isopen(0),
-   is_mc(false),
-   events_total(0),
-   events_thisfile(0),
-   topNodeName(topnodename),
-   _tree_name("save"),
-   run_header(nullptr),
-   spill_map(nullptr),
-   event_header(nullptr),
-   hit_vec(nullptr),
-   trk_vec(nullptr),
-   _fin(nullptr),
-   _tin(nullptr)
+Fun4AllRUSInputManager::Fun4AllRUSInputManager(const std::string& name, const std::string& topnodename)
+  : Fun4AllInputManager(name, ""),
+    segment(-999),
+    isopen(0),
+    is_mc(false),
+    events_total(0),
+    events_thisfile(0),
+    topNodeName(topnodename),
+    _tree_name("save"),
+    run_header(nullptr),
+    spill_map(nullptr),
+    event_header(nullptr),
+    hit_vec(nullptr),
+    trk_vec(nullptr),
+    _fin(nullptr),
+    _tin(nullptr)
 {
     Fun4AllServer* se = Fun4AllServer::instance();
     topNode = se->topNode(topNodeName.c_str());
-    PHNodeIterator iter(topNode);
-
-    PHCompositeNode* runNode = static_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "RUN"));
-    if (!runNode) {
-        runNode = new PHCompositeNode("RUN");
-        topNode->addNode(runNode);
-    }
-
-    PHCompositeNode* eventNode = static_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "DST"));
-    if (!eventNode) {
-        eventNode = new PHCompositeNode("DST");
-        topNode->addNode(eventNode);
-    }
-
-    run_header = new SQRun_v1();
-    PHIODataNode<PHObject>* runHeaderNode = new PHIODataNode<PHObject>(run_header, "SQRun", "PHObject");
-    runNode->addNode(runHeaderNode);
-
-    spill_map = new SQSpillMap_v1();
-    PHIODataNode<PHObject>* spillNode = new PHIODataNode<PHObject>(spill_map, "SQSpillMap", "PHObject");
-    runNode->addNode(spillNode);
-
-    event_header = new SQEvent_v1();
-    PHIODataNode<PHObject>* eventHeaderNode = new PHIODataNode<PHObject>(event_header, "SQEvent", "PHObject");
-    eventNode->addNode(eventHeaderNode);
-
-    hit_vec = new SQHitVector_v1();
-    PHIODataNode<PHObject>* hitNode = new PHIODataNode<PHObject>(hit_vec, "SQHitVector", "PHObject");
-    eventNode->addNode(hitNode);
-
-    trk_vec = new SQTrackVector_v1();
-    PHIODataNode<PHObject>* trknode = new PHIODataNode<PHObject>(trk_vec, "SQTruthTrackVector", "PHObject");
-    eventNode->addNode(trknode);
-
     syncobject = new SyncObjectv2();
 }
 
@@ -258,6 +223,8 @@ int Fun4AllRUSInputManager::fileopen(const std::string &filenam) {
         is_mc = false;
         std::cout << "No MC Track branches found. Running in RUS basic exp mode." << std::endl;
     }
+
+    if (!run_header) MakeNode();
 
     segment = 0;
     isopen = 1;
@@ -470,3 +437,42 @@ int Fun4AllRUSInputManager::fileclose()
      }
    return Fun4AllReturnCodes::SYNC_OK;
  }
+
+void Fun4AllRUSInputManager::MakeNode()
+{
+    PHNodeIterator iter(topNode);
+
+    PHCompositeNode* runNode = static_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "RUN"));
+    if (!runNode) {
+        runNode = new PHCompositeNode("RUN");
+        topNode->addNode(runNode);
+    }
+
+    PHCompositeNode* eventNode = static_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "DST"));
+    if (!eventNode) {
+        eventNode = new PHCompositeNode("DST");
+        topNode->addNode(eventNode);
+    }
+
+    run_header = new SQRun_v1();
+    runNode->addNode(new PHIODataNode<PHObject>(run_header, "SQRun", "PHObject"));
+
+    spill_map = new SQSpillMap_v1();
+    runNode->addNode(new PHIODataNode<PHObject>(spill_map, "SQSpillMap", "PHObject"));
+
+    event_header = new SQEvent_v1();
+    eventNode->addNode(new PHIODataNode<PHObject>(event_header, "SQEvent", "PHObject"));
+
+    hit_vec = new SQHitVector_v1();
+    eventNode->addNode(new PHIODataNode<PHObject>(hit_vec, "SQHitVector", "PHObject"));
+
+    if (is_mc) {
+        trk_vec = new SQTrackVector_v1();
+        eventNode->addNode(new PHIODataNode<PHObject>(trk_vec, "SQTruthTrackVector", "PHObject"));
+    }
+
+    std::cout << "Fun4AllRUSInputManager::MakeNode(): Created "
+              << (is_mc ? "MC" : "Data")
+              << " node structure under DST and RUN." << std::endl;
+}
+

--- a/packages/RUS/Fun4AllRUSInputManager.cc
+++ b/packages/RUS/Fun4AllRUSInputManager.cc
@@ -149,7 +149,6 @@ void Fun4AllRUSInputManager::VectToE1039() {
         hit->set_element_id(elementID->at(i));
         hit->set_tdc_time(tdcTime->at(i));
         hit->set_drift_distance(driftDistance->at(i));
-
         hit_vec->push_back(hit);
     }
 
@@ -230,7 +229,9 @@ int Fun4AllRUSInputManager::fileopen(const std::string &filenam) {
     _tin->SetBranchAddress("driftDistance", &driftDistance);    
     _tin->SetBranchAddress("tdcTime", &tdcTime);    
 
-    if (is_mc) {
+    if (_tin->GetBranch("gCharge") != nullptr) {
+		std::cout << "Detected MC true-track branches." << std::endl;
+        is_mc = true;
         _tin->SetBranchAddress("gCharge", &gCharge);
         _tin->SetBranchAddress("gTrackID", &gTrackID);
         _tin->SetBranchAddress("gvx", &gvx);
@@ -253,6 +254,9 @@ int Fun4AllRUSInputManager::fileopen(const std::string &filenam) {
         _tin->SetBranchAddress("gpx_st3", &gpx_st3);
         _tin->SetBranchAddress("gpy_st3", &gpy_st3);
         _tin->SetBranchAddress("gpz_st3", &gpz_st3);
+    }else {
+        is_mc = false;
+        std::cout << "No MC Track branches found. Running in RUS basic exp mode." << std::endl;
     }
 
     segment = 0;

--- a/packages/RUS/Fun4AllRUSInputManager.h
+++ b/packages/RUS/Fun4AllRUSInputManager.h
@@ -37,6 +37,7 @@ public:
 
     const std::string& get_tree_name() const { return _tree_name; }
     void set_tree_name(const std::string& treeName) { _tree_name = treeName; }
+    void MakeNode();
 protected:
 
     bool is_mc;

--- a/packages/RUS/Fun4AllRUSInputManager.h
+++ b/packages/RUS/Fun4AllRUSInputManager.h
@@ -37,8 +37,6 @@ public:
 
     const std::string& get_tree_name() const { return _tree_name; }
     void set_tree_name(const std::string& treeName) { _tree_name = treeName; }
-    void set_mc(bool val) { is_mc = val; }
-    bool get_mc() const { return is_mc; }
 protected:
 
     bool is_mc;

--- a/packages/RUS/Fun4AllRUSOutputManager.cc
+++ b/packages/RUS/Fun4AllRUSOutputManager.cc
@@ -53,7 +53,9 @@ Fun4AllRUSOutputManager::~Fun4AllRUSOutputManager() {
 }
 
 int Fun4AllRUSOutputManager::OpenFile(PHCompositeNode* startNode) {
-    std::cout << "Fun4AllRUSOutputManager::OpenFile(): Attempting to open file: " << m_file_name << " with tree: " << m_tree_name << std::endl;
+    std::cout << "Fun4AllRUSOutputManager::OpenFile(): Attempting to open file: "
+              << m_file_name << " with tree: " << m_tree_name << std::endl;
+    // Create output ROOT file
     m_file = new TFile(m_file_name.c_str(), "RECREATE");
     m_file->SetCompressionAlgorithm(ROOT::kLZMA);
     m_file->SetCompressionLevel(m_compression_level);
@@ -61,22 +63,21 @@ int Fun4AllRUSOutputManager::OpenFile(PHCompositeNode* startNode) {
     if (!m_file || m_file->IsZombie()) {
         std::cerr << "Error: Could not create file " << m_file_name << std::endl;
         exit(1);
-    } else {
-        std::cout << "File " << m_file->GetName() << " opened successfully." << std::endl;
     }
+    std::cout << "File " << m_file->GetName() << " opened successfully." << std::endl;
 
     m_tree = new TTree(m_tree_name.c_str(), "Tree for storing events");
     if (!m_tree) {
         std::cerr << "Error: Could not create tree " << m_tree_name << std::endl;
         exit(1);
-    } else {
-        std::cout << "Tree " << m_tree->GetName() << " created successfully." << std::endl;
     }
+    std::cout << "Tree " << m_tree->GetName() << " created successfully." << std::endl;
 
+    // Basic event-level branches
     m_tree->Branch("runID", &runID, "runID/I");
     m_tree->Branch("eventID", &eventID, "eventID/I");
 
-    if (write_sq_event_info){
+    if (write_sq_event_info) {
         m_tree->Branch("spillID", &spillID, "spillID/I");
         m_tree->Branch("rfID", &rfID, "rfID/I");
         m_tree->Branch("turnID", &turnID, "turnID/I");
@@ -84,6 +85,8 @@ int Fun4AllRUSOutputManager::OpenFile(PHCompositeNode* startNode) {
         m_tree->Branch("fpgaTrigger", fpgaTrigger, "fpgaTrigger[5]/I");
         m_tree->Branch("nimTrigger", nimTrigger, "nimTrigger[5]/I");
     }
+
+    // Always-present hit-level branches
     m_tree->Branch("hitID", &hitID);
     m_tree->Branch("hitTrackID", &hitTrackID);
     m_tree->Branch("detectorID", &detectorID);
@@ -91,8 +94,17 @@ int Fun4AllRUSOutputManager::OpenFile(PHCompositeNode* startNode) {
     m_tree->Branch("tdcTime", &tdcTime);
     m_tree->Branch("driftDistance", &driftDistance);
 
-    if (mc_truth_mode) {
-        m_tree->Branch("gProcessID", &gProcessID); //Hit level
+    // Find nodes in the Fun4All
+    m_evt     = findNode::getClass<SQEvent>(startNode, "SQEvent");
+    m_hit_vec = findNode::getClass<SQHitVector>(startNode, "SQHitVector");
+    m_vec_trk = findNode::getClass<SQTrackVector>(startNode, "SQTruthTrackVector");
+
+    // Automatically enable MC truth mode if SQTruthTrackVector is found
+    if (m_vec_trk != nullptr) {
+        mc_truth_mode = true;
+        std::cout << "Detected SQTruthTrackVector node -enabling MC truth output." << std::endl;
+
+        m_tree->Branch("gProcessID", &gProcessID);  
         m_tree->Branch("gCharge", &gCharge);
         m_tree->Branch("gTrackID", &gTrackID);
         m_tree->Branch("gvx", &gvx);
@@ -101,32 +113,38 @@ int Fun4AllRUSOutputManager::OpenFile(PHCompositeNode* startNode) {
         m_tree->Branch("gpx", &gpx);
         m_tree->Branch("gpy", &gpy);
         m_tree->Branch("gpz", &gpz);
+
         m_tree->Branch("gx_st1", &gx_st1);
         m_tree->Branch("gy_st1", &gy_st1);
         m_tree->Branch("gz_st1", &gz_st1);
         m_tree->Branch("gpx_st1", &gpx_st1);
         m_tree->Branch("gpy_st1", &gpy_st1);
         m_tree->Branch("gpz_st1", &gpz_st1);
+
         m_tree->Branch("gx_st3", &gx_st3);
         m_tree->Branch("gy_st3", &gy_st3);
         m_tree->Branch("gz_st3", &gz_st3);
         m_tree->Branch("gpx_st3", &gpx_st3);
         m_tree->Branch("gpy_st3", &gpy_st3);
         m_tree->Branch("gpz_st3", &gpz_st3);
+    } else {
+        mc_truth_mode = false;
+        std::cout << "No SQTruthTrackVector node found -writing data-mode output only." << std::endl;
     }
 
+    // Finalize tree configuration
     m_tree->SetAutoFlush(m_auto_flush);
     m_tree->SetBasketSize("*", m_basket_size);
 
-    m_evt = findNode::getClass<SQEvent>(startNode, "SQEvent");
-    m_hit_vec = findNode::getClass<SQHitVector>(startNode, "SQHitVector");
-    if (mc_truth_mode) m_vec_trk = findNode::getClass<SQTrackVector>(startNode, "SQTruthTrackVector");
-
-    if (!m_evt || !m_hit_vec || (mc_truth_mode && !m_vec_trk))
+    // Sanity checks
+    if (!m_evt || !m_hit_vec) {
+        std::cerr << "Error: Missing SQEvent or SQHitVector nodes in the node tree." << std::endl;
         return Fun4AllReturnCodes::ABORTEVENT;
+    }
 
     return Fun4AllReturnCodes::EVENT_OK;
 }
+
 int Fun4AllRUSOutputManager::Write(PHCompositeNode* startNode) {
     if (!m_file || !m_tree) {
         OpenFile(startNode);

--- a/packages/RUS/Fun4AllRUSOutputManager.h
+++ b/packages/RUS/Fun4AllRUSOutputManager.h
@@ -29,7 +29,6 @@ class Fun4AllRUSOutputManager : public Fun4AllOutputManager {
         void SetCompressionLevel(int level) { m_compression_level = level; }
         unsigned int EncodeProcess(int processID, int sourceFlag);
         void SetProcessId(int proc_id) { process_id = proc_id; }
-        void SetMCTrueMode(bool enable) { mc_truth_mode = enable; }
         void EnableEventInfo(bool enable) { write_sq_event_info = enable; }
 
         virtual int Write(PHCompositeNode* startNode);


### PR DESCRIPTION
I have added support for MC true track variables, controlled by the boolean flag `is_mc`.  
This flag can be enabled using the function `set_mc(true);`.   Actually I forgot to add this in the last pull request.

When `is_mc` is enabled, the file manager expects the input RUS file to contain the true track variables (`gCharge`, `gTrackID`, `gvx`, `gvy`, `gvz`, `gpx`, `gpy`, `gpz`, etc.).  
If `is_mc` is disabled, these branches are skipped, allowing the file manager to run normally with real data files that do not include MC truth information.

Relevant code block: https://github.com/E1039-Collaboration/e1039-core/blob/devel_RUS/packages/RUS/Fun4AllRUSInputManager.cc#L233-L256