### PR TITLE
New set names for `recoConsts::init()`

### DIFF
--- a/framework/phool/recoConsts.cc
+++ b/framework/phool/recoConsts.cc
@@ -215,8 +215,8 @@ void recoConsts::init(int runNo, bool verbose)
 
 void recoConsts::init(const std::string& setname, bool verbose)
 {
-  if(setname == "cosmic")
-  {
+  if (verbose) std::cout << "recoConsts::init(): setname = " << setname << std::endl;
+  if (setname == "cosmic") {
     set_BoolFlag("KMAG_ON", false);
     set_BoolFlag("COSMIC_MODE", true);
 
@@ -224,9 +224,12 @@ void recoConsts::init(const std::string& setname, bool verbose)
     set_DoubleFlag("TY_MAX", 1.);
     set_DoubleFlag("X0_MAX", 1000.);
     set_DoubleFlag("Y0_MAX", 1000.);
+  } else if (setname == "Y2024" || setname == "Run1") {
+    init(5433, verbose);
+  } else {
+    std::cout << "  !!ERROR!!  Invalid setname.  Abort." << std::endl;
+    exit(1);
   }
-
-  if(verbose) Print();
 }
 
 void recoConsts::initfile(const std::string& filename, bool verbose)

--- a/framework/phool/recoConsts.h
+++ b/framework/phool/recoConsts.h
@@ -25,8 +25,8 @@ public:
   //! initialize the constants by the runNo
   void init(int runNo = 0, bool verbose = true);
 
-  //! initialize the constants by pre-defined parameter set name - not implemented yet
-  void init(const std::string& setname, bool verbose = false);
+  //! initialize the constants by pre-defined parameter set name
+  void init(const std::string& setname, bool verbose = true);
 
   //! initialize by reading a file
   void initfile(const std::string& filename, bool verbose = false);


### PR DESCRIPTION
This update just adds two set names (`Y2024` and `Run1`) to `recoConsts::init(string setname)`.  The names can be used to do the initialization for the commissioning data.  They should be easier to understand than calling `init(int runNo)` with the standard run ID (5433) for the commissioning data.