### PR TITLE
Updated functions for hodo masking and road matching

### DIFF
--- a/interface_main/SQRoadList.cxx
+++ b/interface_main/SQRoadList.cxx
@@ -1,0 +1,3 @@
+#include "SQRoadList.h"
+using namespace std;
+ClassImp(SQRoadList);

--- a/interface_main/SQRoadList.h
+++ b/interface_main/SQRoadList.h
@@ -1,0 +1,36 @@
+#ifndef __SQ_ROAD_LIST_H__
+#define __SQ_ROAD_LIST_H__
+#include <iostream>
+#include <phool/PHObject.h>
+
+/// An SQ interface class to hold a list of trigger roads.
+class SQRoadList : public PHObject {
+public:
+  typedef std::vector<int> RoadList_t;
+
+  SQRoadList() {}
+  virtual ~SQRoadList() {}
+
+  virtual void identify(std::ostream& os=std::cout) const = 0;
+  virtual void Reset() = 0;
+  virtual int  isValid() const = 0;
+  virtual SQRoadList* Clone() const = 0;
+
+  virtual void        get_list(RoadList_t& pos_top, RoadList_t& pos_bot, RoadList_t& neg_top, RoadList_t& neg_bot) const = 0;
+  virtual RoadList_t get_positive_top   () const = 0;
+  virtual RoadList_t get_positive_bottom() const = 0;
+  virtual RoadList_t get_negative_top   () const = 0;
+  virtual RoadList_t get_negative_bottom() const = 0;
+
+  virtual void set_list(RoadList_t& pos_top, RoadList_t& pos_bot, RoadList_t& neg_top, RoadList_t& neg_bot) = 0;
+  virtual void set_positive_top   (const RoadList_t& pos_top) = 0;
+  virtual void set_positive_bottom(const RoadList_t& pos_bot) = 0;
+  virtual void set_negative_top   (const RoadList_t& neg_top) = 0;
+  virtual void set_negative_bottom(const RoadList_t& neg_bot) = 0;
+
+  virtual void print(std::ostream& os=std::cout) const = 0;
+  
+  ClassDef(SQRoadList, 1);
+};
+
+#endif // __SQ_ROAD_LIST_H__

--- a/interface_main/SQRoadListLinkDef.h
+++ b/interface_main/SQRoadListLinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class SQRoadList+;
+
+#endif /* __CINT__ */

--- a/interface_main/SQRoadList_v1.cxx
+++ b/interface_main/SQRoadList_v1.cxx
@@ -1,0 +1,54 @@
+#include <limits>
+#include <cmath>
+#include "SQRoadList_v1.h"
+using namespace std;
+
+ClassImp(SQRoadList_v1);
+
+SQRoadList_v1::SQRoadList_v1()
+{
+  ;
+}
+
+void SQRoadList_v1::identify(ostream& os) const
+{
+  os << "---SQRoadList_v1--------------------" << endl;
+}
+
+int SQRoadList_v1::isValid() const
+{
+  return 1;
+}
+
+void SQRoadList_v1::get_list(RoadList_t& pos_top, RoadList_t& pos_bot, RoadList_t& neg_top, RoadList_t& neg_bot) const
+{
+  pos_top = m_pos_top;
+  pos_bot = m_pos_bot;
+  neg_top = m_neg_top;
+  neg_bot = m_neg_bot;
+}
+
+void SQRoadList_v1::set_list(RoadList_t& pos_top, RoadList_t& pos_bot, RoadList_t& neg_top, RoadList_t& neg_bot)
+{
+  m_pos_top = pos_top;
+  m_pos_bot = pos_bot;
+  m_neg_top = neg_top;
+  m_neg_bot = neg_bot;
+}
+
+void SQRoadList_v1::print(std::ostream& os) const
+{
+  os << "SQRoadList\n"
+     << "  pos_top (" << m_pos_top.size() << ")";
+  for (auto it = m_pos_top.begin(); it != m_pos_top.end(); it++) os << " " << *it;
+  os << "\n";
+  os << "  pos_bot (" << m_pos_bot.size() << ")";
+  for (auto it = m_pos_bot.begin(); it != m_pos_bot.end(); it++) os << " " << *it;
+  os << "\n";
+  os << "  neg_top (" << m_neg_top.size() << ")";
+  for (auto it = m_neg_top.begin(); it != m_neg_top.end(); it++) os << " " << *it;
+  os << "\n";
+  os << "  neg_bot (" << m_neg_bot.size() << ")";
+  for (auto it = m_neg_bot.begin(); it != m_neg_bot.end(); it++) os << " " << *it;
+  os << endl;
+}

