### PR TITLE
Non-Fun4All use of SQVertexing and Function of road matching with margin

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -64,8 +64,6 @@ else # 'all' or 'resume'
     framework/ffaobjects
     framework/fun4all
     interface_main
-    packages/UtilAna
-    online/decoder_maindaq
     packages/Half
     packages/vararray
     database/pdbcal/base
@@ -79,8 +77,6 @@ else # 'all' or 'resume'
     simulation/g4main
     simulation/g4detectors
     simulation/g4eval
-    generators/E906LegacyGen
-    generators/SingleMuonGen
     packages/calibrator
     packages/evt_filter
     packages/dptrigger
@@ -89,6 +85,10 @@ else # 'all' or 'resume'
     packages/reco/SQGenFit
     packages/reco/kfitter
     packages/reco/ktracker
+    packages/UtilAna
+    online/decoder_maindaq
+    generators/E906LegacyGen
+    generators/SingleMuonGen
     packages/embedding
     packages/rs_Reader
     packages/RUS

--- a/generators/E906LegacyVtxGen/CMakeLists.txt
+++ b/generators/E906LegacyVtxGen/CMakeLists.txt
@@ -31,7 +31,6 @@ target_link_libraries(SQPrimaryVtxGen -L./
   -lgslcblas
   -lphool
   -lphgeom 
-  -lUtilAna
   -lboost_iostreams
 )
 

--- a/interface_main/SQCalHit_v1.cxx
+++ b/interface_main/SQCalHit_v1.cxx
@@ -15,8 +15,8 @@ ClassImp(SQCalHit_v1);
 
 SQCalHit_v1::SQCalHit_v1(): 
   _hit_id(std::numeric_limits<int>::max()),
-  _detector_id(std::numeric_limits<int>::max()),
-	_element_id(std::numeric_limits<int>::max())
+  _detector_id(std::numeric_limits<short>::max()),
+  _element_id(std::numeric_limits<short>::max())
 {
   _cells.clear();
 }

--- a/interface_main/SQHitMap.h
+++ b/interface_main/SQHitMap.h
@@ -47,13 +47,13 @@ public:
   virtual       SQHit* insert(const SQHit *hit) {return NULL;}
   virtual       size_t   erase(unsigned int idkey) {return 0;}
 
-  virtual ConstIter begin()                   const {return HitMap().end();}
-  virtual ConstIter  find(unsigned int idkey) const {return HitMap().end();}
-  virtual ConstIter   end()                   const {return HitMap().end();}
+  virtual ConstIter begin()                   const = 0;
+  virtual ConstIter  find(unsigned int idkey) const = 0;
+  virtual ConstIter   end()                   const = 0;
 
-  virtual Iter begin()                   {return HitMap().end();}
-  virtual Iter  find(unsigned int idkey) {return HitMap().end();}
-  virtual Iter   end()                   {return HitMap().end();}
+  virtual Iter begin()                   = 0;
+  virtual Iter  find(unsigned int idkey) = 0;
+  virtual Iter   end()                   = 0;
 
 protected:
   SQHitMap() {}

--- a/interface_main/SQIntMap.h
+++ b/interface_main/SQIntMap.h
@@ -36,13 +36,13 @@ public:
   virtual       PHObject* insert(const unsigned int idkey, const PHObject *item) {return NULL;}
   virtual       size_t   erase(unsigned int idkey) {return 0;}
 
-  virtual ConstIter begin()                   const {return ObjectMap().end();}
-  virtual ConstIter  find(unsigned int idkey) const {return ObjectMap().end();}
-  virtual ConstIter   end()                   const {return ObjectMap().end();}
+  virtual ConstIter begin()                   const = 0;
+  virtual ConstIter  find(unsigned int idkey) const = 0;
+  virtual ConstIter   end()                   const = 0;
 
-  virtual Iter begin()                   {return ObjectMap().end();}
-  virtual Iter  find(unsigned int idkey) {return ObjectMap().end();}
-  virtual Iter   end()                   {return ObjectMap().end();}
+  virtual Iter begin()                   = 0;
+  virtual Iter  find(unsigned int idkey) = 0;
+  virtual Iter   end()                   = 0;
 
 protected:
   SQIntMap() {}

--- a/interface_main/SQSpillMap.h
+++ b/interface_main/SQSpillMap.h
@@ -43,13 +43,13 @@ public:
   virtual       SQSpill* insert(const SQSpill *hit) {return NULL;} ///< Insert the given SQSpill object.
   virtual       size_t   erase(unsigned int idkey) {return 0;} ///< Erase the SQSpill entry having spill ID = 'idkey'.
 