--- a/interface_main/SQRoadList_v1.h
+++ b/interface_main/SQRoadList_v1.h
@@ -1,0 +1,57 @@
+#ifndef __SQ_ROAD_LIST_V1_H__
+#define __SQ_ROAD_LIST_V1_H__
+#include <phool/PHObject.h>
+#include <iostream>
+#include "SQRoadList.h"
+
+/**
+ * @code
+ * PHNodeIterator iter(topNode);
+ * PHCompositeNode* dst = static_cast<PHCompositeNode*>(iter.findFirst("PHCompositeNode", "DST"));
+ * if(!dst) {
+ *   dst = new PHCompositeNode("DST");
+ *   topNode->addNode(dst);
+ * }
+ * m_sq_road = findNode::getClass<SQRoadList>(topNode, "SQRoadList");
+ * if(! m_sq_road) {
+ *   m_sq_road = new SQRoadList_v1();
+ *   dst->addNode(new PHIODataNode<PHObject>(m_sq_road, "SQRoadList", "PHObject"));
+ * }
+ * @endcode
+ */
+class SQRoadList_v1 : public SQRoadList {
+ public:
+  SQRoadList_v1();
+  virtual ~SQRoadList_v1() {;}
+
+  // PHObject
+  void identify(std::ostream& os = std::cout) const;
+  void Reset() {*this = SQRoadList_v1();}
+  int  isValid() const;
+  SQRoadList* Clone() const {return (new SQRoadList_v1(*this));}
+
+  virtual void        get_list(RoadList_t& pos_top, RoadList_t& pos_bot, RoadList_t& neg_top, RoadList_t& neg_bot) const;
+  virtual RoadList_t get_positive_top   () const { return m_pos_top;}
+  virtual RoadList_t get_positive_bottom() const { return m_pos_bot;}
+  virtual RoadList_t get_negative_top   () const { return m_neg_top;}
+  virtual RoadList_t get_negative_bottom() const { return m_neg_bot;}
+
+  virtual void set_list(RoadList_t& pos_top, RoadList_t& pos_bot, RoadList_t& neg_top, RoadList_t& neg_bot);
+  virtual void set_positive_top   (const RoadList_t& pos_top) { m_pos_top = pos_top; }
+  virtual void set_positive_bottom(const RoadList_t& pos_bot) { m_pos_bot = pos_bot; }
+  virtual void set_negative_top   (const RoadList_t& neg_top) { m_neg_top = neg_top; }
+  virtual void set_negative_bottom(const RoadList_t& neg_bot) { m_neg_bot = neg_bot; }
+
+  virtual void print(std::ostream& os=std::cout) const;
+  
+ private:
+  RoadList_t m_pos_top;
+  RoadList_t m_pos_bot;
+  RoadList_t m_neg_top;
+  RoadList_t m_neg_bot;
+
+  ClassDef(SQRoadList_v1, 1);
+};
+
+
+#endif // __SQ_ROAD_LIST_V1_H__

--- a/interface_main/SQRoadList_v1LinkDef.h
+++ b/interface_main/SQRoadList_v1LinkDef.h
@@ -1,0 +1,5 @@
+#ifdef __CINT__
+
+#pragma link C++ class SQRoadList_v1+;
+
+#endif /* __CINT__ */

--- a/packages/UtilAna/LinkDef.h
+++ b/packages/UtilAna/LinkDef.h
@@ -3,14 +3,19 @@
 #pragma link off all function;
 #pragma link off all global;
 
-#pragma link C++ class UtilOnline-!;
-#pragma link C++ class UtilSQHit-!;
-#pragma link C++ class UtilTrack-!;
-#pragma link C++ class UtilDimuon-!;
-#pragma link C++ class UtilBeam-!;
+#pragma link C++ namespace UtilBeam;
+#pragma link C++ namespace UtilDimuon;
+#pragma link C++ namespace UtilHist;
+#pragma link C++ namespace UtilHodo;
+#pragma link C++ class     UtilOnline-!;
+#pragma link C++ namespace UtilSQHit;
+#pragma link C++ namespace UtilTrack;
+#pragma link C++ namespace UtilTrigger;
 
-#pragma link C++ class UtilTrigger::TrigRoad-!;
-#pragma link C++ class UtilTrigger::TrigRoads-!;
-#pragma link C++ class UtilTrigger::TrigRoadset-!;
+// As of 2025-11-19:
+// The functions in the namespaces above cannot be completed in CINT
+// just after the library is loaded (i.e. `R__LOAD_LIBRARY(UtilAna)`).
+// They become available in the CINT completion once the member functions
+// of UtilOnline are completed (i.e. `UtilOnline::[Tab][Tab]`).
 
 #endif

--- a/packages/UtilAna/TrigRoads.cc
+++ b/packages/UtilAna/TrigRoads.cc
@@ -47,6 +47,32 @@ const TrigRoad* TrigRoads::FindRoad(const int road_id) const
   if (it != m_idx_map.end()) return &m_roads[it->second];
   return 0;
 }
+
+/// Find all roads included in the given list of road IDs.
+/**
+ * The return value is a list (vector) of `const TrigRoad*` pointers.
+ */
+std::vector<const TrigRoad*> TrigRoads::FindRoads(const std::vector<int> list_road_id) const
+{
+  vector<const TrigRoad*> list_road_ret;
+  for (auto it = list_road_id.begin(); it != list_road_id.end(); it++) {
+    const TrigRoad* rd = FindRoad(*it);
+    if (rd) list_road_ret.push_back(rd);
+  }
+  return list_road_ret;
+}
+
+/// Find all roads included in the given list of road IDs.
+/**
+ * The return value is a list (vector) of road IDs.
+ */
+std::vector<int> TrigRoads::FindRoadIDs(const std::vector<int> list_road_id) const
+{
+  vector<const TrigRoad*> list_road = FindRoads(list_road_id);
+  vector<int> list_ret;
+  for (auto it = list_road.begin(); it != list_road.end(); it++) list_ret.push_back((*it)->road_id);
+  return list_ret;
+}
   
 int TrigRoads::LoadConfig(const std::string file_name)
 {

--- a/packages/UtilAna/TrigRoads.h
+++ b/packages/UtilAna/TrigRoads.h
@@ -24,6 +24,8 @@ class TrigRoads {
   int FindRoadIndex(const int road_id) const;
   const TrigRoad* GetRoad(const int idx) const;
   const TrigRoad* FindRoad(const int road_id) const;
+  std::vector<const TrigRoad*> FindRoads(const std::vector<int> list_road_id) const;
+  std::vector<int> FindRoadIDs(const std::vector<int> list_road_id) const;
 
   int Charge() const { return m_pol; }
   int TopBot() const { return m_top_bot; }

--- a/packages/UtilAna/UtilBeam.cc
+++ b/packages/UtilAna/UtilBeam.cc
@@ -1,3 +1,4 @@
+#include <TH1.h>
 #include "UtilBeam.h"
 using namespace std;
 
@@ -56,4 +57,15 @@ void UtilBeam::ListOfRfValues(int& n_value, double*& list_values)
   }
   n_value = idx;
   list_values = list;
+}
+
+/// Normalize a histogram of RF intensity (like RF+00) with bin width.
+void UtilBeam::NormRFHist(TH1* h1)
+{
+  if (h1->GetSumw2N() == 0) h1->Sumw2();
+  for (int ib = 1; ib <= h1->GetNbinsX(); ib++) {
+    double width = h1->GetBinWidth(ib);
+    h1->SetBinContent(ib, h1->GetBinContent(ib) / width);
+    h1->SetBinError  (ib, h1->GetBinError  (ib) / width);
+  }
 }

--- a/packages/UtilAna/UtilBeam.h
+++ b/packages/UtilAna/UtilBeam.h
@@ -1,9 +1,11 @@
 #ifndef _UTIL_BEAM__H_
 #define _UTIL_BEAM__H_
+class TH1;
 
 namespace UtilBeam {
   void ListOfRfValues(int& n_value, int*& list_values);
   void ListOfRfValues(int& n_value, double*& list_values);
+  void NormRFHist(TH1* h1);
 }; // namespace UtilBeam
 
 #endif /* _UTIL_BEAM__H_ */

--- a/packages/UtilAna/UtilOnline.cc
+++ b/packages/UtilAna/UtilOnline.cc
@@ -9,13 +9,13 @@ std::string UtilOnline::m_dir_end     = "/seaquest/e906daq/coda/data/END";
 std::string UtilOnline::m_dir_coda    = "/localdata/codadata"; // could be "/data3/data/mainDAQ" or "/data2/e1039/codadata".
 std::string UtilOnline::m_dir_dst     = "/data2/e1039/dst";
 std::string UtilOnline::m_dir_eddst   = "/data4/e1039_data/online/evt_disp";