-  virtual ConstIter begin()                   const {return SpillMap().end();} ///< Return the const begin iterator.
-  virtual ConstIter  find(unsigned int idkey) const {return SpillMap().end();} ///< Return the const iterator of the SQSpill entry having spill ID = 'idkey'.
-  virtual ConstIter   end()                   const {return SpillMap().end();} ///< Return the const end iterator.
+  virtual ConstIter begin()                   const = 0; ///< Return the const begin iterator.
+  virtual ConstIter  find(unsigned int idkey) const = 0; ///< Return the const iterator of the SQSpill entry having spill ID = 'idkey'.
+  virtual ConstIter   end()                   const = 0; ///< Return the const end iterator.
 
-  virtual Iter begin()                   {return SpillMap().end();} ///< Return the begin iterator.
-  virtual Iter  find(unsigned int idkey) {return SpillMap().end();} ///< Return the iterator of the SQSpill entry having spill ID = 'idkey'.
-  virtual Iter   end()                   {return SpillMap().end();} ///< Return the end iterator.
+  virtual Iter begin()                   = 0; ///< Return the begin iterator.
+  virtual Iter  find(unsigned int idkey) = 0; ///< Return the iterator of the SQSpill entry having spill ID = 'idkey'.
+  virtual Iter   end()                   = 0; ///< Return the end iterator.
 
 protected:
   SQSpillMap() {}

--- a/interface_main/SQStringMap.h
+++ b/interface_main/SQStringMap.h
@@ -36,13 +36,13 @@ public:
   virtual       PHObject* insert(const std::string key, const PHObject *item) {return NULL;}
   virtual       size_t   erase(std::string key) {return 0;}
 
-  virtual ConstIter begin()                const {return ObjectMap().end();}
-  virtual ConstIter  find(std::string key) const {return ObjectMap().end();}
-  virtual ConstIter   end()                const {return ObjectMap().end();}
+  virtual ConstIter begin()                const = 0;
+  virtual ConstIter  find(std::string key) const = 0;
+  virtual ConstIter   end()                const = 0;
 
-  virtual Iter begin()                {return ObjectMap().end();}
-  virtual Iter  find(std::string key) {return ObjectMap().end();}
-  virtual Iter   end()                {return ObjectMap().end();}
+  virtual Iter begin()                = 0;
+  virtual Iter  find(std::string key) = 0;
+  virtual Iter   end()                = 0;
 
 protected:
   SQStringMap() {}

--- a/packages/UtilAna/UtilTrack.cc
+++ b/packages/UtilAna/UtilTrack.cc
@@ -85,7 +85,7 @@ SQHitVector* UtilTrack::FindHodoHitsOfTrack(const SQHitVector* vec_in, const int
   return FindDetectorHitsOfTrack(vec_in, id_trk, "H");
 }
 
-/// Find all roads that match to the given track.
+/// Find all roads that match to the given track within the hodo paddle width plus the given margin.
 /**
  * The closest paddle to the given track at each hodoscope X plane (H1T/B, H2T/B, H3T/B and H4T/B) is selected based on the expected track x-position.
  * The two adjacent paddles are also selected if they are within "width/2 + margin".
@@ -98,11 +98,17 @@ SQHitVector* UtilTrack::FindHodoHitsOfTrack(const SQHitVector* vec_in, const int
  */
 std::vector<int> UtilTrack::FindMatchedRoads(SRecTrack* trk, const double margin)
 {
+  return FindMatchedRoads(trk->get_pos_st1(), trk->get_mom_st1(), trk->get_pos_st3(), trk->get_mom_st3(), margin);
+}
+
+/// Find all roads that match to the given track within the hodo paddle width plus the given margin.
+std::vector<int> UtilTrack::FindMatchedRoads(const TVector3 pos1, const TLorentzVector mom1, const TVector3 pos3, const TLorentzVector mom3, const double margin)  
+{
   GeomSvc* geom = GeomSvc::instance();
-  double y_st1 = trk->get_pos_st1().Y();
-  double y_st3 = trk->get_pos_st3().Y();
+  double y_st1 = pos1.Y();
+  double y_st3 = pos3.Y();
   int top_bot = y_st3>0 ? +1 : -1;
-  if (verbosity > 0) cout << "UtilTrack::FindMatchedRoads(): charge=" << trk->getCharge() << " y_st1=" << y_st1 << " y_st3=" << y_st3 << endl;
+  if (verbosity > 0) cout << "UtilTrack::FindMatchedRoads(): y_st1=" << y_st1 << " y_st3=" << y_st3 << " top_bot=" << top_bot << endl;
   
   vector<int> list_ele_id[5]; // 0=unused, 1=st1, 2=st2,,,
   for (int st = 1; st <= 4; st++) {
@@ -118,8 +124,12 @@ std::vector<int> UtilTrack::FindMatchedRoads(SRecTrack* trk, const double margin
     if (verbosity > 2) cout << "  st" << st << ":";
     if (verbosity > 3) cout << " x_det=" << x_det << " n_ele=" << n_ele << " space=" << space << " width=" << width;
 
-    double x_trk, y_trk;
-    trk->getExpPositionFast(z_det, x_trk, y_trk);
+    const TVector3*       pos = (st == 1 ? &pos1 : &pos3);
+    const TLorentzVector* mom = (st == 1 ? &mom1 : &mom3);
+    double x_trk = pos->X() + (z_det - pos->Z()) * mom->X() / mom->Z();
+    double y_trk = pos->Y() + (z_det - pos->Z()) * mom->Y() / mom->Z();
+    //double x_trk, y_trk;
+    //trk->getExpPositionFast(z_det, x_trk, y_trk);
     int ele_cent = (int)((n_ele+1)/2.0 + (x_trk-x_det)/space + 0.5);
     if (verbosity > 2) cout << " x_trk=" << x_trk << " y_trk=" << y_trk;
 

--- a/packages/UtilAna/UtilTrack.cc
+++ b/packages/UtilAna/UtilTrack.cc
@@ -1,9 +1,13 @@
 #include <cassert>
 #include <geom_svc/GeomSvc.h>
+#include <ktracker/SRecEvent.h>
 #include <interface_main/SQTrackVector.h>
 #include <interface_main/SQHitVector.h>
+#include "UtilTrigger.h"
 #include "UtilTrack.h"
 using namespace std;
+
+int UtilTrack::verbosity = 0;
 
 /// Find a track by track ID in the given track list.
 /**
@@ -79,4 +83,66 @@ SQHitVector* UtilTrack::FindDetectorHitsOfTrack(const SQHitVector* vec_in, const
 SQHitVector* UtilTrack::FindHodoHitsOfTrack(const SQHitVector* vec_in, const int id_trk)
 {
   return FindDetectorHitsOfTrack(vec_in, id_trk, "H");
+}
+
+/// Find all roads that match to the given track.
+/**
+ * The closest paddle to the given track at each hodoscope X plane (H1T/B, H2T/B, H3T/B and H4T/B) is selected based on the expected track x-position.
+ * The two adjacent paddles are also selected if they are within "width/2 + margin".
+ * All selected paddles are used to list up matched roads.
+ * @code
+ *   SRecTrack* trk = ...
+ *   const double margin = 1.0; // in cm
+ *   vector<int> list_road_id = UtilTrack::FindMatchedRoad(trk, margin);
+ * @endcode
+ */
+std::vector<int> UtilTrack::FindMatchedRoads(SRecTrack* trk, const double margin)
+{
+  GeomSvc* geom = GeomSvc::instance();
+  double y_st1 = trk->get_pos_st1().Y();
+  double y_st3 = trk->get_pos_st3().Y();
+  int top_bot = y_st3>0 ? +1 : -1;
+  if (verbosity > 0) cout << "UtilTrack::FindMatchedRoads(): charge=" << trk->getCharge() << " y_st1=" << y_st1 << " y_st3=" << y_st3 << endl;
+  
+  vector<int> list_ele_id[5]; // 0=unused, 1=st1, 2=st2,,,
+  for (int st = 1; st <= 4; st++) {
+    string det_name = (string)"H" + (char)('0'+st) + (top_bot>0 ? 'T' : 'B');
+    int det_id = geom->getDetectorID(det_name);
+    Plane* det = geom->getPlanePtr(det_id);
+    double x_det = det->xc + det->deltaX;
+    //double y_det = det->yc + det->deltaY;
+    double z_det = det->zc + det->deltaZ;
+    int    n_ele = det->nElements;
+    double space = det->spacing;
+    double width = det->cellWidth;
+    if (verbosity > 2) cout << "  st" << st << ":";
+    if (verbosity > 3) cout << " x_det=" << x_det << " n_ele=" << n_ele << " space=" << space << " width=" << width;
+
+    double x_trk, y_trk;
+    trk->getExpPositionFast(z_det, x_trk, y_trk);
+    int ele_cent = (int)((n_ele+1)/2.0 + (x_trk-x_det)/space + 0.5);
+    if (verbosity > 2) cout << " x_trk=" << x_trk << " y_trk=" << y_trk;
+
+    /// Check three elements, assuming the margin is much smaller than the half width.
+    for (int i_ele = ele_cent - 1; i_ele <= ele_cent + 1; i_ele++) {
+      if (i_ele <= 0 || i_ele > n_ele) continue;
+      double x_ele = x_det + space * (i_ele - (n_ele+1)/2.0);
+      if (verbosity > 2) cout << " [ele=" << i_ele << " x=" << x_ele;
+      if (verbosity > 3) cout << " edge=" << (width/2-fabs(x_trk-x_ele));
+      if (verbosity > 2) cout << "]";
+      if (fabs(x_trk - x_ele) < width/2 + margin) list_ele_id[st].push_back(i_ele);
+    }
+    if (verbosity > 2) cout << endl;
+  }
+  vector<int> list_road_id;
+  for (auto it1 = list_ele_id[1].begin(); it1 != list_ele_id[1].end(); it1++) {
+  for (auto it2 = list_ele_id[2].begin(); it2 != list_ele_id[2].end(); it2++) {
+  for (auto it3 = list_ele_id[3].begin(); it3 != list_ele_id[3].end(); it3++) {
+  for (auto it4 = list_ele_id[4].begin(); it4 != list_ele_id[4].end(); it4++) {
+    if (verbosity > 0) cout << "  road " << *it1 << " " << *it2 << " " << *it3 << " " << *it4;
+    if (verbosity > 1) cout << " " << UtilTrigger::Hodo2Road(*it1, *it2, *it3, *it4, top_bot);
+    if (verbosity > 0) cout << endl;
+    list_road_id.push_back(UtilTrigger::Hodo2Road(*it1, *it2, *it3, *it4, top_bot));
+  }}}}
+  return list_road_id;
 }

--- a/packages/UtilAna/UtilTrack.h
+++ b/packages/UtilAna/UtilTrack.h
@@ -5,6 +5,8 @@ class SQTrack;
 class SQTrackVector;
 class SQHitVector;
 class SRecTrack;
+class TVector3;
+class TLorentzVector;
 
 namespace UtilTrack {
   extern int verbosity;
@@ -16,6 +18,7 @@ namespace UtilTrack {
   SQHitVector* FindHodoHitsOfTrack(const SQHitVector* vec_in, const int id_trk);
 
   std::vector<int> FindMatchedRoads(SRecTrack* trk, const double margin=0);
+  std::vector<int> FindMatchedRoads(const TVector3 pos1, const TLorentzVector mom1, const TVector3 pos3, const TLorentzVector mom3, const double margin=0);
 }
 
 #endif /* _UTIL_TRACK__H_ */

--- a/packages/UtilAna/UtilTrack.h
+++ b/packages/UtilAna/UtilTrack.h
@@ -1,16 +1,21 @@
 #ifndef _UTIL_TRACK__H_
 #define _UTIL_TRACK__H_
+#include <vector>
 class SQTrack;
 class SQTrackVector;
 class SQHitVector;
+class SRecTrack;
 
 namespace UtilTrack {
+  extern int verbosity;
   SQTrack* FindTrackByID(const SQTrackVector* vec, const int id_trk, const bool do_assert=false);
 
   SQHitVector* FindHitsOfTrack(const SQHitVector* vec_in, const int id_trk);
   SQHitVector* FindDetectorHitsOfTrack(const SQHitVector* vec_in, const int id_trk, const std::string det_name);
   SQHitVector* FindDetectorHitsOfTrack(const SQHitVector* vec_in, const int id_trk, const char*       det_name);
   SQHitVector* FindHodoHitsOfTrack(const SQHitVector* vec_in, const int id_trk);
+
+  std::vector<int> FindMatchedRoads(SRecTrack* trk, const double margin=0);
 }
 
 #endif /* _UTIL_TRACK__H_ */

--- a/packages/reco/ktracker/SQVertexing.cxx
+++ b/packages/reco/ktracker/SQVertexing.cxx
@@ -90,13 +90,13 @@ int SQVertexing::InitRun(PHCompositeNode* topNode)
     
     ret = MakeNodes(topNode);
     if(ret != Fun4AllReturnCodes::EVENT_OK) return ret;
-    
-    ret = InitField(topNode);
-    if(ret != Fun4AllReturnCodes::EVENT_OK) return ret;
-    
-    ret = InitGeom(topNode);
-    if(ret != Fun4AllReturnCodes::EVENT_OK) return ret;
   }
+    
+  ret = InitField(topNode);
+  if(ret != Fun4AllReturnCodes::EVENT_OK) return ret;
+  
+  ret = InitGeom(topNode);
+  if(ret != Fun4AllReturnCodes::EVENT_OK) return ret;
   
   //Initialize random seed
   recoConsts* rc = recoConsts::instance();

--- a/packages/reco/ktracker/SQVertexing.cxx
+++ b/packages/reco/ktracker/SQVertexing.cxx
@@ -21,7 +21,7 @@
 
 #include "SRecEvent.h"
 #include "GFTrack.h"
-
+#include <TGeoManager.h>
 #include <iostream>
 #include <vector>
 
@@ -84,18 +84,20 @@ int SQVertexing::Init(PHCompositeNode* topNode)
 
 int SQVertexing::InitRun(PHCompositeNode* topNode)
 {
-  int ret = GetNodes(topNode);
-  if(ret != Fun4AllReturnCodes::EVENT_OK) return ret;
-
-  ret = MakeNodes(topNode);
-  if(ret != Fun4AllReturnCodes::EVENT_OK) return ret;
-
-  ret = InitField(topNode);
-  if(ret != Fun4AllReturnCodes::EVENT_OK) return ret;
-
-  ret = InitGeom(topNode);
-  if(ret != Fun4AllReturnCodes::EVENT_OK) return ret;
-
+  if (topNode) {
+    int ret = GetNodes(topNode);
+    if(ret != Fun4AllReturnCodes::EVENT_OK) return ret;
+    
+    ret = MakeNodes(topNode);
+    if(ret != Fun4AllReturnCodes::EVENT_OK) return ret;
+    
+    ret = InitField(topNode);
+    if(ret != Fun4AllReturnCodes::EVENT_OK) return ret;
+    
+    ret = InitGeom(topNode);
+    if(ret != Fun4AllReturnCodes::EVENT_OK) return ret;
+  }
+  
   //Initialize random seed
   recoConsts* rc = recoConsts::instance();
   rndm.SetSeed(rc->get_IntFlag("RUNNUMBER"));
@@ -447,7 +449,9 @@ int SQVertexing::InitField(PHCompositeNode* topNode)
     recoConsts* rc = recoConsts::instance();
 
     std::unique_ptr<PHFieldConfig> default_field_cfg(new PHFieldConfig_v3(rc->get_CharFlag("fMagFile"), rc->get_CharFlag("kMagFile"), rc->get_DoubleFlag("FMAGSTR"), rc->get_DoubleFlag("KMAGSTR"), 5.));
-    PHField* phfield = PHFieldUtility::GetFieldMapNode(default_field_cfg.get(), topNode, 0);
+    PHField* phfield;
+    if (topNode) phfield = PHFieldUtility::GetFieldMapNode(default_field_cfg.get(), topNode, 0);
+    else         phfield = PHFieldUtility::BuildFieldMap(default_field_cfg.get(), 0);
 
     std::cout << "SQVertexing::InitField - creating new GenFit field map" << std::endl;
     gfield = new SQGenFit::GFField(phfield);
@@ -466,11 +470,14 @@ int SQVertexing::InitGeom(PHCompositeNode* topNode)
   if(geom_file_name != "")
   {
     std::cout << "SQVertexing::InitGeom - create geom from " << geom_file_name << std::endl;
-
-    int ret = PHGeomUtility::ImportGeomFile(topNode, geom_file_name);
+    if (topNode) {
+      int ret = PHGeomUtility::ImportGeomFile(topNode, geom_file_name);
+      if (ret != Fun4AllReturnCodes::EVENT_OK) return ret;
+    } else {
+      TGeoManager* geom = TGeoManager::Import(geom_file_name.c_str());
+      if (!geom) return Fun4AllReturnCodes::ABORTEVENT;
+    }
     genfit::MaterialEffects::getInstance()->init(new genfit::TGeoMaterialInterface());
-
-    if(ret != Fun4AllReturnCodes::EVENT_OK) return ret;
   }
   else
   {

--- a/packages/reco/ktracker/SQVertexing.cxx
+++ b/packages/reco/ktracker/SQVertexing.cxx
@@ -84,8 +84,9 @@ int SQVertexing::Init(PHCompositeNode* topNode)
 
 int SQVertexing::InitRun(PHCompositeNode* topNode)
 {
+  int ret;
   if (topNode) {
-    int ret = GetNodes(topNode);
+    ret = GetNodes(topNode);
     if(ret != Fun4AllReturnCodes::EVENT_OK) return ret;
     
     ret = MakeNodes(topNode);

--- a/packages/reco/ktracker/SQVertexing.h
+++ b/packages/reco/ktracker/SQVertexing.h
@@ -53,7 +53,6 @@ private:
   double findDimuonZVertex(SRecDimuon& dimuon, SQGenFit::GFTrack& track1, SQGenFit::GFTrack& track2);
   double calcZsclp(double p);
 
-private:
   bool legacyContainer_in, legacyContainer_out;
   bool enableSingleRetracking;
 

--- a/packages/reco/ktracker/SQVertexing.h
+++ b/packages/reco/ktracker/SQVertexing.h
@@ -16,14 +16,19 @@ class SRecEvent;
 class SRecTrack;
 class SRecDimuon;
 
+/// SubsysReco module to carry out the vertexing (i.e. forming dimuons).
+/**
+ * This class can be used outside the Fun4All macro, 
+ * where some member functions are called with topNode = 0 in such use.
+ */
 class SQVertexing: public SubsysReco
 {
 public:
   SQVertexing(const std::string& name = "SQVertexing", int sign1 = 1, int sign2 = -1);
   ~SQVertexing();
 
-  int Init(PHCompositeNode* topNode);
-  int InitRun(PHCompositeNode* topNode);
+  int Init(PHCompositeNode* topNode=0);
+  int InitRun(PHCompositeNode* topNode=0);
   int process_event(PHCompositeNode* topNode);
   int End(PHCompositeNode* topNode);
 
@@ -35,8 +40,8 @@ public:
   void set_geom_file_name(const std::string& geomFileName) { geom_file_name = geomFileName; }
 
 private:
-  int InitField(PHCompositeNode* topNode);
-  int InitGeom(PHCompositeNode*  topNode);
+  int InitField(PHCompositeNode* topNode=0);
+  int InitGeom(PHCompositeNode*  topNode=0);
   int MakeNodes(PHCompositeNode* topNode);
   int GetNodes(PHCompositeNode*  topNode);
 

--- a/packages/reco/ktracker/SQVertexing.h
+++ b/packages/reco/ktracker/SQVertexing.h
@@ -38,6 +38,8 @@ public:
   void set_single_retracking(const bool enable = true)     { enableSingleRetracking = true; }
 
   void set_geom_file_name(const std::string& geomFileName) { geom_file_name = geomFileName; }
+  bool processOneDimuon(SRecTrack* track1, SRecTrack* track2, SRecDimuon& dimuon);
+  bool processOneMuon(SRecTrack* track);
 
 private:
   int InitField(PHCompositeNode* topNode=0);
@@ -50,9 +52,8 @@ private:
   double refitTrkToVtx(SRecTrack*         track, double z, TVector3* pos = nullptr, TVector3* mom = nullptr);
   double findDimuonZVertex(SRecDimuon& dimuon, SQGenFit::GFTrack& track1, SQGenFit::GFTrack& track2);
   double calcZsclp(double p);
-  bool   processOneDimuon(SRecTrack* track1, SRecTrack* track2, SRecDimuon& dimuon);
-  bool   processOneMuon(SRecTrack* track);
 
+private:
   bool legacyContainer_in, legacyContainer_out;
   bool enableSingleRetracking;
 


### PR DESCRIPTION
1. `SQVertexing` was modified so that it can be used outside the Fun4All macro.  It is necessary in the track mixing (i.e. `e1039-analysis/TrackMixingNMSU`) because events are mixed (sorted) before vertexing.  The present analysis code carries a modified version of SQVertexing (`_v2`).  We will no longer need it and maintain this original version only.
2. `UtilTrack::FindMatchedRoads()` was added.  It finds all roads that match to the given track within the hodo paddle width plus a given margin.  The road ID currently assigned to `SRecTrack` is single with no margin considered.
3. Interface classes under `interface_main` were modified to suppress warning (i.e. member functions were returning local objects).

The modified code has been complied fine.  The default behavior of all programs is unchanged.  The performance of `FindMatchedRoads()` will be studied.