-std::string UtilOnline::m_dir_onlmon  = "/data2/e1039/onlmon/plots";
+std::string UtilOnline::m_dir_onlmon  = "/data4/e1039_data/online/plots";
 std::string UtilOnline::m_sch_maindaq = "user_e1039_maindaq";
 
 void UtilOnline::UseOutputLocationForDevel()
 {
   m_dir_dst     = "/data2/e1039/dst-devel";
-  m_dir_onlmon  = "/data2/e1039/onlmon/plots-devel";
+  m_dir_onlmon  = "/data4/e1039_data/online/plots-devel";
   m_sch_maindaq = "user_e1039_maindaq_devel";
 }
 

--- a/packages/UtilAna/UtilTrack.cc
+++ b/packages/UtilAna/UtilTrack.cc
@@ -115,32 +115,37 @@ std::vector<int> UtilTrack::FindMatchedRoads(const TVector3 pos1, const TLorentz
     string det_name = (string)"H" + (char)('0'+st) + (top_bot>0 ? 'T' : 'B');
     int det_id = geom->getDetectorID(det_name);
     Plane* det = geom->getPlanePtr(det_id);
-    double x_det = det->xc + det->deltaX;
-    //double y_det = det->yc + det->deltaY;
-    double z_det = det->zc + det->deltaZ;
+    double x_det = det->xc;
+    double y_det = det->yc;
+    double z_det = det->zc;
+    double sinth = det->sintheta;
+    double costh = det->costheta;
     int    n_ele = det->nElements;
     double space = det->spacing;
     double width = det->cellWidth;
     if (verbosity > 2) cout << "  st" << st << ":";
-    if (verbosity > 3) cout << " x_det=" << x_det << " n_ele=" << n_ele << " space=" << space << " width=" << width;
+    if (verbosity > 3) cout << " x,y,z_det=" << x_det << "," << y_det << "," << z_det << " sin,cos=" << sinth << "," << costh << " n_ele=" << n_ele << " space=" << space << " width=" << width;
 
     const TVector3*       pos = (st == 1 ? &pos1 : &pos3);
     const TLorentzVector* mom = (st == 1 ? &mom1 : &mom3);
     double x_trk = pos->X() + (z_det - pos->Z()) * mom->X() / mom->Z();
     double y_trk = pos->Y() + (z_det - pos->Z()) * mom->Y() / mom->Z();
-    //double x_trk, y_trk;
-    //trk->getExpPositionFast(z_det, x_trk, y_trk);
-    int ele_cent = (int)((n_ele+1)/2.0 + (x_trk-x_det)/space + 0.5);
-    if (verbosity > 2) cout << " x_trk=" << x_trk << " y_trk=" << y_trk;
+    
+    // d_trk = Signed distance of the track position from the plane center axis.
+    //   Center axis: y = y_det-(x-x_det)*costh/sinth ->  costh*x + sinth*y - sinth*y_det - costh*x_det = 0
+    //   Note: theta > 0 for the 2nd quadrant (x<0, y>0).
+    double d_trk = costh*x_trk + sinth*y_trk - sinth*y_det - costh*x_det; // https://en.wikipedia.org/wiki/Distance_from_a_point_to_a_line
+    int ele_cent = (int)((n_ele+1)/2.0 + d_trk/space + 0.5);
+    if (verbosity > 2) cout << " x,y,d_trk=" << x_trk << "," << y_trk << "," << d_trk;
 
     /// Check three elements, assuming the margin is much smaller than the half width.
     for (int i_ele = ele_cent - 1; i_ele <= ele_cent + 1; i_ele++) {
       if (i_ele <= 0 || i_ele > n_ele) continue;
-      double x_ele = x_det + space * (i_ele - (n_ele+1)/2.0);
-      if (verbosity > 2) cout << " [ele=" << i_ele << " x=" << x_ele;
-      if (verbosity > 3) cout << " edge=" << (width/2-fabs(x_trk-x_ele));
+      double d_ele = space * (i_ele - (n_ele+1)/2.0);
+      if (verbosity > 2) cout << "  [ele=" << i_ele << " d=" << d_ele;
+      if (verbosity > 3) cout << " edge=" << (width/2-fabs(d_trk-d_ele));
       if (verbosity > 2) cout << "]";
-      if (fabs(x_trk - x_ele) < width/2 + margin) list_ele_id[st].push_back(i_ele);
+      if (fabs(d_trk - d_ele) < width/2 + margin) list_ele_id[st].push_back(i_ele);
     }
     if (verbosity > 2) cout << endl;
   }

--- a/packages/geom_svc/GeomSvc.cxx
+++ b/packages/geom_svc/GeomSvc.cxx
@@ -533,7 +533,6 @@ void GeomSvc::initPlaneDbSvc() {
   }
 }
 
-
 void GeomSvc::initWireLUT() {
 
   ///Initialize the position look up table for all wires, hodos, and tubes
@@ -547,7 +546,7 @@ void GeomSvc::initWireLUT() {
       planes          [i].elementPos.clear();
       for(int j = 1; j <= planes[i].nElements; ++j)
       {
-          double pos = (j - (planes[i].nElements+1.)/2.)*planes[i].spacing + planes[i].xoffset + planes[i].x0*planes[i].costheta + planes[i].y0*planes[i].sintheta + planes[i].deltaW;
+          double pos = (j - (planes[i].nElements+1.)/2.)*planes[i].spacing + planes[i].xoffset + planes[i].xc*planes[i].costheta + planes[i].yc*planes[i].sintheta + planes[i].deltaW;
           map_wirePosition[i].insert(posType(j, pos));
 
           map_endPoint1[i].insert(epType(j, planes[i].getEndPoint(j, -1)));
@@ -570,17 +569,17 @@ void GeomSvc::initWireLUT() {
           double pos;
           if(i <= nChamberPlanes+nHodoPlanes)
           {
-              pos = planes[i].x0*planes[i].costheta + planes[i].y0*planes[i].sintheta + planes[i].xoffset + (j - (planes[i].nElements+1)/2.)*planes[i].spacing + planes[i].deltaW;
+              pos = planes[i].xc*planes[i].costheta + planes[i].yc*planes[i].sintheta + planes[i].xoffset + (j - (planes[i].nElements+1)/2.)*planes[i].spacing + planes[i].deltaW;
           }
           else if(i <= nChamberPlanes+nHodoPlanes+nPropPlanes)
           {
               int moduleID = 8 - int((j - 1)/8);        //Need to re-define moduleID for run2, note it's reversed compared to elementID
-              pos = planes[i].x0*planes[i].costheta + planes[i].y0*planes[i].sintheta + planes[i].xoffset + (j - (planes[i].nElements+1)/2.)*planes[i].spacing + planes[i].deltaW_module[moduleID];
+              pos = planes[i].xc*planes[i].costheta + planes[i].yc*planes[i].sintheta + planes[i].xoffset + (j - (planes[i].nElements+1)/2.)*planes[i].spacing + planes[i].deltaW_module[moduleID];
           }
           else
           {
               int elementID = ((i-55) & 2) > 0 ? planes[i].nElements + 1 - j : j;
-              pos = planes[i].x0*planes[i].costheta + planes[i].y0*planes[i].sintheta + planes[i].xoffset + (elementID - (planes[i].nElements+1)/2.)*planes[i].spacing + planes[i].deltaW;
+              pos = planes[i].xc*planes[i].costheta + planes[i].yc*planes[i].sintheta + planes[i].xoffset + (elementID - (planes[i].nElements+1)/2.)*planes[i].spacing + planes[i].deltaW;
           }
           map_wirePosition[i].insert(posType(j, pos));
           map_endPoint1[i].insert(epType(j, planes[i].getEndPoint(j, -1)));
@@ -685,7 +684,10 @@ int GeomSvc::getExpElementID(int detectorID, double pos_exp)
     if(pos_exp > pos_max) return planes[detectorID].nElements+1;
     if(pos_exp < pos_min) return 0;
 
-    int index = std::lower_bound(planes[detectorID].elementPos.begin(), planes[detectorID].elementPos.end(), pos_exp) - planes[detectorID].elementPos.begin();
+    auto iter = std::lower_bound(planes[detectorID].elementPos.begin(), planes[detectorID].elementPos.end(), pos_exp);
+    int index;
+    if (iter != planes[detectorID].elementPos.end()) index = iter - planes[detectorID].elementPos.begin();
+    else index = planes[detectorID].nElements - 1; // pos_exp > pos_last_element.  pos_exp is inside the last element since "pos_exp <= pos_max" was assured above
     int elementID = index + 1 + (planes[detectorID].elementPos[index] - pos_exp > 0.5*planes[detectorID].spacing ? -1 : 0);
 
     if(detectorID > nChamberPlanes+nHodoPlanes+nPropPlanes)
@@ -1143,5 +1145,22 @@ void GeomSvc::printTable()
   {
     if(iter->second>nChamberPlanes+nHodoPlanes+nPropPlanes+nDarkPhotonPlanes) continue;
     std::cout << planes[iter->second] << std::endl;
+  }
+}
+
+void GeomSvc::printElementPos()
+{
+  std::cout << "GeomSvc::printElementPos():\n";
+  for(auto it = map_detectorID.begin(); it != map_detectorID.end(); ++it) {
+    std::string det_name = it->first;
+    int         det_id   = it->second;
+    if(det_id > nChamberPlanes+nHodoPlanes+nPropPlanes+nDarkPhotonPlanes) continue;
+    std::cout << "Detector " << det_id << ":" << det_name;
+    int n_ele = planes[det_id].nElements;
+    for (int i_ele = 0; i_ele < n_ele; i_ele++) {
+      if (i_ele % 10 == 0) std::cout << "\n  " << std::setw(3) << (i_ele+1) << ": ";
+      std::cout << " " << planes[det_id].elementPos.at(i_ele);
+    }
+    std::cout << "\n";
   }
 }

--- a/packages/geom_svc/GeomSvc.h
+++ b/packages/geom_svc/GeomSvc.h
@@ -347,6 +347,7 @@ public:
     void printAlignPar();
     void printTable();
     void printWirePosition();
+    void printElementPos();
 
     static void UseDbSvc(const bool val) { use_dbsvc = val; }
     static bool UseDbSvc()        { return use_dbsvc; }

--- a/packages/reco/interface/TriggerRoad.cxx
+++ b/packages/reco/interface/TriggerRoad.cxx
@@ -7,6 +7,8 @@
 
 ClassImp(TriggerRoad)
 
+int TriggerRoad::verbosity = 0;
+
 TriggerRoad::TriggerRoad()
 {
     targetWeight = 0.;
@@ -61,11 +63,21 @@ TriggerRoad::TriggerRoad(Tracklet& tracklet) : detectorIDs(4), elementIDs(4)
     }
 
     tb = tb > 0 ? 0 : 1;
+    if (verbosity > 1) std::cout << "TriggerRoad::TriggerRoad(): tb=" << tb << std::endl;
     for(int i = 0; i < 4; ++i)
     {
         detectorIDs[i] = hodoIDs[tb][i];
-        elementIDs[i] = p_geomSvc->getExpElementID(hodoIDs[tb][i], tracklet.getExpPositionX(p_geomSvc->getPlanePosition(hodoIDs[tb][i])));
-        //std::cout << i << " " << detectorIDs[i] << " " << elementIDs[i] << std::endl;
+        double w_trk = tracklet.getExpPositionW(hodoIDs[tb][i]);
+        elementIDs[i] = p_geomSvc->getExpElementID(hodoIDs[tb][i], w_trk);
+        //elementIDs[i] = p_geomSvc->getExpElementID(hodoIDs[tb][i], tracklet.getExpPositionX(p_geomSvc->getPlanePosition(hodoIDs[tb][i])));
+        if (verbosity > 1) {
+          double z = p_geomSvc->getPlanePosition(hodoIDs[tb][i]);
+          double x = tracklet.getExpPositionX(z);
+          double y = tracklet.getExpPositionY(z);
+          std::cout << "  st" << (i+1) << ": det=" << detectorIDs[i] << " z=" << z << " x,y,w_trk=" << x << "," << y << "," << w_trk << " ele=" << elementIDs[i];
+          if (verbosity > 2) std::cout << " w_ele=" << p_geomSvc->getPlanePtr(hodoIDs[tb][i])->elementPos.at(elementIDs[i]-1);
+          std::cout << std::endl;
+        }
     }
 }
 

--- a/packages/reco/interface/TriggerRoad.h
+++ b/packages/reco/interface/TriggerRoad.h
@@ -87,6 +87,8 @@ public:
     friend std::ostream& operator << (std::ostream& os, const TriggerRoad& road);
 
 public:
+    static int verbosity;
+  
     //Unique road ID
     int roadID;
 


### PR DESCRIPTION
I updated the functions for the hodo masking and the trigger road matching, as described in DocDB 11457.

I also added an interface class, `SQRoadList`, which can be used to store a list of roads in DST.  At present it is not used by any SubsysReco module in e1039-core.